### PR TITLE
Add stream support for images

### DIFF
--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('New-QRCode', 'New-QRCodeWiFi')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Add-ImageText', 'Compare-Image', 'ConvertTo-Image', 'Get-Image', 'Get-ImageBarCode', 'Get-ImageExif', 'Get-ImageQRCode', 'Merge-Image', 'New-ImageBarCode', 'New-ImageChart', 'New-ImageChartBar', 'New-ImageChartBarOptions', 'New-ImageChartLine', 'New-ImageChartPie', 'New-ImageChartRadial', 'New-ImageGrid', 'New-ImageIcon', 'New-ImageQRCode', 'New-ImageQRCodeWiFi', 'New-ImageQRContact', 'Remove-ImageExif', 'Resize-Image', 'Save-Image', 'Set-ImageExif')
+    CmdletsToExport        = @('Add-ImageText', 'Add-ImageWatermark', 'Compare-Image', 'ConvertTo-Image', 'Get-Image', 'Get-ImageBarCode', 'Get-ImageExif', 'Get-ImageQRCode', 'Merge-Image', 'New-ImageBarCode', 'New-ImageChart', 'New-ImageChartBar', 'New-ImageChartBarOptions', 'New-ImageChartLine', 'New-ImageChartPie', 'New-ImageChartRadial', 'New-ImageGrid', 'New-ImageIcon', 'New-ImageQRCode', 'New-ImageQRCodeWiFi', 'New-ImageQRContact', 'Remove-ImageExif', 'Resize-Image', 'Save-Image', 'Set-ImageExif')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
@@ -17,6 +17,9 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     [Parameter(Position = 1)]
     public string? FilePath { get; set; }
 
+    [Parameter]
+    public SwitchParameter AsStream { get; set; }
+
     /// <summary>Open file after saving.</summary>
     [Parameter]
     public SwitchParameter Open { get; set; }
@@ -25,6 +28,8 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     protected override void ProcessRecord() {
         if (!string.IsNullOrWhiteSpace(FilePath)) {
             Image.Save(FilePath, Open.IsPresent);
+        } else if (AsStream.IsPresent) {
+            WriteObject(Image.ToStream());
         } else {
             Image.Save(Open.IsPresent);
         }

--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -309,6 +309,34 @@ namespace ImagePlayground {
             Save("", openImage);
         }
 
+        public void Save(Stream stream) {
+            string extension = System.IO.Path.GetExtension(_filePath)?.ToLowerInvariant();
+            if (extension == ".jpg" || extension == ".jpeg") {
+                _image.SaveAsJpeg(stream);
+            } else if (extension == ".bmp") {
+                _image.SaveAsBmp(stream);
+            } else if (extension == ".gif") {
+                _image.SaveAsGif(stream);
+            } else if (extension == ".pbm") {
+                _image.SaveAsPbm(stream);
+            } else if (extension == ".tga") {
+                _image.SaveAsTga(stream);
+            } else if (extension == ".tiff") {
+                _image.SaveAsTiff(stream);
+            } else if (extension == ".webp") {
+                _image.SaveAsWebp(stream);
+            } else {
+                _image.SaveAsPng(stream);
+            }
+            stream.Seek(0, SeekOrigin.Begin);
+        }
+
+        public MemoryStream ToStream() {
+            var ms = new MemoryStream();
+            Save(ms);
+            return ms;
+        }
+
         public void Dispose() {
             if (_image != null) {
                 _image.Dispose();

--- a/Tests/Save-Image.Tests.ps1
+++ b/Tests/Save-Image.Tests.ps1
@@ -30,5 +30,20 @@ Describe 'Save-Image' {
 
     }
 
-}
+    It 'returns a MemoryStream when AsStream is used' {
 
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+
+        $img = Get-Image -FilePath $src
+
+        $stream = Save-Image -Image $img -AsStream
+
+        $img.Dispose()
+
+        $stream | Should -BeOfType ([System.IO.MemoryStream])
+
+        $stream.Length | Should -BeGreaterThan 0
+
+    }
+
+}


### PR DESCRIPTION
## Summary
- add `Save(Stream)` and `ToStream()` helpers
- allow Save-Image cmdlet to output memory stream via `-AsStream`
- export Add-ImageWatermark command
- test stream functionality

## Testing
- `dotnet build Sources/ImagePlayground.sln --configuration Debug --no-restore`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6851568dab8c832eb4556e387c302063