### PR TITLE
Fix Compare overloads to drop unused isEqual

### DIFF
--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -72,18 +72,14 @@ namespace ImagePlayground {
         }
 
         public ICompareResult Compare(Image imageToCompare) {
-            bool isEqual = ImageSharpCompare.ImagesAreEqual(_image, imageToCompare._image);
-            ICompareResult calcDiff = ImageSharpCompare.CalcDiff(_image, imageToCompare._image);
-            return calcDiff;
+            return ImageSharpCompare.CalcDiff(_image, imageToCompare._image);
         }
 
         public ICompareResult Compare(string filePathToCompare) {
             string fullPath = Helpers.ResolvePath(filePathToCompare);
 
             using (var imageToCompare = GetImage(fullPath)) {
-                bool isEqual = ImageSharpCompare.ImagesAreEqual(_image, imageToCompare);
-                ICompareResult calcDiff = ImageSharpCompare.CalcDiff(_image, imageToCompare);
-                return calcDiff;
+                return ImageSharpCompare.CalcDiff(_image, imageToCompare);
             }
         }
 

--- a/Sources/ImagePlayground/ImageHelper.Compare.cs
+++ b/Sources/ImagePlayground/ImageHelper.Compare.cs
@@ -8,9 +8,7 @@ namespace ImagePlayground {
             string fullPath = Helpers.ResolvePath(filePath);
             string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);
 
-            bool isEqual = ImageSharpCompare.ImagesAreEqual(fullPath, fullPathToCompare);
-            ICompareResult calcDiff = ImageSharpCompare.CalcDiff(fullPath, fullPathToCompare);
-            return calcDiff;
+            return ImageSharpCompare.CalcDiff(fullPath, fullPathToCompare);
         }
 
         public static void Compare(string filePath, string filePathToCompare, string filePathToSave) {


### PR DESCRIPTION
## Summary
- remove unused `isEqual` variable from comparison helpers
- minor cleanup of Compare overloads

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -v minimal` *(fails: Could not find 'mono' host)*


------
https://chatgpt.com/codex/tasks/task_e_6851cbfdba34832ea52edfdfa9e9f3df