### PR TITLE
Add barcode and merge tests

### DIFF
--- a/Tests/ImagePlayground.Tests.ps1
+++ b/Tests/ImagePlayground.Tests.ps1
@@ -29,4 +29,31 @@ Describe 'ImagePlayground module' {
         ConvertTo-Image -FilePath $src -OutputPath $dest
         Test-Path $dest | Should -BeTrue
     }
+    It 'creates and reads bar code' {
+        $file = Join-Path $TestDir 'barcode.png'
+        if (Test-Path $file) { Remove-Item $file }
+        New-ImageBarCode -Type EAN -Value '9012341234571' -FilePath $file
+        Test-Path $file | Should -BeTrue
+        (Get-ImageBarCode -FilePath $file).Message | Should -Be '9012341234571'
+    }
+    
+    It 'merges two images vertically' {
+        $src1 = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $src2 = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'merged.png'
+        if (Test-Path $dest) { Remove-Item $dest }
+        Merge-Image -FilePath $src1 -FilePathToMerge $src2 -FilePathOutput $dest
+        Test-Path $dest | Should -BeTrue
+        $img1 = [ImagePlayground.Image]::Load($src1)
+        $img2 = [ImagePlayground.Image]::Load($src2)
+        $expectedWidth = [Math]::Max($img1.Width, $img2.Width)
+        $expectedHeight = $img1.Height + $img2.Height
+        $img1.Dispose()
+        $img2.Dispose()
+        $img = [ImagePlayground.Image]::Load($dest)
+        $img.Width | Should -Be $expectedWidth
+        $img.Height | Should -Be $expectedHeight
+        $img.Dispose()
+    }
 }
+


### PR DESCRIPTION
## Summary
- extend Pester test suite with barcode and merge scenarios

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --no-build --configuration Debug --framework net8.0 --verbosity normal`
- `pwsh ./Tests/ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_684fea5bbcf8832e8b83b8fb5b123831