### PR TITLE
Expand chart validation tests

### DIFF
--- a/Sources/ImagePlayground.Tests/Charts.cs
+++ b/Sources/ImagePlayground.Tests/Charts.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Xunit;
@@ -30,6 +31,26 @@ namespace ImagePlayground.Tests {
             Assert.True(File.Exists(file));
             var read = QrCode.Read(file);
             Assert.Contains("BEGIN", read.Message);
+        }
+
+        [Fact]
+        public void Test_GenerateMixedChartsThrows() {
+            var defs = new List<Charts.ChartDefinition> {
+                new Charts.ChartBar("A", new List<double> { 1 }),
+                new Charts.ChartLine("B", new List<double> { 2 })
+            };
+
+            Assert.Throws<ArgumentException>(() => Charts.Generate(defs, Path.Combine(_directoryWithTests, "mixed.png")));
+        }
+
+        [Fact]
+        public void Test_GenerateNullDefinitionsThrows() {
+            Assert.Throws<ArgumentNullException>(() => Charts.Generate(null!, Path.Combine(_directoryWithTests, "null.png")));
+        }
+
+        [Fact]
+        public void Test_GenerateEmptyDefinitionsThrows() {
+            Assert.Throws<ArgumentException>(() => Charts.Generate(new List<Charts.ChartDefinition>(), Path.Combine(_directoryWithTests, "empty.png")));
         }
     }
 }

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -108,6 +108,8 @@ public static class Charts {
 
         var plot = new Plot();
         var type = list[0].Type;
+        if (list.Any(d => d.Type != type))
+            throw new ArgumentException("Mixed chart definition types provided. All chart definitions must have the same ChartDefinitionType.", nameof(definitions));
 
         switch (type) {
             case ChartDefinitionType.Bar:


### PR DESCRIPTION
## Summary
- add tests for null and empty chart definitions
- ensure chart generation throws when definitions are missing

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -c Release -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_6851a9c0b93c832e86da5ae5cc3ef1f4