### PR TITLE
Add invalid percentage tests

### DIFF
--- a/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
+++ b/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
@@ -61,6 +61,24 @@ namespace ImagePlayground.Tests {
             Assert.Equal(330, img.Height);
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-10)]
+        public void Test_Resize_Percentage_Invalid(int percentage) {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            using var img = Image.Load(src);
+            Assert.Throws<ArgumentOutOfRangeException>(() => img.Resize(percentage));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-20)]
+        public void Test_ImageHelper_Resize_Percentage_Invalid(int percentage) {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string dest = Path.Combine(_directoryWithTests, $"percent_invalid_{percentage}.png");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ImageHelper.Resize(src, dest, percentage));
+        }
+
         [Fact]
         public void Test_Combine_LeftResize() {
             string file1 = Path.Combine(_directoryWithImages, "LogoEvotec.png");

--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -239,6 +239,10 @@ namespace ImagePlayground {
         }
 
         public void Resize(int percentage) {
+            if (percentage <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(percentage));
+            }
+
             int width = _image.Width * percentage / 100;
             int height = _image.Height * percentage / 100;
             var options = new ResizeOptions {

--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -91,6 +91,10 @@ namespace ImagePlayground {
         /// <param name="outFilePath"></param>
         /// <param name="percentage"></param>
         public static void Resize(string filePath, string outFilePath, int percentage) {
+            if (percentage <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(percentage));
+            }
+
             string fullPath = Helpers.ResolvePath(filePath);
             string outFullPath = Helpers.ResolvePath(outFilePath);
 

--- a/Tests/Resize-Image.Tests.ps1
+++ b/Tests/Resize-Image.Tests.ps1
@@ -55,6 +55,13 @@ Describe 'Resize-Image' {
         $original.Dispose()
 
     }
+    It 'throws for invalid percentage' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dest = Join-Path $TestDir 'logo-invalid.png'
+        { Resize-Image -FilePath $src -OutputPath $dest -Percentage 0 } | Should -Throw
+        { Resize-Image -FilePath $src -OutputPath $dest -Percentage -5 } | Should -Throw
+    }
+
 
 }
 


### PR DESCRIPTION
## Summary
- validate inputs to `Resize` methods
- add xUnit and Pester tests for invalid percentage

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release`
- `pwsh ./ImagePlayground.Tests.ps1` *(fails: CommandNotFoundException, missing cmdlets)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9de5b4c832e8060606ad65ce39b