### PR TITLE
Add C# and PowerShell tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Sources/packages/*
 Lib/Default/*
 Lib/Standard/*
 Lib/Core/*
+Tests/Artifacts/*
+testResults.xml

--- a/Sources/ImagePlayground.Tests/ImageHelperAdditional.cs
+++ b/Sources/ImagePlayground.Tests/ImageHelperAdditional.cs
@@ -1,0 +1,39 @@
+using System;
+using ImagePlayground;
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_ConvertImageFormat() {
+            string source = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string output = Path.Combine(_directoryWithImages, "QRCode1_converted.jpg");
+            if (File.Exists(output)) File.Delete(output);
+
+            ImageHelper.ConvertTo(source, output);
+            Assert.True(File.Exists(output));
+
+            var img = Image.GetImage(output);
+            Assert.Equal(660, img.Width);
+            Assert.Equal(660, img.Height);
+            img.Dispose();
+        }
+
+        [Fact]
+        public void Test_CombineImages() {
+            string file1 = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string file2 = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string combined = Path.Combine(_directoryWithImages, "combined.png");
+            if (File.Exists(combined)) File.Delete(combined);
+
+            ImageHelper.Combine(file1, file2, combined);
+            Assert.True(File.Exists(combined));
+
+            var img = Image.GetImage(combined);
+            Assert.Equal(1675, img.Width);
+            Assert.Equal(533 + 660, img.Height);
+            img.Dispose();
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/ImageManipulation.cs
+++ b/Sources/ImagePlayground.Tests/ImageManipulation.cs
@@ -1,18 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using ImagePlayground;
 using Xunit;
 
 namespace ImagePlayground.Tests {
     public partial class ImagePlayground {
         [Fact]
         public void Test_ImageManipulation() {
-            string filePath = System.IO.Path.Combine(_directoryWithImages, "QRCodeUrlBefore.jpg");
-            File.Delete(filePath);
-            Assert.True(File.Exists(filePath) == false);
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string dest = Path.Combine(_directoryWithImages, "QRCode1_pixelate.png");
+            if (File.Exists(dest)) File.Delete(dest);
+
+            using (var img = Image.Load(src)) {
+                img.Pixelate(10);
+                img.Save(dest);
+                Assert.Equal(660, img.Width);
+                Assert.Equal(660, img.Height);
+            }
+            Assert.True(File.Exists(dest));
         }
     }
 }

--- a/Tests/ImagePlayground.Tests.ps1
+++ b/Tests/ImagePlayground.Tests.ps1
@@ -1,0 +1,32 @@
+Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
+
+$TestDir = Join-Path $PSScriptRoot 'Artifacts'
+if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
+
+Describe 'ImagePlayground module' {
+    It 'creates and reads QR code' {
+        $file = Join-Path $TestDir 'qr.png'
+        if (Test-Path $file) { Remove-Item $file }
+        New-ImageQRCode -Content 'https://evotec.xyz' -FilePath $file
+        Test-Path $file | Should -BeTrue
+        (Get-ImageQRCode -FilePath $file).Message | Should -Be 'https://evotec.xyz'
+    }
+
+    It 'resizes an image' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dest = Join-Path $TestDir 'logo-small.png'
+        Resize-Image -FilePath $src -OutputPath $dest -Width 50 -Height 50
+        $img = [ImagePlayground.Image]::Load($dest)
+        $img.Width | Should -Be 50
+        $img.Height | Should -Be 50
+        $img.Dispose()
+    }
+
+    It 'converts image format' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'qr.jpg'
+        if (Test-Path $dest) { Remove-Item $dest }
+        ConvertTo-Image -FilePath $src -OutputPath $dest
+        Test-Path $dest | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- add ignore rules for test artifacts
- create Pester tests for module functionality
- expand image manipulation test
- add tests for converting and combining images

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0 --logger "console;verbosity=normal"`
- `pwsh Tests/ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684fe4a6181c832eb94a8f19c0360f01