### PR TITLE
Add path utilities and use across cmdlets

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -44,11 +45,13 @@ public sealed class AddImageTextCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Add-ImageText - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        ImagePlayground.ImageHelper.AddText(FilePath, OutputPath, X, Y, Text, Color, FontSize, FontFamily);
+        var output = Helpers.ResolvePath(OutputPath);
+        ImagePlayground.ImageHelper.AddText(filePath, output, X, Y, Text, Color, FontSize, FontFamily);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 using SixLabors.ImageSharp.Processing;
@@ -42,19 +43,22 @@ namespace ImagePlayground.PowerShell {
         public int WatermarkPercentage { get; set; } = 20;
 
         protected override void ProcessRecord() {
-            if (!File.Exists(FilePath)) {
+            var filePath = Helpers.ResolvePath(FilePath);
+            if (!File.Exists(filePath)) {
                 WriteWarning($"Add-ImageWatermark - File {FilePath} not found. Please check the path.");
                 return;
             }
-            if (!File.Exists(WatermarkPath)) {
+            var watermark = Helpers.ResolvePath(WatermarkPath);
+            if (!File.Exists(watermark)) {
                 WriteWarning($"Add-ImageWatermark - Watermark file {WatermarkPath} not found. Please check the path.");
                 return;
             }
+            var output = Helpers.ResolvePath(OutputPath);
 
             if (ParameterSetName == ParameterSetCoordinates) {
-                ImagePlayground.ImageHelper.WatermarkImage(FilePath, OutputPath, WatermarkPath, X, Y, Opacity, Rotate, FlipMode, WatermarkPercentage);
+                ImagePlayground.ImageHelper.WatermarkImage(filePath, output, watermark, X, Y, Opacity, Rotate, FlipMode, WatermarkPercentage);
             } else {
-                ImagePlayground.ImageHelper.WatermarkImage(FilePath, OutputPath, WatermarkPath, Placement, Opacity, Padding, Rotate, FlipMode, WatermarkPercentage);
+                ImagePlayground.ImageHelper.WatermarkImage(filePath, output, watermark, Placement, Opacity, Padding, Rotate, FlipMode, WatermarkPercentage);
             }
         }
     }

--- a/Sources/ImagePlayground.PowerShell/CmdletCompareImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletCompareImage.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -24,19 +25,22 @@ public sealed class CompareImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Compare-Image - File {FilePath} not found. Please check the path.");
             return;
         }
-        if (!File.Exists(FilePathToCompare)) {
+        var compare = Helpers.ResolvePath(FilePathToCompare);
+        if (!File.Exists(compare)) {
             WriteWarning($"Compare-Image - File {FilePathToCompare} not found. Please check the path.");
             return;
         }
 
         if (!string.IsNullOrWhiteSpace(OutputPath)) {
-            ImagePlayground.ImageHelper.Compare(FilePath, FilePathToCompare, OutputPath);
+            var output = Helpers.ResolvePath(OutputPath);
+            ImagePlayground.ImageHelper.Compare(filePath, compare, output);
         } else {
-            var result = ImagePlayground.ImageHelper.Compare(FilePath, FilePathToCompare);
+            var result = ImagePlayground.ImageHelper.Compare(filePath, compare);
             WriteObject(result);
         }
     }

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -31,11 +32,13 @@ public sealed class ConvertToImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"ConvertTo-Image - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        ImagePlayground.ImageHelper.ConvertTo(FilePath, OutputPath, Quality, CompressionLevel);
+        var output = Helpers.ResolvePath(OutputPath);
+        ImagePlayground.ImageHelper.ConvertTo(filePath, output, Quality, CompressionLevel);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImage.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -17,12 +18,13 @@ public sealed class GetImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Get-Image - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        var img = ImagePlayground.Image.Load(FilePath);
+        var img = ImagePlayground.Image.Load(filePath);
         WriteObject(img);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageBarCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageBarCode.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -17,12 +18,13 @@ public sealed class GetImageBarCodeCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Get-ImageBarCode - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        var result = ImagePlayground.BarCode.Read(FilePath);
+        var result = ImagePlayground.BarCode.Read(filePath);
         WriteObject(result);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageExif.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -27,12 +28,13 @@ public sealed class GetImageExifCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Get-ImageExif - File not found: {FilePath}");
             return;
         }
 
