### PR TITLE
Add color options for charts

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartBar.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartBar.cs
@@ -14,8 +14,12 @@ public sealed class NewImageChartBarCmdlet : PSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public double[] Value { get; set; } = System.Array.Empty<double>();
 
+    /// <summary>Bar color.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color? Color { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        WriteObject(new ImagePlayground.Charts.ChartBar(Name, Value));
+        WriteObject(new ImagePlayground.Charts.ChartBar(Name, Value, Color));
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartLine.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartLine.cs
@@ -14,8 +14,12 @@ public sealed class NewImageChartLineCmdlet : PSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public double[] Value { get; set; } = System.Array.Empty<double>();
 
+    /// <summary>Line color.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color? Color { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        WriteObject(new ImagePlayground.Charts.ChartLine(Name, Value));
+        WriteObject(new ImagePlayground.Charts.ChartLine(Name, Value, Color));
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartPie.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartPie.cs
@@ -14,8 +14,12 @@ public sealed class NewImageChartPieCmdlet : PSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public double Value { get; set; }
 
+    /// <summary>Slice color.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color? Color { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        WriteObject(new ImagePlayground.Charts.ChartPie(Name, Value));
+        WriteObject(new ImagePlayground.Charts.ChartPie(Name, Value, Color));
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartRadial.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartRadial.cs
@@ -14,8 +14,12 @@ public sealed class NewImageChartRadialCmdlet : PSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public double Value { get; set; }
 
+    /// <summary>Gauge color.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color? Color { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        WriteObject(new ImagePlayground.Charts.ChartRadial(Name, Value));
+        WriteObject(new ImagePlayground.Charts.ChartRadial(Name, Value, Color));
     }
 }


### PR DESCRIPTION
## Summary
- support color parameters for chart data cmdlets
- extend chart definitions with optional `Color`
- apply chart colors when plotting with ScottPlot

## Testing
- `dotnet test Sources/ImagePlayground.sln` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_68514f937460832e92276ba00e38a865