### PR TITLE
Fix random usage in ImageHelper

### DIFF
--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -201,11 +201,10 @@ namespace ImagePlayground {
                     ic.Fill(color);
 
                     var rotation = GeometryUtilities.DegreeToRadian(45);
-
+                    var rand = new Random();
 
                     for (var row = 1; row < rowCount; row++) {
                         for (var col = 1; col < columnCount; col++) {
-                            var rand = new Random();
                             var r = (byte)rand.Next(0, 255);
                             var g = (byte)rand.Next(0, 255);
                             var b = (byte)rand.Next(0, 255);


### PR DESCRIPTION
## Summary
- reuse a single Random object for drawing colored squares

## Testing
- `pwsh -NoLogo -NoProfile -File ImagePlayground.Tests.ps1` *(fails: network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6851cc0edf38832eb067b03b50cd544a