-        using var img = ImagePlayground.Image.Load(FilePath);
+        using var img = ImagePlayground.Image.Load(filePath);
         IReadOnlyList<IExifValue> values = img.GetExifValues();
 
         if (Translate.IsPresent) {

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageQRCode.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -17,12 +18,13 @@ public sealed class GetImageQrCodeCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Get-ImageQRCode - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        var result = ImagePlayground.QrCode.Read(FilePath);
+        var result = ImagePlayground.QrCode.Read(filePath);
         WriteObject(result);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletMergeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletMergeImage.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -34,15 +35,18 @@ public sealed class MergeImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Merge-Image - File {FilePath} not found. Please check the path.");
             return;
         }
-        if (!File.Exists(FilePathToMerge)) {
+        var merge = Helpers.ResolvePath(FilePathToMerge);
+        if (!File.Exists(merge)) {
             WriteWarning($"Merge-Image - File {FilePathToMerge} not found. Please check the path.");
             return;
         }
+        var output = Helpers.ResolvePath(FilePathOutput);
 
-        ImagePlayground.ImageHelper.Combine(FilePath, FilePathToMerge, FilePathOutput, ResizeToFit.IsPresent, Placement);
+        ImagePlayground.ImageHelper.Combine(filePath, merge, output, ResizeToFit.IsPresent, Placement);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -31,18 +32,20 @@ public sealed class NewImageAvatarCmdlet : PSCmdlet {
     public SwitchParameter Open { get; set; }
 
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"New-ImageAvatar - File {FilePath} not found. Please check the path.");
             return;
         }
 
         if (ParameterSetName == ParameterSetStream) {
-            ImagePlayground.ImageHelper.Avatar(FilePath, OutputStream, Width, Height, CornerRadius);
+            ImagePlayground.ImageHelper.Avatar(filePath, OutputStream, Width, Height, CornerRadius);
             OutputStream.Position = 0;
         } else {
-            ImagePlayground.ImageHelper.Avatar(FilePath, OutputPath, Width, Height, CornerRadius);
+            var output = Helpers.ResolvePath(OutputPath);
+            ImagePlayground.ImageHelper.Avatar(filePath, output, Width, Height, CornerRadius);
             if (Open.IsPresent) {
-                ImagePlayground.Helpers.Open(OutputPath, true);
+                ImagePlayground.Helpers.Open(output, true);
             }
         }
     }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageBarCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageBarCode.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.Management.Automation;
 
 namespace ImagePlayground.PowerShell;
@@ -23,6 +24,7 @@ public sealed class NewImageBarCodeCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        ImagePlayground.BarCode.Generate(Type, Value, FilePath);
+        var output = Helpers.ResolvePath(FilePath);
+        ImagePlayground.BarCode.Generate(Type, Value, output);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.Collections.Generic;
 using System.Management.Automation;
 
@@ -50,10 +51,11 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
             return;
         }
 
