### PR TITLE
Add ShowGrid option in chart generation

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -31,6 +31,10 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Show grid lines on the chart.</summary>
+    [Parameter]
+    public SwitchParameter ShowGrid { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var list = new List<Charts.ChartDefinition>();
@@ -52,7 +56,7 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.Charts.Generate(list, output, Width, Height);
+        ImagePlayground.Charts.Generate(list, output, Width, Height, null, ShowGrid.IsPresent);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.Tests/Charts.cs
+++ b/Sources/ImagePlayground.Tests/Charts.cs
@@ -21,6 +21,21 @@ namespace ImagePlayground.Tests {
         }
 
         [Fact]
+        public void Test_GenerateBarChart_ShowGrid() {
+            string file = Path.Combine(_directoryWithTests, "chart_bar_grid.png");
+            if (File.Exists(file)) File.Delete(file);
+
+            var defs = new List<global::ImagePlayground.Charts.ChartDefinition> {
+                new global::ImagePlayground.Charts.ChartBar("A", new List<double> { 1, 2 }),
+                new global::ImagePlayground.Charts.ChartBar("B", new List<double> { 3, 4 })
+            };
+
+            global::ImagePlayground.Charts.Generate(defs, file, 300, 200, null, true);
+
+            Assert.True(File.Exists(file));
+        }
+
+        [Fact]
         public void Test_GenerateContactQr() {
             string file = Path.Combine(_directoryWithTests, "contact.png");
             if (File.Exists(file)) File.Delete(file);

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -101,7 +101,7 @@ public static class Charts {
     }
 
     /// <summary>Generate a chart based on provided definitions.</summary>
-    public static void Generate(IEnumerable<ChartDefinition> definitions, string filePath, int width = 600, int height = 400, ChartBarOptions? barOptions = null) {
+    public static void Generate(IEnumerable<ChartDefinition> definitions, string filePath, int width = 600, int height = 400, ChartBarOptions? barOptions = null, bool showGrid = false) {
         if (definitions is null) throw new ArgumentNullException(nameof(definitions));
         var list = definitions.ToList();
         if (list.Count == 0) throw new ArgumentException("No chart definitions provided", nameof(definitions));
@@ -188,6 +188,7 @@ public static class Charts {
         }
 
         filePath = Helpers.ResolvePath(filePath);
+        plot.ShowGrid(showGrid);
         plot.SavePng(filePath, width, height);
     }
 }

--- a/Sources/ImagePlayground/PlotExtensions.cs
+++ b/Sources/ImagePlayground/PlotExtensions.cs
@@ -1,0 +1,17 @@
+using ScottPlot;
+
+namespace ImagePlayground;
+
+/// <summary>Extension methods for ScottPlot.Plot.</summary>
+internal static class PlotExtensions {
+    /// <summary>Show or hide grid lines.</summary>
+    /// <param name="plot">Plot instance.</param>
+    /// <param name="show">Whether to show grid.</param>
+    public static void ShowGrid(this Plot plot, bool show) {
+        if (show) {
+            plot.ShowGrid();
+        } else {
+            plot.HideGrid();
+        }
+    }
+}

--- a/Tests/New-ImageChart.Tests.ps1
+++ b/Tests/New-ImageChart.Tests.ps1
@@ -16,4 +16,16 @@ Describe 'New-ImageChart' {
 
         Test-Path $file | Should -BeTrue
     }
+
+    It 'creates a bar chart with grid' -Skip:(-not $IsWindows) {
+        $file = Join-Path $TestDir 'chart_grid.png'
+        if (Test-Path $file) { Remove-Item $file }
+
+        New-ImageChart -ChartsDefinition {
+            New-ImageChartBar -Name 'Jan' -Value @(1,2)
+            New-ImageChartBar -Name 'Feb' -Value @(3,4)
+        } -FilePath $file -Width 200 -Height 150 -ShowGrid
+
+        Test-Path $file | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- allow specifying grid visibility when generating charts
- add `-ShowGrid` switch to `New-ImageChart` cmdlet
- support enabling or disabling grid lines with a new plot extension
- cover grid option with C# and PowerShell tests

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release`
- `dotnet build Sources/ImagePlayground.sln -c Debug`
- `dotnet test Sources/ImagePlayground.sln -f net8.0`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Output Detailed"`


------
https://chatgpt.com/codex/tasks/task_e_6851a86a6dac832e862d6cd8014daee5