### PR TITLE
Fix numeric WiFi password quoting

### DIFF
--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -49,5 +49,21 @@ namespace ImagePlayground.Tests {
             var read2 = BarCode.Read(filePath);
             Assert.True(read2.Message == "96385074");
         }
+
+        [Theory]
+        [InlineData("12345678")]
+        [InlineData("pass123")]
+        public void Test_QRCodeWiFi_Passwords(string password) {
+            string filePath = System.IO.Path.Combine(_directoryWithImages, $"WiFi_{password}.png");
+            File.Delete(filePath);
+            Assert.True(File.Exists(filePath) == false);
+
+            QrCode.GenerateWiFi("TestSSID", password, filePath, true);
+
+            Assert.True(File.Exists(filePath) == true);
+
+            var read = QrCode.Read(filePath);
+            Assert.True(read.Message == $"WIFI:T:WPA;S:TestSSID;P:{password};;");
+        }
     }
 }

--- a/Sources/ImagePlayground/QRCode.cs
+++ b/Sources/ImagePlayground/QRCode.cs
@@ -48,7 +48,7 @@ namespace ImagePlayground {
             }
         }
         public static void GenerateWiFi(string ssid, string password, string filePath, bool transparent = false) {
-            PayloadGenerator.WiFi generator = new PayloadGenerator.WiFi(ssid, password, PayloadGenerator.WiFi.Authentication.WPA);
+            PayloadGenerator.WiFi generator = new PayloadGenerator.WiFi(ssid, password, PayloadGenerator.WiFi.Authentication.WPA, false, false);
             Generate(generator.ToString(), filePath, transparent);
         }
 

--- a/Tests/ImagePlayground.psd1
+++ b/Tests/ImagePlayground.psd1
@@ -1,0 +1,10 @@
+@{
+    RootModule = '../ImagePlayground.psm1'
+    ModuleVersion = '0.0.0'
+    CompatiblePSEditions = @('Desktop','Core')
+    FunctionsToExport = '*'
+    CmdletsToExport = @()
+    AliasesToExport = '*'
+    PrivateData = @{}
+    RequiredModules = @('Microsoft.PowerShell.Management','Microsoft.PowerShell.Utility')
+}

--- a/Tests/Tests/WiFiQr.Tests.ps1
+++ b/Tests/Tests/WiFiQr.Tests.ps1
@@ -1,0 +1,16 @@
+Import-Module $PSScriptRoot/../ImagePlayground.psd1 -Force
+
+Describe 'New-ImageQRCodeWiFi password quoting' {
+    It 'does not quote numeric passwords' {
+        $file = Join-Path $TestDrive 'wifi_numeric.png'
+        New-ImageQRCodeWiFi -SSID 'Test' -Password '12345678' -FilePath $file
+        $result = Get-ImageQRCode -FilePath $file
+        $result.Message | Should -Be 'WIFI:T:WPA;S:Test;P:12345678;;'
+    }
+    It 'handles alphanumeric passwords' {
+        $file = Join-Path $TestDrive 'wifi_alpha.png'
+        New-ImageQRCodeWiFi -SSID 'Test' -Password 'pass123' -FilePath $file
+        $result = Get-ImageQRCode -FilePath $file
+        $result.Message | Should -Be 'WIFI:T:WPA;S:Test;P:pass123;;'
+    }
+}


### PR DESCRIPTION
## Summary
- ensure WiFi QR codes don't add quotes around numeric passwords
- add new WiFi QR code tests in both C# and PowerShell

## Testing
- `dotnet test Sources/ImagePlayground.sln --framework net8.0 --no-build`
- `pwsh -NoLogo -File Tests/ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_684fe7f34da8832e89bd27ddc274eec4