### PR TITLE
Add quality/compression options

### DIFF
--- a/Docs/ConvertTo-Image.md
+++ b/Docs/ConvertTo-Image.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-ConvertTo-Image [-FilePath] <String> [-OutputPath] <String> [<CommonParameters>]
+ConvertTo-Image [-FilePath] <String> [-OutputPath] <String> [-Quality <Int32>] [-CompressionLevel <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/Docs/Save-Image.md
+++ b/Docs/Save-Image.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Save-Image [-Image] <Image> [[-FilePath] <String>] [-Open] [<CommonParameters>]
+Save-Image [-Image] <Image> [[-FilePath] <String>] [-Quality <Int32>] [-CompressionLevel <Int32>] [-Open] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('New-QRCode', 'New-QRCodeWiFi')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Add-ImageText', 'Compare-Image', 'ConvertTo-Image', 'Get-Image', 'Get-ImageBarCode', 'Get-ImageExif', 'Get-ImageQRCode', 'Merge-Image', 'New-ImageBarCode', 'New-ImageChart', 'New-ImageChartBar', 'New-ImageChartBarOptions', 'New-ImageChartLine', 'New-ImageChartPie', 'New-ImageChartRadial', 'New-ImageGrid', 'New-ImageQRCode', 'New-ImageQRCodeWiFi', 'New-ImageQRContact', 'Remove-ImageExif', 'Resize-Image', 'Save-Image', 'Set-ImageExif')
+    CmdletsToExport        = @('Add-ImageText', 'Add-ImageWatermark', 'Compare-Image', 'ConvertTo-Image', 'Get-Image', 'Get-ImageBarCode', 'Get-ImageExif', 'Get-ImageQRCode', 'Merge-Image', 'New-ImageBarCode', 'New-ImageChart', 'New-ImageChartBar', 'New-ImageChartBarOptions', 'New-ImageChartLine', 'New-ImageChartPie', 'New-ImageChartRadial', 'New-ImageGrid', 'New-ImageQRCode', 'New-ImageQRCodeWiFi', 'New-ImageQRContact', 'Remove-ImageExif', 'Resize-Image', 'Save-Image', 'Set-ImageExif')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -205,17 +205,17 @@ Resize-Image -FilePath $PSScriptRoot\Samples\LogoEvotec.png -OutputPath $PSScrip
 $Image = Get-Image -FilePath $PSScriptRoot\Samples\LogoEvotec.png
 $Image.BlackWhite()
 $Image.BackgroundColor("Red")
-Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\LogoEvotecChanged.png
+Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\LogoEvotecChanged.png -Quality 80
 
 # Save Pixalate
 $Image = Get-Image -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg
 $Image.Pixelate(30)
-Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\PrzemyslawKlysAndKulkozaurrPixelate.jpg
+Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\PrzemyslawKlysAndKulkozaurrPixelate.jpg -Quality 80
 
 # Save as Polaroid
 $Image = Get-Image -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg
 $Image.Polaroid()
-Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\PrzemyslawKlysAndKulkozaurrPolaroid.jpg
+Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\PrzemyslawKlysAndKulkozaurrPolaroid.jpg -Quality 80
 
 # Add watermark
 $Image = Get-Image -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg
@@ -247,7 +247,7 @@ $Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.I
 #void Watermark(string text, ImagePlayground.Image+WatermarkPlacement placement, SixLabors.ImageSharp.Color color, float fontSize = 16, string fontFamilyName = "Arial", float padding = 18)
 $Image.Watermark("Evotec", [ImagePlayground.Image+WatermarkPlacement]::TopRight, [SixLabors.ImageSharp.Color]::Blue, 50, "Calibri")
 
-Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\PrzemyslawKlysAndKulkozaurrWatermarkWithText.jpg
+Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\PrzemyslawKlysAndKulkozaurrWatermarkWithText.jpg -Quality 80
 ```
 
 ![PrzemyslawKlysAndKulkozaurrWatermarkWithText.jpg](https://github.com/EvotecIT/ImagePlayground/blob/feb33319f00df1933f53a4df89d65aa498278e41/Examples/Samples/PrzemyslawKlysAndKulkozaurrWatermarkWithText.jpg)

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
@@ -21,6 +21,14 @@ public sealed class ConvertToImageCmdlet : PSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public string OutputPath { get; set; } = string.Empty;
 
+    /// <summary>Quality for JPEG or WEBP images.</summary>
+    [Parameter]
+    public int? Quality { get; set; }
+
+    /// <summary>Compression level for PNG images.</summary>
+    [Parameter]
+    public int? CompressionLevel { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (!File.Exists(FilePath)) {
@@ -28,6 +36,6 @@ public sealed class ConvertToImageCmdlet : PSCmdlet {
             return;
         }
 
-        ImagePlayground.ImageHelper.ConvertTo(FilePath, OutputPath);
+        ImagePlayground.ImageHelper.ConvertTo(FilePath, OutputPath, Quality, CompressionLevel);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
@@ -17,6 +17,14 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     [Parameter(Position = 1)]
     public string? FilePath { get; set; }
 
+    /// <summary>Quality for JPEG or WEBP images.</summary>
+    [Parameter]
+    public int? Quality { get; set; }
+
+    /// <summary>Compression level for PNG images.</summary>
+    [Parameter]
+    public int? CompressionLevel { get; set; }
+
     /// <summary>Open file after saving.</summary>
     [Parameter]
     public SwitchParameter Open { get; set; }
@@ -24,9 +32,9 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (!string.IsNullOrWhiteSpace(FilePath)) {
-            Image.Save(FilePath, Open.IsPresent);
+            Image.Save(FilePath, Open.IsPresent, Quality, CompressionLevel);
         } else {
-            Image.Save(Open.IsPresent);
+            Image.Save("", Open.IsPresent, Quality, CompressionLevel);
         }
     }
 }

--- a/Sources/ImagePlayground/Helpers.Encoder.cs
+++ b/Sources/ImagePlayground/Helpers.Encoder.cs
@@ -1,0 +1,35 @@
+using System;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Pbm;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Tga;
+using SixLabors.ImageSharp.Formats.Tiff;
+using SixLabors.ImageSharp.Formats.Webp;
+
+namespace ImagePlayground {
+    public static partial class Helpers {
+        public static IImageEncoder GetEncoder(string extension, int? quality, int? compressionLevel) {
+            extension = extension.ToLowerInvariant();
+            return extension switch {
+                ".png" => new PngEncoder {
+                    CompressionLevel = compressionLevel.HasValue
+                        ? (PngCompressionLevel)Math.Max(0, Math.Min(9, compressionLevel.Value))
+                        : PngCompressionLevel.DefaultCompression
+                },
+                ".jpg" => new JpegEncoder { Quality = Math.Clamp(quality ?? 75, 0, 100) },
+                ".jpeg" => new JpegEncoder { Quality = Math.Clamp(quality ?? 75, 0, 100) },
+                ".bmp" => new BmpEncoder(),
+                ".gif" => new GifEncoder(),
+                ".pbm" => new PbmEncoder(),
+                ".tga" => new TgaEncoder(),
+                ".tiff" => new TiffEncoder(),
+                ".webp" => new WebpEncoder { Quality = Math.Clamp(quality ?? 75, 0, 100) },
+                _ => throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it."),
+            };
+        }
+    }
+}

--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -295,18 +295,19 @@ namespace ImagePlayground {
             return image;
         }
 
-        public void Save(string filePath = "", bool openImage = false) {
+        public void Save(string filePath = "", bool openImage = false, int? quality = null, int? compressionLevel = null) {
             if (filePath == "") {
                 filePath = _filePath;
             } else {
                 filePath = System.IO.Path.GetFullPath(filePath);
             }
-            _image.Save(filePath);
+            var encoder = Helpers.GetEncoder(System.IO.Path.GetExtension(filePath), quality, compressionLevel);
+            _image.Save(filePath, encoder);
             Helpers.Open(filePath, openImage);
         }
 
         public void Save(bool openImage) {
-            Save("", openImage);
+            Save("", openImage, null, null);
         }
 
         public void Dispose() {

--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -18,34 +18,17 @@ namespace ImagePlayground {
         /// <param name="filePath"></param>
         /// <param name="outFilePath"></param>
         /// <exception cref="UnknownImageFormatException"></exception>
-        public static void ConvertTo(string filePath, string outFilePath) {
+        public static void ConvertTo(string filePath, string outFilePath, int? quality = null, int? compressionLevel = null) {
             string fullPath = System.IO.Path.GetFullPath(filePath);
             string outFullPath = System.IO.Path.GetFullPath(outFilePath);
-            using (var inStream = System.IO.File.OpenRead(fullPath)) {
-                using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
-                    FileInfo fileInfo = new FileInfo(outFilePath);
-                    if (fileInfo.Extension == ".png") {
-                        image.SaveAsPng(outFilePath);
-                    } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
-                        image.SaveAsJpeg(outFilePath);
-                    } else if (fileInfo.Extension == ".bmp") {
-                        image.SaveAsBmp(outFilePath);
-                    } else if (fileInfo.Extension == ".gif") {
-                        image.SaveAsGif(outFilePath);
-                    } else if (fileInfo.Extension == ".pbm") {
-                        image.SaveAsPbm(outFilePath);
-                    } else if (fileInfo.Extension == ".tga") {
-                        image.SaveAsTga(outFilePath);
-                    } else if (fileInfo.Extension == ".tiff") {
-                        image.SaveAsTiff(outFilePath);
-                    } else if (fileInfo.Extension == ".webp") {
-                        image.SaveAsWebp(outFilePath);
-                    } else if (fileInfo.Extension == ".ico") {
-                        // maybe it will work?
-                        System.IO.File.Copy(fullPath, outFullPath, true);
-                    } else {
-                        throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
-                    }
+            using (var inStream = System.IO.File.OpenRead(fullPath))
+            using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
+                FileInfo fileInfo = new FileInfo(outFilePath);
+                if (fileInfo.Extension == ".ico") {
+                    System.IO.File.Copy(fullPath, outFullPath, true);
+                } else {
+                    var encoder = Helpers.GetEncoder(fileInfo.Extension, quality, compressionLevel);
+                    image.Save(outFullPath, encoder);
                 }
             }
         }

--- a/Tests/ConvertTo-Image.Tests.ps1
+++ b/Tests/ConvertTo-Image.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'ConvertTo-Image' {
 
         if (Test-Path $dest) { Remove-Item $dest }
 
-        ConvertTo-Image -FilePath $src -OutputPath $dest
+        ConvertTo-Image -FilePath $src -OutputPath $dest -Quality 80
 
         Test-Path $dest | Should -BeTrue
 

--- a/Tests/Save-Image.Tests.ps1
+++ b/Tests/Save-Image.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Save-Image' {
 
         $img = Get-Image -FilePath $src
 
-        Save-Image -Image $img -FilePath $dest
+        Save-Image -Image $img -FilePath $dest -CompressionLevel 6 -Quality 80
 
         $img.Dispose()
 


### PR DESCRIPTION
## Summary
- add helper to pick encoders
- allow providing Quality or CompressionLevel when converting or saving
- expose parameters in `ConvertTo-Image` and `Save-Image` cmdlets
- document new parameters and usage
- export Add-ImageWatermark cmdlet
- test saving and converting with new options
- clamp quality input to valid range

## Testing
- `dotnet build Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj -c Debug -f net8.0`
- `pwsh -NoLogo -NoProfile -File ./ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_685150b04de4832ebc69c3078fe076ac