### PR TITLE
Fix GetImage disposal

### DIFF
--- a/Sources/ImagePlayground.Tests/ImageHelpers.cs
+++ b/Sources/ImagePlayground.Tests/ImageHelpers.cs
@@ -22,6 +22,7 @@ namespace ImagePlayground.Tests {
             var image = Image.GetImage(filePath);
             Assert.True(image.Width == 660);
             Assert.True(image.Height == 660);
+            image.Dispose();
 
             var newImage = System.IO.Path.Combine(_directoryWithImages, "QRCodeUrlResized.jpg");
             ImageHelper.Resize(filePath, newImage, 100, 100);

--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -80,10 +80,11 @@ namespace ImagePlayground {
         public ICompareResult Compare(string filePathToCompare) {
             string fullPath = System.IO.Path.GetFullPath(filePathToCompare);
 
-            var imageToCompare = GetImage(fullPath);
-            bool isEqual = ImageSharpCompare.ImagesAreEqual(_image, imageToCompare);
-            ICompareResult calcDiff = ImageSharpCompare.CalcDiff(_image, imageToCompare);
-            return calcDiff;
+            using (var imageToCompare = GetImage(fullPath)) {
+                bool isEqual = ImageSharpCompare.ImagesAreEqual(_image, imageToCompare);
+                ICompareResult calcDiff = ImageSharpCompare.CalcDiff(_image, imageToCompare);
+                return calcDiff;
+            }
         }
 
         public void Compare(Image imageToCompare, string filePathToSave) {
@@ -100,9 +101,10 @@ namespace ImagePlayground {
             string outFullPath = System.IO.Path.GetFullPath(filePathToSave);
 
             using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
-                var imageToCompare = GetImage(fullPath);
-                using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(_image, imageToCompare)) {
-                    SixLabors.ImageSharp.ImageExtensions.SaveAsPng(maskImage, fileStreamDifferenceMask);
+                using (var imageToCompare = GetImage(fullPath)) {
+                    using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(_image, imageToCompare)) {
+                        SixLabors.ImageSharp.ImageExtensions.SaveAsPng(maskImage, fileStreamDifferenceMask);
+                    }
                 }
             }
         }
@@ -271,9 +273,8 @@ namespace ImagePlayground {
 
         public static SixLabors.ImageSharp.Image GetImage(string filePath) {
             string fullPath = System.IO.Path.GetFullPath(filePath);
-            var inStream = System.IO.File.OpenRead(fullPath);
-            using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
-                return image;
+            using (var inStream = System.IO.File.OpenRead(fullPath)) {
+                return SixLabors.ImageSharp.Image.Load(inStream);
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure `GetImage` closes the input stream and returns the image without disposing it
- dispose images returned from `GetImage` in callers

## Testing
- `dotnet test --framework net7.0` *(fails: requires missing .NET runtime)*

------
https://chatgpt.com/codex/tasks/task_e_684e9f61f38c832eb7b3bdf1568afec1