-        ImagePlayground.Charts.Generate(list, FilePath, Width, Height);
+        var output = Helpers.ResolvePath(FilePath);
+        ImagePlayground.Charts.Generate(list, output, Width, Height);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(FilePath, true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -38,8 +38,8 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
             list.AddRange(Definition);
         }
         if (ChartsDefinition != null) {
-            var output = ChartsDefinition.Invoke();
-            foreach (var o in output) {
+            var results = ChartsDefinition.Invoke();
+            foreach (var o in results) {
                 var obj = o is PSObject ps ? ps.BaseObject : o;
                 if (obj is Charts.ChartDefinition def) {
                     list.Add(def);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.Management.Automation;
 
 namespace ImagePlayground.PowerShell;
@@ -31,6 +32,7 @@ public sealed class NewImageGridCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        ImagePlayground.ImageHelper.Create(FilePath, Width, Height, Color, Open.IsPresent);
+        var output = Helpers.ResolvePath(FilePath);
+        ImagePlayground.ImageHelper.Create(output, Width, Height, Color, Open.IsPresent);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -31,15 +32,17 @@ public sealed class NewImageIconCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"New-ImageIcon - File {FilePath} not found. Please check the path.");
             return;
         }
 
-        using var img = ImagePlayground.Image.Load(FilePath);
-        img.SaveAsIcon(OutputPath, Size);
+        var output = Helpers.ResolvePath(OutputPath);
+        using var img = ImagePlayground.Image.Load(filePath);
+        img.SaveAsIcon(output, Size);
         if (Open.IsPresent) {
-            ImagePlayground.Helpers.Open(OutputPath, true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -30,10 +31,11 @@ public sealed class NewImageQrCodeCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCode - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.Generate(Content, FilePath, false);
+        var output = Helpers.ResolvePath(FilePath);
+        ImagePlayground.QrCode.Generate(Content, output, false);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(FilePath, true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 
@@ -34,10 +35,11 @@ public sealed class NewImageQrCodeWiFiCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeWiFi - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateWiFi(SSID, Password, FilePath, false);
+        var output = Helpers.ResolvePath(FilePath);
+        ImagePlayground.QrCode.GenerateWiFi(SSID, Password, output, false);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(FilePath, true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System;
 using System.Management.Automation;
 
@@ -46,10 +47,11 @@ public sealed class NewImageQrContactCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRContact - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateContact(FilePath, OutputType, Firstname ?? string.Empty, Lastname ?? string.Empty, Nickname, Phone, MobilePhone, WorkPhone, Email, Birthday, Website, Street, HouseNumber, City, ZipCode, Country, Note, StateRegion, AddressOrder, Org, OrgTitle, false);
+        var output = Helpers.ResolvePath(FilePath);
+        ImagePlayground.QrCode.GenerateContact(output, OutputType, Firstname ?? string.Empty, Lastname ?? string.Empty, Nickname, Phone, MobilePhone, WorkPhone, Email, Birthday, Website, Street, HouseNumber, City, ZipCode, Country, Note, StateRegion, AddressOrder, Org, OrgTitle, false);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(FilePath, true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
@@ -38,19 +39,20 @@ public sealed class RemoveImageExifCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Remove-ImageExif - File not found: {FilePath}");
             return;
         }
 
-        using var img = ImagePlayground.Image.Load(FilePath);
+        using var img = ImagePlayground.Image.Load(filePath);
         if (ParameterSetName == ParameterSetAll) {
             img.ClearExifValues();
         } else {
             img.RemoveExifValues(ExifTag);
         }
 
-        string output = string.IsNullOrWhiteSpace(FilePathOutput) ? FilePath : FilePathOutput!;
+        var output = string.IsNullOrWhiteSpace(FilePathOutput) ? filePath : Helpers.ResolvePath(FilePathOutput!);
         img.Save(output);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Resizes an image.</summary>
@@ -49,13 +50,15 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Resize-Image - File {FilePath} not found. Please check the path.");
             return;
         }
+        var output = Helpers.ResolvePath(OutputPath);
 
         if (ParameterSetName == ParameterSetPercentage) {
-            ImagePlayground.ImageHelper.Resize(FilePath, OutputPath, Percentage);
+            ImagePlayground.ImageHelper.Resize(filePath, output, Percentage);
             return;
         }
 
@@ -71,6 +74,6 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
         int? height = heightBound ? Height : (int?)null;
         bool keepAspect = !DontRespectAspectRatio.IsPresent;
 
-        ImagePlayground.ImageHelper.Resize(FilePath, OutputPath, width, height, keepAspect);
+        ImagePlayground.ImageHelper.Resize(filePath, output, width, height, keepAspect);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.Management.Automation;
 
 namespace ImagePlayground.PowerShell;
@@ -36,7 +37,8 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (!string.IsNullOrWhiteSpace(FilePath)) {
-            Image.Save(FilePath, Open.IsPresent, Quality, CompressionLevel);
+            var output = Helpers.ResolvePath(FilePath);
+            Image.Save(output, Open.IsPresent, Quality, CompressionLevel);
         } else if (AsStream.IsPresent) {
             WriteObject(Image.ToStream(Quality, CompressionLevel));
         } else {

--- a/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
@@ -1,3 +1,4 @@
+using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
@@ -29,15 +30,16 @@ public sealed class SetImageExifCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        if (!File.Exists(FilePath)) {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
             WriteWarning($"Set-ImageExif - File not found: {FilePath}");
             return;
         }
 
-        using var img = ImagePlayground.Image.Load(FilePath);
+        using var img = ImagePlayground.Image.Load(filePath);
         img.SetExifValue(ExifTag, Value);
 
-        string output = string.IsNullOrWhiteSpace(FilePathOutput) ? FilePath : FilePathOutput!;
+        var output = string.IsNullOrWhiteSpace(FilePathOutput) ? filePath : Helpers.ResolvePath(FilePathOutput!);
         img.Save(output);
     }
 }

--- a/Sources/ImagePlayground/BarCode.cs
+++ b/Sources/ImagePlayground/BarCode.cs
@@ -26,7 +26,7 @@ namespace ImagePlayground {
             EAN
         }
         private static void SaveToFile(IBarcode barcode, string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             ImageFormat imageFormatDetected;
             FileInfo fileInfo = new FileInfo(fullPath);
@@ -110,7 +110,7 @@ namespace ImagePlayground {
         }
 
         public static BarcodeResult<Rgba32> Read(string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
             BarcodeReader<Rgba32> reader = new BarcodeReader<Rgba32>();

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -187,7 +187,7 @@ public static class Charts {
                 break;
         }
 
-        filePath = System.IO.Path.GetFullPath(filePath);
+        filePath = Helpers.ResolvePath(filePath);
         plot.SavePng(filePath, width, height);
     }
 }

--- a/Sources/ImagePlayground/Helpers.Path.cs
+++ b/Sources/ImagePlayground/Helpers.Path.cs
@@ -1,0 +1,106 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Helper methods for working with file paths.
+/// </summary>
+public static partial class Helpers {
+    /// <summary>
+    /// Resolves the provided path to an absolute file system path.
+    /// Environment variables are expanded and relative paths are
+    /// converted to full paths.
+    /// </summary>
+    /// <param name="path">File system path to resolve.</param>
+    /// <returns>Absolute file path.</returns>
+    /// <exception cref="System.ArgumentException">Thrown when path is null or empty.</exception>
+    public static string ResolvePath(string path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new System.ArgumentException("Path cannot be null or empty", nameof(path));
+        }
+
+        string expanded = System.Environment.ExpandEnvironmentVariables(path);
+        return System.IO.Path.GetFullPath(expanded);
+    }
+
+    /// <summary>
+    /// Reads the contents of a file after verifying that it exists.
+    /// </summary>
+    /// <param name="path">Path to the file.</param>
+    /// <returns>File contents.</returns>
+    /// <exception cref="System.IO.FileNotFoundException">Thrown when the file does not exist.</exception>
+    public static string ReadFileChecked(string path) {
+        string fullPath = ResolvePath(path);
+        if (!System.IO.File.Exists(fullPath)) {
+            throw new System.IO.FileNotFoundException($"File not found: {path}", fullPath);
+        }
+
+        return System.IO.File.ReadAllText(fullPath);
+    }
+
+    /// <summary>
+    /// Asynchronously reads the contents of a file after verifying that it exists.
+    /// </summary>
+    /// <param name="path">Path to the file.</param>
+    /// <returns>File contents.</returns>
+    /// <exception cref="System.IO.FileNotFoundException">Thrown when the file does not exist.</exception>
+    public static async System.Threading.Tasks.Task<string> ReadFileCheckedAsync(string path) {
+        string fullPath = ResolvePath(path);
+        if (!System.IO.File.Exists(fullPath)) {
+            throw new System.IO.FileNotFoundException($"File not found: {path}", fullPath);
+        }
+
+#if NETSTANDARD2_0 || NETFRAMEWORK
+        return await System.Threading.Tasks.Task.Run(() => System.IO.File.ReadAllText(fullPath)).ConfigureAwait(false);
+#else
+        return await System.IO.File.ReadAllTextAsync(fullPath).ConfigureAwait(false);
+#endif
+}
+
+
+    /// <summary>
+    /// Downloads content from a URL with proper encoding detection.
+    /// </summary>
+    /// <param name="client">HttpClient to use for the request.</param>
+    /// <param name="url">URL to download from.</param>
+    /// <returns>Content as a string with proper encoding.</returns>
+    public static async System.Threading.Tasks.Task<string> GetStringWithProperEncodingAsync(System.Net.Http.HttpClient client, string url) {
+        using var response = await client.GetAsync(url).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+        var contentType = response.Content.Headers.ContentType;
+        if (contentType?.CharSet != null) {
+            try {
+                var encoding = System.Text.Encoding.GetEncoding(contentType.CharSet);
+                return encoding.GetString(bytes);
+            } catch {
+            }
+        }
+
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
+            return System.Text.Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+        }
+        if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE) {
+            return System.Text.Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+        }
+        if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF) {
+            return System.Text.Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+        }
+
+        var asciiContent = System.Text.Encoding.ASCII.GetString(bytes);
+        var metaMatch = System.Text.RegularExpressions.Regex.Match(
+            asciiContent,
+            @"<meta[^>]+charset\s*=\s*[\"']?([^\"'>\s]+)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        if (metaMatch.Success) {
+            try {
+                var encoding = System.Text.Encoding.GetEncoding(metaMatch.Groups[1].Value);
+                return encoding.GetString(bytes);
+            } catch {
+            }
+        }
+
+        return System.Text.Encoding.UTF8.GetString(bytes);
+    }
+}

