### PR TITLE
Ensure avatar stream resets

### DIFF
--- a/Sources/ImagePlayground.Tests/AvatarStream.cs
+++ b/Sources/ImagePlayground.Tests/AvatarStream.cs
@@ -1,0 +1,16 @@
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_SaveAsAvatar_StreamReset() {
+            string filePath = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            using var img = Image.Load(filePath);
+            using var ms = new MemoryStream();
+            img.SaveAsAvatar(ms, 64, 64, 10f);
+            Assert.Equal(0, ms.Position);
+            Assert.True(ms.Length > 0);
+        }
+    }
+}

--- a/Sources/ImagePlayground/Image.Avatar.cs
+++ b/Sources/ImagePlayground/Image.Avatar.cs
@@ -20,6 +20,7 @@ namespace ImagePlayground {
         public void SaveAsAvatar(Stream stream, int width, int height, float cornerRadius) {
             using var clone = _image.Clone(x => ConvertToAvatar(x, new Size(width, height), cornerRadius));
             clone.SaveAsPng(stream);
+            stream.Seek(0, SeekOrigin.Begin);
         }
 
         public void SaveAsCircularAvatar(string filePath, int size) {


### PR DESCRIPTION
## Summary
- reset the stream position after saving avatar images
- add a unit test checking the stream starts at position 0

## Testing
- `dotnet test Sources/ImagePlayground.sln --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6851a9f34764832e8fe139611eb93f55