### PR TITLE
Implement compression for Save-Image stream

### DIFF
--- a/Docs/Save-Image.md
+++ b/Docs/Save-Image.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Save-Image [-Image] <Image> [[-FilePath] <String>] [-Quality <Int32>] [-CompressionLevel <Int32>] [-Open] [<CommonParameters>]
+Save-Image [-Image] <Image> [[-FilePath] <String>] [-Quality <Int32>] [-CompressionLevel <Int32>] [-AsStream] [-Open] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -55,6 +55,48 @@ Aliases:
 
 Required: False
 Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Quality
+{{ Fill Quality Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CompressionLevel
+{{ Fill CompressionLevel Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AsStream
+{{ Fill AsStream Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -1,11 +1,33 @@
 ﻿@{
     AliasesToExport        = @('New-QRCode', 'New-QRCodeWiFi')
     Author                 = 'Przemyslaw Klys'
-<<<<<<< implement-issue-#10-from-imageplayground -- Incoming Change
-    CmdletsToExport        = @('Add-ImageText', 'Add-ImageWatermark', 'Compare-Image', 'ConvertTo-Image', 'Get-Image', 'Get-ImageBarCode', 'Get-ImageExif', 'Get-ImageQRCode', 'Merge-Image', 'New-ImageBarCode', 'New-ImageChart', 'New-ImageChartBar', 'New-ImageChartBarOptions', 'New-ImageChartLine', 'New-ImageChartPie', 'New-ImageChartRadial', 'New-ImageGrid', 'New-ImageQRCode', 'New-ImageQRCodeWiFi', 'New-ImageQRContact', 'Remove-ImageExif', 'Resize-Image', 'Save-Image', 'Set-ImageExif')
-=======
-    CmdletsToExport        = @('Add-ImageText', 'Add-ImageWatermark', 'Compare-Image', 'ConvertTo-Image', 'Get-Image', 'Get-ImageBarCode', 'Get-ImageExif', 'Get-ImageQRCode', 'Merge-Image', 'New-ImageBarCode', 'New-ImageChart', 'New-ImageChartBar', 'New-ImageChartBarOptions', 'New-ImageChartLine', 'New-ImageChartPie', 'New-ImageChartRadial', 'New-ImageGrid', 'New-ImageIcon', 'New-ImageQRCode', 'New-ImageQRCodeWiFi', 'New-ImageQRContact', 'Remove-ImageExif', 'Resize-Image', 'Save-Image', 'Set-ImageExif')
->>>>>>> master -- Current Change
+    CmdletsToExport        = @(
+        'Add-ImageText',
+        'Add-ImageWatermark',
+        'Compare-Image',
+        'ConvertTo-Image',
+        'Get-Image',
+        'Get-ImageBarCode',
+        'Get-ImageExif',
+        'Get-ImageQRCode',
+        'Merge-Image',
+        'New-ImageBarCode',
+        'New-ImageChart',
+        'New-ImageChartBar',
+        'New-ImageChartBarOptions',
+        'New-ImageChartLine',
+        'New-ImageChartPie',
+        'New-ImageChartRadial',
+        'New-ImageGrid',
+        'New-ImageIcon',
+        'New-ImageQRCode',
+        'New-ImageQRCodeWiFi',
+        'New-ImageQRContact',
+        'Remove-ImageExif',
+        'Resize-Image',
+        'Save-Image',
+        'Set-ImageExif'
+    )
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
@@ -17,7 +17,6 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     [Parameter(Position = 1)]
     public string? FilePath { get; set; }
 
-<<<<<<< implement-issue-#10-from-imageplayground -- Incoming Change
     /// <summary>Quality for JPEG or WEBP images.</summary>
     [Parameter]
     public int? Quality { get; set; }
@@ -25,10 +24,10 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     /// <summary>Compression level for PNG images.</summary>
     [Parameter]
     public int? CompressionLevel { get; set; }
-=======
+
+    /// <summary>Return the image as a stream instead of saving.</summary>
     [Parameter]
     public SwitchParameter AsStream { get; set; }
->>>>>>> master -- Current Change
 
     /// <summary>Open file after saving.</summary>
     [Parameter]
@@ -37,13 +36,9 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (!string.IsNullOrWhiteSpace(FilePath)) {
-<<<<<<< implement-issue-#10-from-imageplayground -- Incoming Change
             Image.Save(FilePath, Open.IsPresent, Quality, CompressionLevel);
-=======
-            Image.Save(FilePath, Open.IsPresent);
         } else if (AsStream.IsPresent) {
-            WriteObject(Image.ToStream());
->>>>>>> master -- Current Change
+            WriteObject(Image.ToStream(Quality, CompressionLevel));
         } else {
             Image.Save("", Open.IsPresent, Quality, CompressionLevel);
         }

--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -310,31 +310,16 @@ namespace ImagePlayground {
             Save("", openImage, null, null);
         }
 
-        public void Save(Stream stream) {
+        public void Save(Stream stream, int? quality = null, int? compressionLevel = null) {
             string extension = System.IO.Path.GetExtension(_filePath)?.ToLowerInvariant();
-            if (extension == ".jpg" || extension == ".jpeg") {
-                _image.SaveAsJpeg(stream);
-            } else if (extension == ".bmp") {
-                _image.SaveAsBmp(stream);
-            } else if (extension == ".gif") {
-                _image.SaveAsGif(stream);
-            } else if (extension == ".pbm") {
-                _image.SaveAsPbm(stream);
-            } else if (extension == ".tga") {
-                _image.SaveAsTga(stream);
-            } else if (extension == ".tiff") {
-                _image.SaveAsTiff(stream);
-            } else if (extension == ".webp") {
-                _image.SaveAsWebp(stream);
-            } else {
-                _image.SaveAsPng(stream);
-            }
+            var encoder = Helpers.GetEncoder(extension, quality, compressionLevel);
+            _image.Save(stream, encoder);
             stream.Seek(0, SeekOrigin.Begin);
         }
 
-        public MemoryStream ToStream() {
+        public MemoryStream ToStream(int? quality = null, int? compressionLevel = null) {
             var ms = new MemoryStream();
-            Save(ms);
+            Save(ms, quality, compressionLevel);
             return ms;
         }
 

--- a/Tests/Save-Image.Tests.ps1
+++ b/Tests/Save-Image.Tests.ps1
@@ -37,13 +37,25 @@ Describe 'Save-Image' {
         $img = Get-Image -FilePath $src
 
         $stream = Save-Image -Image $img -AsStream
-
+        
         $img.Dispose()
 
         $stream | Should -BeOfType ([System.IO.MemoryStream])
 
         $stream.Length | Should -BeGreaterThan 0
 
+    }
+
+    It 'supports quality and compression when AsStream is used' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $img = Get-Image -FilePath $src
+
+        $stream = Save-Image -Image $img -AsStream -Quality 80 -CompressionLevel 6
+
+        $img.Dispose()
+
+        $stream | Should -BeOfType ([System.IO.MemoryStream])
+        $stream.Length | Should -BeGreaterThan 0
     }
 
 }


### PR DESCRIPTION
## Summary
- resolve merge leftovers in manifest
- add `AsStream`, `Quality` and `CompressionLevel` parameters together
- allow streaming with compression/quality
- document new parameters
- test streaming with compression

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --framework net8.0 --verbosity minimal`
- `pwsh -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685167296cf8832eaebf7ca20eac8cf1