--- a/Sources/ImagePlayground/Helpers.Path.cs
+++ b/Sources/ImagePlayground/Helpers.Path.cs
@@ -90,7 +90,7 @@ public static partial class Helpers {
         var asciiContent = System.Text.Encoding.ASCII.GetString(bytes);
         var metaMatch = System.Text.RegularExpressions.Regex.Match(
             asciiContent,
-            @"<meta[^>]+charset\s*=\s*[\"']?([^\"'>\s]+)",
+            @"<meta[^>]+charset\s*=\s*[""']?([^""'>\s]+)",
             System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
         if (metaMatch.Success) {

--- a/Sources/ImagePlayground/Image.Avatar.cs
+++ b/Sources/ImagePlayground/Image.Avatar.cs
@@ -12,7 +12,7 @@ namespace ImagePlayground {
         }
 
         public void SaveAsAvatar(string filePath, int width, int height, float cornerRadius) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
             using var clone = _image.Clone(x => ConvertToAvatar(x, new Size(width, height), cornerRadius));
             clone.Save(fullPath);
         }

--- a/Sources/ImagePlayground/Image.Icon.cs
+++ b/Sources/ImagePlayground/Image.Icon.cs
@@ -9,7 +9,7 @@ using SixLabors.ImageSharp.Processing;
 namespace ImagePlayground {
     public partial class Image {
         public void SaveAsIcon(string filePath, params int[] sizes) {
-            string fullPath = Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
             if (sizes == null || sizes.Length == 0) {
                 sizes = new[] { 16, 32, 48, 64, 128, 256 };
             }

--- a/Sources/ImagePlayground/Image.Image.cs
+++ b/Sources/ImagePlayground/Image.Image.cs
@@ -6,7 +6,7 @@ using SixLabors.ImageSharp.Processing;
 namespace ImagePlayground {
     public partial class Image : IDisposable {
         public void AddImage(string filePath, int x, int y, float opacity) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             var location = new Point(x, y);
             using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {

--- a/Sources/ImagePlayground/Image.Watermark.cs
+++ b/Sources/ImagePlayground/Image.Watermark.cs
@@ -48,7 +48,7 @@ namespace ImagePlayground {
         }
 
         public void WatermarkImage(string filePath, WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             var location = new Point(0, 0);
             using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {
@@ -87,7 +87,7 @@ namespace ImagePlayground {
         }
 
         public void WatermarkImage(string filePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             var location = new Point(x, y);
             using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {

--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -78,7 +78,7 @@ namespace ImagePlayground {
         }
 
         public ICompareResult Compare(string filePathToCompare) {
-            string fullPath = System.IO.Path.GetFullPath(filePathToCompare);
+            string fullPath = Helpers.ResolvePath(filePathToCompare);
 
             using (var imageToCompare = GetImage(fullPath)) {
                 bool isEqual = ImageSharpCompare.ImagesAreEqual(_image, imageToCompare);
@@ -88,7 +88,7 @@ namespace ImagePlayground {
         }
 
         public void Compare(Image imageToCompare, string filePathToSave) {
-            string outFullPath = System.IO.Path.GetFullPath(filePathToSave);
+            string outFullPath = Helpers.ResolvePath(filePathToSave);
             using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
                 using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(_image, imageToCompare._image)) {
                     SixLabors.ImageSharp.ImageExtensions.SaveAsPng(maskImage, fileStreamDifferenceMask);
@@ -97,8 +97,8 @@ namespace ImagePlayground {
         }
 
         public void Compare(string filePathToCompare, string filePathToSave) {
-            string fullPath = System.IO.Path.GetFullPath(filePathToCompare);
-            string outFullPath = System.IO.Path.GetFullPath(filePathToSave);
+            string fullPath = Helpers.ResolvePath(filePathToCompare);
+            string outFullPath = Helpers.ResolvePath(filePathToSave);
 
             using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
                 using (var imageToCompare = GetImage(fullPath)) {
@@ -273,7 +273,7 @@ namespace ImagePlayground {
         }
 
         public static SixLabors.ImageSharp.Image GetImage(string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
             using (var inStream = System.IO.File.OpenRead(fullPath)) {
                 return SixLabors.ImageSharp.Image.Load(inStream);
             }
@@ -285,7 +285,7 @@ namespace ImagePlayground {
         }
 
         public static Image Load(string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             Image image = new Image {
                 _filePath = fullPath,
@@ -299,7 +299,7 @@ namespace ImagePlayground {
             if (filePath == "") {
                 filePath = _filePath;
             } else {
-                filePath = System.IO.Path.GetFullPath(filePath);
+                filePath = Helpers.ResolvePath(filePath);
             }
             var encoder = Helpers.GetEncoder(System.IO.Path.GetExtension(filePath), quality, compressionLevel);
             _image.Save(filePath, encoder);

--- a/Sources/ImagePlayground/ImageHelper.AddText.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddText.cs
@@ -4,8 +4,8 @@ using SixLabors.ImageSharp;
 namespace ImagePlayground {
     public partial class ImageHelper {
         public static void AddText(string filePath, string outFilePath, float x, float y, string text, Color color, float fontSize = 16f, string fontFamilyName = "Arial") {
-            string fullPath = Path.GetFullPath(filePath);
-            string outFullPath = Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using var img = Image.Load(fullPath);
             img.AddText(x, y, text, color, fontSize, fontFamilyName);

--- a/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
@@ -5,16 +5,16 @@ using SixLabors.ImageSharp.Processing;
 namespace ImagePlayground {
     public partial class ImageHelper {
         public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, Image.WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
-            string fullPath = Path.GetFullPath(filePath);
-            string outFullPath = Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
             using var img = Image.Load(fullPath);
             img.WatermarkImage(watermarkFilePath, placement, opacity, padding, rotate, flipMode, watermarkPercentage);
             img.Save(outFullPath);
         }
 
         public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
-            string fullPath = Path.GetFullPath(filePath);
-            string outFullPath = Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
             using var img = Image.Load(fullPath);
             img.WatermarkImage(watermarkFilePath, x, y, opacity, rotate, flipMode, watermarkPercentage);
             img.Save(outFullPath);

--- a/Sources/ImagePlayground/ImageHelper.Avatar.cs
+++ b/Sources/ImagePlayground/ImageHelper.Avatar.cs
@@ -4,30 +4,30 @@ using SixLabors.ImageSharp;
 namespace ImagePlayground {
     public partial class ImageHelper {
         public static void Avatar(string filePath, string outFilePath, int width, int height, float cornerRadius) {
-            string fullPath = Path.GetFullPath(filePath);
-            string outFullPath = Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using var img = Image.Load(fullPath);
             img.SaveAsAvatar(outFullPath, width, height, cornerRadius);
         }
 
         public static void Avatar(string filePath, Stream outStream, int width, int height, float cornerRadius) {
-            string fullPath = Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             using var img = Image.Load(fullPath);
             img.SaveAsAvatar(outStream, width, height, cornerRadius);
         }
 
         public static void AvatarCircular(string filePath, string outFilePath, int size) {
-            string fullPath = Path.GetFullPath(filePath);
-            string outFullPath = Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using var img = Image.Load(fullPath);
             img.SaveAsCircularAvatar(outFullPath, size);
         }
 
         public static void AvatarCircular(string filePath, Stream outStream, int size) {
-            string fullPath = Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             using var img = Image.Load(fullPath);
             img.SaveAsCircularAvatar(outStream, size);

--- a/Sources/ImagePlayground/ImageHelper.Compare.cs
+++ b/Sources/ImagePlayground/ImageHelper.Compare.cs
@@ -5,8 +5,8 @@ namespace ImagePlayground {
     public partial class ImageHelper {
 
         public static ICompareResult Compare(string filePath, string filePathToCompare) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string fullPathToCompare = System.IO.Path.GetFullPath(filePathToCompare);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);
 
             bool isEqual = ImageSharpCompare.ImagesAreEqual(fullPath, fullPathToCompare);
             ICompareResult calcDiff = ImageSharpCompare.CalcDiff(fullPath, fullPathToCompare);
@@ -14,9 +14,9 @@ namespace ImagePlayground {
         }
 
         public static void Compare(string filePath, string filePathToCompare, string filePathToSave) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string fullPathToCompare = System.IO.Path.GetFullPath(filePathToCompare);
-            string outFullPath = System.IO.Path.GetFullPath(filePathToSave);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);
+            string outFullPath = Helpers.ResolvePath(filePathToSave);
 
             using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
                 using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(fullPath, fullPathToCompare)) {

--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -19,8 +19,8 @@ namespace ImagePlayground {
         /// <param name="outFilePath"></param>
         /// <exception cref="UnknownImageFormatException"></exception>
         public static void ConvertTo(string filePath, string outFilePath, int? quality = null, int? compressionLevel = null) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string outFullPath = System.IO.Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
             using (var inStream = System.IO.File.OpenRead(fullPath))
             using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
                 FileInfo fileInfo = new FileInfo(outFilePath);
@@ -44,8 +44,8 @@ namespace ImagePlayground {
         /// <param name="keepAspectRatio"></param>
         /// <param name="sampler"></param>
         public static void Resize(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Image.Sampler? sampler = null) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string outFullPath = System.IO.Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using (var inStream = System.IO.File.OpenRead(fullPath))
             using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
@@ -91,8 +91,8 @@ namespace ImagePlayground {
         /// <param name="outFilePath"></param>
         /// <param name="percentage"></param>
         public static void Resize(string filePath, string outFilePath, int percentage) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string outFullPath = System.IO.Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using (var inStream = System.IO.File.OpenRead(fullPath))
             using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
@@ -104,9 +104,9 @@ namespace ImagePlayground {
         }
 
         public static void Combine(string filePath, string filePath2, string outFilePath, bool resizeToFit = false, ImagePlacement imagePlacement = ImagePlacement.Bottom) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
-            string fullPath2 = System.IO.Path.GetFullPath(filePath2);
-            string outFullPath = System.IO.Path.GetFullPath(outFilePath);
+            string fullPath = Helpers.ResolvePath(filePath);
+            string fullPath2 = Helpers.ResolvePath(filePath2);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using (var inStream = System.IO.File.OpenRead(fullPath))
             using (var inStream2 = System.IO.File.OpenRead(fullPath2))
@@ -181,7 +181,7 @@ namespace ImagePlayground {
         }
 
         public static void Create(string filePath, int width, int height, Color color, bool open = false) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             using (Image<Rgba32> outputImage = new Image<Rgba32>(width, height)) {
                 //outputImage.Mutate(x => x.Fill(color));

--- a/Sources/ImagePlayground/ImagePlayground.csproj
+++ b/Sources/ImagePlayground/ImagePlayground.csproj
@@ -43,4 +43,7 @@
         <Using Include="System.Net" />
         <Using Include="System.Net.Http" />
     </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+        <Reference Include="System.Net.Http" />
+    </ItemGroup>
 </Project>

--- a/Sources/ImagePlayground/QRCode.cs
+++ b/Sources/ImagePlayground/QRCode.cs
@@ -8,7 +8,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace ImagePlayground {
     public class QrCode {
         public static void Generate(string content, string filePath, bool transparent = false, QRCodeGenerator.ECCLevel eccLevel = QRCodeGenerator.ECCLevel.Q) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             FileInfo fileInfo = new FileInfo(fullPath);
 
@@ -86,7 +86,7 @@ namespace ImagePlayground {
         }
 
         public static BarcodeResult<Rgba32> Read(string filePath) {
-            string fullPath = System.IO.Path.GetFullPath(filePath);
+            string fullPath = Helpers.ResolvePath(filePath);
 
             Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
             BarcodeReader<Rgba32> reader = new BarcodeReader<Rgba32>(types: ZXing.BarcodeFormat.QR_CODE);


### PR DESCRIPTION
## Summary
- add `Helpers.Path` with path resolution utilities
- use path resolution in ImagePlayground library
- integrate new helpers in PowerShell cmdlets and add required using directives

## Testing
- `pwsh -NoLogo -NoProfile -File ./ImagePlayground.Tests.ps1` *(fails: Unable to find type [ImagePlayground.Image])*

------
https://chatgpt.com/codex/tasks/task_e_68518daab460832e8923b92312f0c2a1