### PR TITLE
Integrate centralized path helpers

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
@@ -44,11 +44,13 @@ public sealed class AddImageTextCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string src = ImagePlayground.Helpers.ResolvePath(FilePath);
+        string dest = ImagePlayground.Helpers.ResolvePath(OutputPath);
+        if (!File.Exists(src)) {
             WriteWarning($"Add-ImageText - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        ImagePlayground.ImageHelper.AddText(FilePath, OutputPath, X, Y, Text, Color, FontSize, FontFamily);
+        ImagePlayground.ImageHelper.AddText(src, dest, X, Y, Text, Color, FontSize, FontFamily);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
@@ -42,19 +42,22 @@ namespace ImagePlayground.PowerShell {
         public int WatermarkPercentage { get; set; } = 20;
 
         protected override void ProcessRecord() {
-            if (!File.Exists(FilePath)) {
+            string src = ImagePlayground.Helpers.ResolvePath(FilePath);
+            string dest = ImagePlayground.Helpers.ResolvePath(OutputPath);
+            string watermark = ImagePlayground.Helpers.ResolvePath(WatermarkPath);
+            if (!File.Exists(src)) {
                 WriteWarning($"Add-ImageWatermark - File {FilePath} not found. Please check the path.");
                 return;
             }
-            if (!File.Exists(WatermarkPath)) {
+            if (!File.Exists(watermark)) {
                 WriteWarning($"Add-ImageWatermark - Watermark file {WatermarkPath} not found. Please check the path.");
                 return;
             }
 
             if (ParameterSetName == ParameterSetCoordinates) {
-                ImagePlayground.ImageHelper.WatermarkImage(FilePath, OutputPath, WatermarkPath, X, Y, Opacity, Rotate, FlipMode, WatermarkPercentage);
+                ImagePlayground.ImageHelper.WatermarkImage(src, dest, watermark, X, Y, Opacity, Rotate, FlipMode, WatermarkPercentage);
             } else {
-                ImagePlayground.ImageHelper.WatermarkImage(FilePath, OutputPath, WatermarkPath, Placement, Opacity, Padding, Rotate, FlipMode, WatermarkPercentage);
+                ImagePlayground.ImageHelper.WatermarkImage(src, dest, watermark, Placement, Opacity, Padding, Rotate, FlipMode, WatermarkPercentage);
             }
         }
     }

--- a/Sources/ImagePlayground.PowerShell/CmdletCompareImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletCompareImage.cs
@@ -24,19 +24,22 @@ public sealed class CompareImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string src1 = ImagePlayground.Helpers.ResolvePath(FilePath);
+        string src2 = ImagePlayground.Helpers.ResolvePath(FilePathToCompare);
+        if (!File.Exists(src1)) {
             WriteWarning($"Compare-Image - File {FilePath} not found. Please check the path.");
             return;
         }
-        if (!File.Exists(FilePathToCompare)) {
+        if (!File.Exists(src2)) {
             WriteWarning($"Compare-Image - File {FilePathToCompare} not found. Please check the path.");
             return;
         }
 
         if (!string.IsNullOrWhiteSpace(OutputPath)) {
-            ImagePlayground.ImageHelper.Compare(FilePath, FilePathToCompare, OutputPath);
+            string dest = ImagePlayground.Helpers.ResolvePath(OutputPath);
+            ImagePlayground.ImageHelper.Compare(src1, src2, dest);
         } else {
-            var result = ImagePlayground.ImageHelper.Compare(FilePath, FilePathToCompare);
+            var result = ImagePlayground.ImageHelper.Compare(src1, src2);
             WriteObject(result);
         }
     }

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
@@ -23,11 +23,13 @@ public sealed class ConvertToImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string src = ImagePlayground.Helpers.ResolvePath(FilePath);
+        string dest = ImagePlayground.Helpers.ResolvePath(OutputPath);
+        if (!File.Exists(src)) {
             WriteWarning($"ConvertTo-Image - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        ImagePlayground.ImageHelper.ConvertTo(FilePath, OutputPath);
+        ImagePlayground.ImageHelper.ConvertTo(src, dest);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImage.cs
@@ -17,12 +17,13 @@ public sealed class GetImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string fullPath = ImagePlayground.Helpers.ResolvePath(FilePath);
+        if (!File.Exists(fullPath)) {
             WriteWarning($"Get-Image - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        var img = ImagePlayground.Image.Load(FilePath);
+        var img = ImagePlayground.Image.Load(fullPath);
         WriteObject(img);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageBarCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageBarCode.cs
@@ -17,12 +17,13 @@ public sealed class GetImageBarCodeCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string fullPath = ImagePlayground.Helpers.ResolvePath(FilePath);
+        if (!File.Exists(fullPath)) {
             WriteWarning($"Get-ImageBarCode - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        var result = ImagePlayground.BarCode.Read(FilePath);
+        var result = ImagePlayground.BarCode.Read(fullPath);
         WriteObject(result);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageExif.cs
@@ -27,12 +27,13 @@ public sealed class GetImageExifCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string fullPath = ImagePlayground.Helpers.ResolvePath(FilePath);
+        if (!File.Exists(fullPath)) {
             WriteWarning($"Get-ImageExif - File not found: {FilePath}");
             return;
         }
 
-        using var img = ImagePlayground.Image.Load(FilePath);
+        using var img = ImagePlayground.Image.Load(fullPath);
         IReadOnlyList<IExifValue> values = img.GetExifValues();
 
         if (Translate.IsPresent) {

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageQRCode.cs
@@ -17,12 +17,13 @@ public sealed class GetImageQrCodeCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string fullPath = ImagePlayground.Helpers.ResolvePath(FilePath);
+        if (!File.Exists(fullPath)) {
             WriteWarning($"Get-ImageQRCode - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        var result = ImagePlayground.QrCode.Read(FilePath);
+        var result = ImagePlayground.QrCode.Read(fullPath);
         WriteObject(result);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletMergeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletMergeImage.cs
@@ -34,15 +34,18 @@ public sealed class MergeImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string src1 = ImagePlayground.Helpers.ResolvePath(FilePath);
+        string src2 = ImagePlayground.Helpers.ResolvePath(FilePathToMerge);
+        string dest = ImagePlayground.Helpers.ResolvePath(FilePathOutput);
+        if (!File.Exists(src1)) {
             WriteWarning($"Merge-Image - File {FilePath} not found. Please check the path.");
             return;
         }
-        if (!File.Exists(FilePathToMerge)) {
+        if (!File.Exists(src2)) {
             WriteWarning($"Merge-Image - File {FilePathToMerge} not found. Please check the path.");
             return;
         }
 
-        ImagePlayground.ImageHelper.Combine(FilePath, FilePathToMerge, FilePathOutput, ResizeToFit.IsPresent, Placement);
+        ImagePlayground.ImageHelper.Combine(src1, src2, dest, ResizeToFit.IsPresent, Placement);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
@@ -31,15 +31,17 @@ public sealed class NewImageIconCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string src = ImagePlayground.Helpers.ResolvePath(FilePath);
+        string dest = ImagePlayground.Helpers.ResolvePath(OutputPath);
+        if (!File.Exists(src)) {
             WriteWarning($"New-ImageIcon - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        using var img = ImagePlayground.Image.Load(FilePath);
-        img.SaveAsIcon(OutputPath, Size);
+        using var img = ImagePlayground.Image.Load(src);
+        img.SaveAsIcon(dest, Size);
         if (Open.IsPresent) {
-            ImagePlayground.Helpers.Open(OutputPath, true);
+            ImagePlayground.Helpers.Open(dest, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
@@ -38,20 +38,21 @@ public sealed class RemoveImageExifCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string src = ImagePlayground.Helpers.ResolvePath(FilePath);
+        string dest = string.IsNullOrWhiteSpace(FilePathOutput) ? src : ImagePlayground.Helpers.ResolvePath(FilePathOutput!);
+        if (!File.Exists(src)) {
             WriteWarning($"Remove-ImageExif - File not found: {FilePath}");
             return;
         }
 
-        using var img = ImagePlayground.Image.Load(FilePath);
+        using var img = ImagePlayground.Image.Load(src);
         if (ParameterSetName == ParameterSetAll) {
             img.ClearExifValues();
         } else {
             img.RemoveExifValues(ExifTag);
         }
 
-        string output = string.IsNullOrWhiteSpace(FilePathOutput) ? FilePath : FilePathOutput!;
-        img.Save(output);
+        img.Save(dest);
     }
 }
 

--- a/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
@@ -49,13 +49,15 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string src = ImagePlayground.Helpers.ResolvePath(FilePath);
+        string dest = ImagePlayground.Helpers.ResolvePath(OutputPath);
+        if (!File.Exists(src)) {
             WriteWarning($"Resize-Image - File {FilePath} not found. Please check the path.");
             return;
         }
 
         if (ParameterSetName == ParameterSetPercentage) {
-            ImagePlayground.ImageHelper.Resize(FilePath, OutputPath, Percentage);
+            ImagePlayground.ImageHelper.Resize(src, dest, Percentage);
             return;
         }
 
@@ -71,6 +73,6 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
         int? height = heightBound ? Height : (int?)null;
         bool keepAspect = !DontRespectAspectRatio.IsPresent;
 
-        ImagePlayground.ImageHelper.Resize(FilePath, OutputPath, width, height, keepAspect);
+        ImagePlayground.ImageHelper.Resize(src, dest, width, height, keepAspect);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
@@ -27,7 +27,8 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (!string.IsNullOrWhiteSpace(FilePath)) {
-            Image.Save(FilePath, Open.IsPresent);
+            string outPath = ImagePlayground.Helpers.ResolvePath(FilePath);
+            Image.Save(outPath, Open.IsPresent);
         } else if (AsStream.IsPresent) {
             WriteObject(Image.ToStream());
         } else {

--- a/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
@@ -29,16 +29,17 @@ public sealed class SetImageExifCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        string src = ImagePlayground.Helpers.ResolvePath(FilePath);
+        string dest = string.IsNullOrWhiteSpace(FilePathOutput) ? src : ImagePlayground.Helpers.ResolvePath(FilePathOutput!);
+        if (!File.Exists(src)) {
             WriteWarning($"Set-ImageExif - File not found: {FilePath}");
             return;
         }
 
-        using var img = ImagePlayground.Image.Load(FilePath);
+        using var img = ImagePlayground.Image.Load(src);
         img.SetExifValue(ExifTag, Value);
 
-        string output = string.IsNullOrWhiteSpace(FilePathOutput) ? FilePath : FilePathOutput!;
-        img.Save(output);
+        img.Save(dest);
     }
 }
 

--- a/Sources/ImagePlayground/BarCode.cs
+++ b/Sources/ImagePlayground/BarCode.cs
@@ -26,7 +26,7 @@ namespace ImagePlayground {
             EAN
         }
         private static void SaveToFile(IBarcode barcode, string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             ImageFormat imageFormatDetected;
             FileInfo fileInfo = new FileInfo(fullPath);
@@ -110,7 +110,7 @@ namespace ImagePlayground {
         }
 
         public static BarcodeResult<Rgba32> Read(string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
             BarcodeReader<Rgba32> reader = new BarcodeReader<Rgba32>();

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -143,7 +143,7 @@ public static class Charts {
                 break;
         }
 
-        filePath = System.IO.Path.GetFullPath(filePath);
+        filePath = Helpers.ResolvePath(filePath);
         plot.SavePng(filePath, width, height);
     }
 }

--- a/Sources/ImagePlayground/Helpers.Path.cs
+++ b/Sources/ImagePlayground/Helpers.Path.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace ImagePlayground {
+    public static partial class Helpers {
+        public static string ResolvePath(string path) {
+            if (string.IsNullOrWhiteSpace(path)) {
+                throw new ArgumentException("Path cannot be null or empty", nameof(path));
+            }
+            string expanded = Environment.ExpandEnvironmentVariables(path);
+            return Path.GetFullPath(expanded);
+        }
+
+        public static string ReadFileChecked(string path) {
+            string fullPath = ResolvePath(path);
+            if (!File.Exists(fullPath)) {
+                throw new FileNotFoundException($"File not found: {path}", fullPath);
+            }
+            return File.ReadAllText(fullPath);
+        }
+
+        public static async Task<string> ReadFileCheckedAsync(string path) {
+            string fullPath = ResolvePath(path);
+            if (!File.Exists(fullPath)) {
+                throw new FileNotFoundException($"File not found: {path}", fullPath);
+            }
+#if NETSTANDARD2_0 || NETFRAMEWORK
+            return await Task.Run(() => File.ReadAllText(fullPath)).ConfigureAwait(false);
+#else
+            return await File.ReadAllTextAsync(fullPath).ConfigureAwait(false);
+#endif
+        }
+
+        public static async Task<string> GetStringWithProperEncodingAsync(HttpClient client, string url) {
+            using var response = await client.GetAsync(url).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+            var contentType = response.Content.Headers.ContentType;
+            if (contentType?.CharSet != null) {
+                try {
+                    var encoding = System.Text.Encoding.GetEncoding(contentType.CharSet);
+                    return encoding.GetString(bytes);
+                } catch {
+                }
+            }
+
+            if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
+                return System.Text.Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+            }
+            if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE) {
+                return System.Text.Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+            }
+            if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF) {
+                return System.Text.Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+            }
+
+            var asciiContent = System.Text.Encoding.ASCII.GetString(bytes);
+            var metaMatch = System.Text.RegularExpressions.Regex.Match(
+                asciiContent,
+                @"<meta[^>]+charset\s*=\s*['""]?([^'"">\s]+)",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+            if (metaMatch.Success) {
+                try {
+                    var encoding = System.Text.Encoding.GetEncoding(metaMatch.Groups[1].Value);
+                    return encoding.GetString(bytes);
+                } catch {
+                }
+            }
+
+            return System.Text.Encoding.UTF8.GetString(bytes);
+        }
+    }
+}

--- a/Sources/ImagePlayground/Image.Icon.cs
+++ b/Sources/ImagePlayground/Image.Icon.cs
@@ -9,7 +9,7 @@ using SixLabors.ImageSharp.Processing;
 namespace ImagePlayground {
     public partial class Image {
         public void SaveAsIcon(string filePath, params int[] sizes) {
-            string fullPath = Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
             if (sizes == null || sizes.Length == 0) {
                 sizes = new[] { 16, 32, 48, 64, 128, 256 };
             }

--- a/Sources/ImagePlayground/Image.Image.cs
+++ b/Sources/ImagePlayground/Image.Image.cs
@@ -6,7 +6,7 @@ using SixLabors.ImageSharp.Processing;
 namespace ImagePlayground {
     public partial class Image : IDisposable {
         public void AddImage(string filePath, int x, int y, float opacity) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             var location = new Point(x, y);
             using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {

--- a/Sources/ImagePlayground/Image.Watermark.cs
+++ b/Sources/ImagePlayground/Image.Watermark.cs
@@ -48,7 +48,7 @@ namespace ImagePlayground {
         }
 
         public void WatermarkImage(string filePath, WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             var location = new Point(0, 0);
             using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {
@@ -87,7 +87,7 @@ namespace ImagePlayground {
         }
 
         public void WatermarkImage(string filePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             var location = new Point(x, y);
             using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {

--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -78,7 +78,7 @@ namespace ImagePlayground {
         }
 
         public ICompareResult Compare(string filePathToCompare) {
-            string fullPath = System.IO.Path.GetFullPath(filePathToCompare);
+            string fullPath = Helpers.ResolvePath(filePathToCompare);
 
             using (var imageToCompare = GetImage(fullPath)) {
                 bool isEqual = ImageSharpCompare.ImagesAreEqual(_image, imageToCompare);
@@ -88,7 +88,7 @@ namespace ImagePlayground {
         }
 
         public void Compare(Image imageToCompare, string filePathToSave) {
-            string outFullPath = System.IO.Path.GetFullPath(filePathToSave);
+            string outFullPath = Helpers.ResolvePath(filePathToSave);
             using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
                 using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(_image, imageToCompare._image)) {
                     SixLabors.ImageSharp.ImageExtensions.SaveAsPng(maskImage, fileStreamDifferenceMask);
@@ -97,8 +97,8 @@ namespace ImagePlayground {
         }
 
         public void Compare(string filePathToCompare, string filePathToSave) {
-            string fullPath = System.IO.Path.GetFullPath(filePathToCompare);
-            string outFullPath = System.IO.Path.GetFullPath(filePathToSave);
+            string fullPath = Helpers.ResolvePath(filePathToCompare);
+            string outFullPath = Helpers.ResolvePath(filePathToSave);
 
             using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
                 using (var imageToCompare = GetImage(fullPath)) {
@@ -273,7 +273,7 @@ namespace ImagePlayground {
         }
 
         public static SixLabors.ImageSharp.Image GetImage(string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
             using (var inStream = System.IO.File.OpenRead(fullPath)) {
                 return SixLabors.ImageSharp.Image.Load(inStream);
             }
@@ -285,7 +285,7 @@ namespace ImagePlayground {
         }
 
         public static Image Load(string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             Image image = new Image {
                 _filePath = fullPath,
@@ -299,7 +299,7 @@ namespace ImagePlayground {
             if (filePath == "") {
                 filePath = _filePath;
             } else {
-                filePath = System.IO.Path.GetFullPath(filePath);
+                filePath = Helpers.ResolvePath(filePath);
             }
             _image.Save(filePath);
             Helpers.Open(filePath, openImage);

--- a/Sources/ImagePlayground/ImageHelper.AddText.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddText.cs
@@ -4,8 +4,8 @@ using SixLabors.ImageSharp;
 namespace ImagePlayground {
     public partial class ImageHelper {
         public static void AddText(string filePath, string outFilePath, float x, float y, string text, Color color, float fontSize = 16f, string fontFamilyName = "Arial") {
-            string fullPath = Path.GetFullPath(filePath);
-            string outFullPath = Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using var img = Image.Load(fullPath);
             img.AddText(x, y, text, color, fontSize, fontFamilyName);

--- a/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
@@ -5,16 +5,16 @@ using SixLabors.ImageSharp.Processing;
 namespace ImagePlayground {
     public partial class ImageHelper {
         public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, Image.WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
-            string fullPath = Path.GetFullPath(filePath);
-            string outFullPath = Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
             using var img = Image.Load(fullPath);
             img.WatermarkImage(watermarkFilePath, placement, opacity, padding, rotate, flipMode, watermarkPercentage);
             img.Save(outFullPath);
         }
 
         public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
-            string fullPath = Path.GetFullPath(filePath);
-            string outFullPath = Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
             using var img = Image.Load(fullPath);
             img.WatermarkImage(watermarkFilePath, x, y, opacity, rotate, flipMode, watermarkPercentage);
             img.Save(outFullPath);

--- a/Sources/ImagePlayground/ImageHelper.Compare.cs
+++ b/Sources/ImagePlayground/ImageHelper.Compare.cs
@@ -5,8 +5,8 @@ namespace ImagePlayground {
     public partial class ImageHelper {
 
         public static ICompareResult Compare(string filePath, string filePathToCompare) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string fullPathToCompare = System.IO.Path.GetFullPath(filePathToCompare);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);
 
             bool isEqual = ImageSharpCompare.ImagesAreEqual(fullPath, fullPathToCompare);
             ICompareResult calcDiff = ImageSharpCompare.CalcDiff(fullPath, fullPathToCompare);
@@ -14,9 +14,9 @@ namespace ImagePlayground {
         }
 
         public static void Compare(string filePath, string filePathToCompare, string filePathToSave) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string fullPathToCompare = System.IO.Path.GetFullPath(filePathToCompare);
-            string outFullPath = System.IO.Path.GetFullPath(filePathToSave);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);
+            string outFullPath = Helpers.ResolvePath(filePathToSave);
 
             using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
                 using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(fullPath, fullPathToCompare)) {

--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -19,8 +19,8 @@ namespace ImagePlayground {
         /// <param name="outFilePath"></param>
         /// <exception cref="UnknownImageFormatException"></exception>
         public static void ConvertTo(string filePath, string outFilePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string outFullPath = System.IO.Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
             using (var inStream = System.IO.File.OpenRead(fullPath)) {
                 using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
                     FileInfo fileInfo = new FileInfo(outFilePath);
@@ -61,8 +61,8 @@ namespace ImagePlayground {
         /// <param name="keepAspectRatio"></param>
         /// <param name="sampler"></param>
         public static void Resize(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Image.Sampler? sampler = null) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string outFullPath = System.IO.Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using (var inStream = System.IO.File.OpenRead(fullPath))
             using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
@@ -108,8 +108,8 @@ namespace ImagePlayground {
         /// <param name="outFilePath"></param>
         /// <param name="percentage"></param>
         public static void Resize(string filePath, string outFilePath, int percentage) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string outFullPath = System.IO.Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using (var inStream = System.IO.File.OpenRead(fullPath))
             using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
@@ -121,9 +121,9 @@ namespace ImagePlayground {
         }
 
         public static void Combine(string filePath, string filePath2, string outFilePath, bool resizeToFit = false, ImagePlacement imagePlacement = ImagePlacement.Bottom) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string fullPath2 = System.IO.Path.GetFullPath(filePath2);
-            string outFullPath = System.IO.Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string fullPath2 = Helpers.ResolvePath(filePath2);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using (var inStream = System.IO.File.OpenRead(fullPath))
             using (var inStream2 = System.IO.File.OpenRead(fullPath2))
@@ -198,7 +198,7 @@ namespace ImagePlayground {
         }
 
         public static void Create(string filePath, int width, int height, Color color, bool open = false) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             using (Image<Rgba32> outputImage = new Image<Rgba32>(width, height)) {
                 //outputImage.Mutate(x => x.Fill(color));

--- a/Sources/ImagePlayground/ImagePlayground.csproj
+++ b/Sources/ImagePlayground/ImagePlayground.csproj
@@ -43,4 +43,7 @@
         <Using Include="System.Net" />
         <Using Include="System.Net.Http" />
     </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <Reference Include="System.Net.Http" />
+    </ItemGroup>
 </Project>

--- a/Sources/ImagePlayground/QRCode.cs
+++ b/Sources/ImagePlayground/QRCode.cs
@@ -8,7 +8,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace ImagePlayground {
     public class QrCode {
         public static void Generate(string content, string filePath, bool transparent = false, QRCodeGenerator.ECCLevel eccLevel = QRCodeGenerator.ECCLevel.Q) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             FileInfo fileInfo = new FileInfo(fullPath);
 
@@ -86,7 +86,7 @@ namespace ImagePlayground {
         }
 
         public static BarcodeResult<Rgba32> Read(string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
             BarcodeReader<Rgba32> reader = new BarcodeReader<Rgba32>(types: ZXing.BarcodeFormat.QR_CODE);


### PR DESCRIPTION
## Summary
- add `Helpers.ResolvePath` and file utility helpers
- reference new helpers across core library and PowerShell cmdlets
- ensure .NET Framework builds by referencing System.Net.Http

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1` *(fails: cmdlets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851646c9828832eba87d0f594b8ecad