### PR TITLE
Add ShowGrid option for chart generation

### DIFF
--- a/Docs/New-ImageChart.md
+++ b/Docs/New-ImageChart.md
@@ -121,7 +121,7 @@ Accept wildcard characters: False
 ```
 
 ### -ShowGrid
-{{ Fill ShowGrid Description }}
+If specified, grid lines are shown on the chart image.
 
 ```yaml
 Type: SwitchParameter

--- a/Docs/New-ImageChart.md
+++ b/Docs/New-ImageChart.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-New-ImageChart [[-ChartsDefinition] <ScriptBlock>] [[-Width] <Int32>] [[-Height] <Int32>] [[-XTitle] <String>] [[-YTitle] <String>] [[-FilePath] <String>] [-Show] [<CommonParameters>]
+New-ImageChart [[-ChartsDefinition] <ScriptBlock>] [[-Width] <Int32>] [[-Height] <Int32>] [[-XTitle] <String>] [[-YTitle] <String>] [[-FilePath] <String>] [-Show] [-ShowGrid] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -107,6 +107,21 @@ Accept wildcard characters: False
 
 ### -Show
 {{ Fill Show Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShowGrid
+{{ Fill ShowGrid Description }}
 
 ```yaml
 Type: SwitchParameter

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -39,6 +39,10 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Display grid lines.</summary>
+    [Parameter]
+    public SwitchParameter ShowGrid { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var list = new List<Charts.ChartDefinition>();
@@ -60,7 +64,7 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.Charts.Generate(list, output, Width, Height, null, XTitle, YTitle);
+        ImagePlayground.Charts.Generate(list, output, Width, Height, null, XTitle, YTitle, ShowGrid.IsPresent);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.Tests/Charts.cs
+++ b/Sources/ImagePlayground.Tests/Charts.cs
@@ -37,6 +37,21 @@ namespace ImagePlayground.Tests {
         }
 
         [Fact]
+        public void Test_GenerateBarChart_ShowGrid() {
+            string file = Path.Combine(_directoryWithTests, "chart_bar_grid.png");
+            if (File.Exists(file)) File.Delete(file);
+
+            var defs = new List<global::ImagePlayground.Charts.ChartDefinition> {
+                new global::ImagePlayground.Charts.ChartBar("A", new List<double> { 1, 2 }),
+                new global::ImagePlayground.Charts.ChartBar("B", new List<double> { 3, 4 })
+            };
+
+            global::ImagePlayground.Charts.Generate(defs, file, 300, 200, null, null, null, true);
+
+            Assert.True(File.Exists(file));
+        }
+
+        [Fact]
         public void Test_GenerateContactQr() {
             string file = Path.Combine(_directoryWithTests, "contact.png");
             if (File.Exists(file)) File.Delete(file);

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -205,7 +205,11 @@ public static class Charts {
             plot.Axes.Left.Label.Text = yTitle;
         }
 
-        plot.ShowGrid(showGrid);
+        if (showGrid) {
+            plot.ShowGrid();
+        } else {
+            plot.HideGrid();
+        }
 
         filePath = Helpers.ResolvePath(filePath);
         plot.SavePng(filePath, width, height);

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -108,7 +108,8 @@ public static class Charts {
         int height = 400,
         ChartBarOptions? barOptions = null,
         string? xTitle = null,
-        string? yTitle = null) {
+        string? yTitle = null,
+        bool showGrid = false) {
         if (definitions is null) throw new ArgumentNullException(nameof(definitions));
         var list = definitions.ToList();
         if (list.Count == 0) throw new ArgumentException("No chart definitions provided", nameof(definitions));
@@ -203,6 +204,8 @@ public static class Charts {
         if (!string.IsNullOrEmpty(yTitle)) {
             plot.Axes.Left.Label.Text = yTitle;
         }
+
+        plot.ShowGrid(showGrid);
 
         filePath = Helpers.ResolvePath(filePath);
         plot.SavePng(filePath, width, height);

--- a/Tests/New-ImageChart.Tests.ps1
+++ b/Tests/New-ImageChart.Tests.ps1
@@ -28,4 +28,16 @@ Describe 'New-ImageChart' {
 
         Test-Path $file | Should -BeTrue
     }
+
+    It 'creates a bar chart with grid lines' -Skip:(-not $IsWindows) {
+        $file = Join-Path $TestDir 'chart_grid.png'
+        if (Test-Path $file) { Remove-Item $file }
+
+        New-ImageChart -ChartsDefinition {
+            New-ImageChartBar -Name 'Jan' -Value @(1,2)
+            New-ImageChartBar -Name 'Feb' -Value @(3,4)
+        } -FilePath $file -Width 200 -Height 150 -ShowGrid
+
+        Test-Path $file | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- allow toggling grid lines when generating charts
- plumb `-ShowGrid` switch through New-ImageChart
- update docs and tests

## Testing
- `dotnet test Sources/ImagePlayground.sln --no-build` *(fails: no output)*
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1` *(fails: 26 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851d2c079f0832e8297ea9bcade29ad