### PR TITLE
Add text shadow and outline options

### DIFF
--- a/Docs/Add-ImageText.md
+++ b/Docs/Add-ImageText.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Add-ImageText [-FilePath] <String> [-OutputPath] <String> [-Text] <String> [-X] <Single> [-Y] <Single> [-Color <Color>] [-FontSize <Single>] [-FontFamily <String>] [<CommonParameters>]
+Add-ImageText [-FilePath] <String> [-OutputPath] <String> [-Text] <String> [-X] <Single> [-Y] <Single> [-Color <Color>] [-FontSize <Single>] [-FontFamily <String>] [-ShadowColor <Color>] [-ShadowOffsetX <Single>] [-ShadowOffsetY <Single>] [-OutlineColor <Color>] [-OutlineWidth <Single>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -146,6 +146,81 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShadowColor
+{{ Fill ShadowColor Description }}
+
+```yaml
+Type: Color
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShadowOffsetX
+{{ Fill ShadowOffsetX Description }}
+
+```yaml
+Type: Single
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShadowOffsetY
+{{ Fill ShadowOffsetY Description }}
+
+```yaml
+Type: Single
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutlineColor
+{{ Fill OutlineColor Description }}
+
+```yaml
+Type: Color
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutlineWidth
+{{ Fill OutlineWidth Description }}
+
+```yaml
+Type: Single
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
@@ -43,6 +43,26 @@ public sealed class AddImageTextCmdlet : PSCmdlet {
     [Parameter]
     public string FontFamily { get; set; } = "Arial";
 
+    /// <summary>Color of shadow.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color? ShadowColor { get; set; }
+
+    /// <summary>X offset for shadow.</summary>
+    [Parameter]
+    public float ShadowOffsetX { get; set; } = 0f;
+
+    /// <summary>Y offset for shadow.</summary>
+    [Parameter]
+    public float ShadowOffsetY { get; set; } = 0f;
+
+    /// <summary>Outline color.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color? OutlineColor { get; set; }
+
+    /// <summary>Outline width.</summary>
+    [Parameter]
+    public float OutlineWidth { get; set; } = 0f;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var filePath = Helpers.ResolvePath(FilePath);
@@ -52,6 +72,19 @@ public sealed class AddImageTextCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(OutputPath);
-        ImagePlayground.ImageHelper.AddText(filePath, output, X, Y, Text, Color, FontSize, FontFamily);
+        ImagePlayground.ImageHelper.AddText(
+            filePath,
+            output,
+            X,
+            Y,
+            Text,
+            Color,
+            FontSize,
+            FontFamily,
+            ShadowColor,
+            ShadowOffsetX,
+            ShadowOffsetY,
+            OutlineColor,
+            OutlineWidth);
     }
 }

--- a/Sources/ImagePlayground.Tests/ImageHelperTextAndCompare.cs
+++ b/Sources/ImagePlayground.Tests/ImageHelperTextAndCompare.cs
@@ -27,6 +27,31 @@ namespace ImagePlayground.Tests {
         }
 
         [Fact]
+        public void Test_AddTextWithShadowAndOutline() {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string dest = Path.Combine(_directoryWithTests, "text_shadow_outline.png");
+            if (File.Exists(dest)) File.Delete(dest);
+            ImageHelper.AddText(
+                src,
+                dest,
+                1,
+                1,
+                "Test",
+                SixLabors.ImageSharp.Color.Red,
+                16f,
+                "Arial",
+                SixLabors.ImageSharp.Color.Black,
+                1,
+                1,
+                SixLabors.ImageSharp.Color.Yellow,
+                1);
+            Assert.True(File.Exists(dest));
+            using var img = Image.Load(dest);
+            Assert.Equal(660, img.Width);
+            Assert.Equal(660, img.Height);
+        }
+
+        [Fact]
         public void Test_CreateGridImage() {
             string dest = Path.Combine(_directoryWithTests, "grid.png");
             if (File.Exists(dest)) File.Delete(dest);

--- a/Sources/ImagePlayground/Image.Text.cs
+++ b/Sources/ImagePlayground/Image.Text.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using SixLabors.Fonts;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Processing;
 
@@ -19,7 +20,7 @@ namespace ImagePlayground {
             return textSize;
         }
 
-        public void AddText(float x, float y, string text, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial") {
+        public void AddText(float x, float y, string text, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.ImageSharp.Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, SixLabors.ImageSharp.Color? outlineColor = null, float outlineWidth = 0f) {
             if (!SixLabors.Fonts.SystemFonts.TryGet(fontFamilyName, out var fontFamily)) {
                 if (!SixLabors.Fonts.SystemFonts.TryGet("DejaVu Sans", out fontFamily)) {
                     fontFamily = SixLabors.Fonts.SystemFonts.Collection.Families.First();
@@ -27,7 +28,16 @@ namespace ImagePlayground {
             }
             var font = fontFamily.CreateFont(fontSize, FontStyle.Regular);
             var pointF = new PointF(x, y);
-            _image.Mutate(mx => mx.DrawText(text, font, color, pointF));
+            _image.Mutate(mx => {
+                if (shadowColor != null) {
+                    var shadowPoint = new PointF(x + shadowOffsetX, y + shadowOffsetY);
+                    mx.DrawText(text, font, shadowColor.Value, shadowPoint);
+                }
+                if (outlineColor != null && outlineWidth > 0f) {
+                    mx.DrawText(text, font, Brushes.Solid(outlineColor.Value), Pens.Solid(outlineColor.Value, outlineWidth), pointF);
+                }
+                mx.DrawText(text, font, color, pointF);
+            });
         }
     }
 }

--- a/Sources/ImagePlayground/ImageHelper.AddText.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddText.cs
@@ -3,12 +3,12 @@ using SixLabors.ImageSharp;
 
 namespace ImagePlayground {
     public partial class ImageHelper {
-        public static void AddText(string filePath, string outFilePath, float x, float y, string text, Color color, float fontSize = 16f, string fontFamilyName = "Arial") {
+        public static void AddText(string filePath, string outFilePath, float x, float y, string text, Color color, float fontSize = 16f, string fontFamilyName = "Arial", Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) {
             string fullPath = Helpers.ResolvePath(filePath);
             string outFullPath = Helpers.ResolvePath(outFilePath);
 
             using var img = Image.Load(fullPath);
-            img.AddText(x, y, text, color, fontSize, fontFamilyName);
+            img.AddText(x, y, text, color, fontSize, fontFamilyName, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
             img.Save(outFullPath);
         }
     }

--- a/Tests/Add-ImageText.Tests.ps1
+++ b/Tests/Add-ImageText.Tests.ps1
@@ -26,5 +26,18 @@ Describe 'Add-ImageText' {
 
     }
 
+    It 'adds text with shadow and outline' {
+
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'text_shadow_outline.png'
+
+        if (Test-Path $dest) { Remove-Item $dest }
+
+        Add-ImageText -FilePath $src -OutputPath $dest -Text 'Test' -X 1 -Y 1 -Color ([SixLabors.ImageSharp.Color]::Red) -ShadowColor ([SixLabors.ImageSharp.Color]::Black) -ShadowOffsetX 1 -ShadowOffsetY 1 -OutlineColor ([SixLabors.ImageSharp.Color]::Yellow) -OutlineWidth 1
+
+        Test-Path $dest | Should -BeTrue
+
+    }
+
 }
 


### PR DESCRIPTION
## Summary
- add support for shadow and outline drawing in `Image.AddText`
- expose new options in `Add-ImageText` cmdlet
- document additional parameters for `Add-ImageText`
- **add tests for the new shadow/outline options**

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6851a8840c48832e971a210723fa7187