### PR TITLE
Add PSD1 refresh step before PowerShell tests

### DIFF
--- a/.github/workflows/test_powershell.yml
+++ b/.github/workflows/test_powershell.yml
@@ -18,12 +18,44 @@ env:
   BUILD_CONFIGURATION: 'Debug'
 
 jobs:
+  refresh-psd1:
+    name: 'Refresh PSD1'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PowerShell modules
+        shell: pwsh
+        run: |
+          Install-Module PSPublishModule -Force -Scope CurrentUser -AllowClobber
+
+      - name: Refresh module manifest
+        shell: pwsh
+        env:
+          RefreshPSD1Only: 'true'
+        run: |
+          .\Build\Build-Module.ps1
+
+      - name: Upload refreshed manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: psd1
+          path: ImagePlayground.psd1
+
   test-windows-ps5:
+    needs: refresh-psd1
     name: 'Windows PowerShell 5.1'
     runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -47,11 +79,18 @@ jobs:
         run: ./Tests/ImagePlayground.Tests.ps1
 
   test-windows-ps7:
+    needs: refresh-psd1
     name: 'Windows PowerShell 7'
     runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -75,11 +114,18 @@ jobs:
         run: ./Tests/ImagePlayground.Tests.ps1
 
   test-ubuntu:
+    needs: refresh-psd1
     name: 'Ubuntu PowerShell 7'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -110,11 +156,18 @@ jobs:
         run: ./Tests/ImagePlayground.Tests.ps1
 
   test-macos:
+    needs: refresh-psd1
     name: 'macOS PowerShell 7'
     runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
## Summary
- run Build-Module in a new `refresh-psd1` job
- download the refreshed manifest in each PowerShell test job

## Testing
- `pwsh Tests/ImagePlayground.Tests.ps1` *(fails: The term 'New-ImageBarCode' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68503b566f00832ea5c9138d2be5da8c