### PR TITLE
Add scatter charts without binary screenshot

### DIFF
--- a/Docs/New-ImageChartScatter.md
+++ b/Docs/New-ImageChartScatter.md
@@ -1,0 +1,90 @@
+---
+external help file: ImagePlayground-help.xml
+Module Name: ImagePlayground
+online version:
+schema: 2.0.0
+---
+
+# New-ImageChartScatter
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+New-ImageChartScatter [[-Name] <String>] [[-X] <Array>] [[-Y] <Array>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Name
+{{ Fill Name Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Label
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -X
+{{ Fill X Description }}
+
+```yaml
+Type: Array
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Y
+{{ Fill Y Description }}
+
+```yaml
+Type: Array
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -53,6 +53,9 @@ Gets EXIF data from image
 ### [New-ImageChartRadial](New-ImageChartRadial.md)
 {{ Fill in the Synopsis }}
 
+### [New-ImageChartScatter](New-ImageChartScatter.md)
+{{ Fill in the Synopsis }}
+
 ### [New-ImageQRCode](New-ImageQRCode.md)
 {{ Fill in the Synopsis }}
 

--- a/Examples/Charts.Scatter.ps1
+++ b/Examples/Charts.Scatter.ps1
@@ -1,0 +1,6 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+New-ImageChart {
+    New-ImageChartScatter -Name "First" -X 1,2,3 -Y 4,5,6
+    New-ImageChartScatter -Name "Second" -X 1,2,3 -Y 3,2,1
+} -Show -FilePath $PSScriptRoot\Output\ChartsScatter.png -Width 500 -Height 500

--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -16,6 +16,7 @@
         'New-ImageChartBar',
         'New-ImageChartBarOptions',
         'New-ImageChartLine',
+        'New-ImageChartScatter',
         'New-ImageChartPie',
         'New-ImageChartRadial',
         'New-ImageGrid',

--- a/README.MD
+++ b/README.MD
@@ -129,6 +129,15 @@ New-ImageChart {
 
 ![ChartsLine.png](https://github.com/EvotecIT/ImagePlayground/blob/feb33319f00df1933f53a4df89d65aa498278e41/Examples/Samples/ChartsLine.png)
 
+#### Scatter charts
+
+```powershell
+New-ImageChart {
+    New-ImageChartScatter -Name "First" -X 1,2,3 -Y 4,5,6
+    New-ImageChartScatter -Name "Second" -X 1,2,3 -Y 3,2,1
+} -Show -FilePath $PSScriptRoot\Output\ChartsScatter.png -Width 500 -Height 500
+```
+
 #### Radar charts
 
 ```powershell

--- a/Sources/ImagePlayground.Examples/Example.Charts.cs
+++ b/Sources/ImagePlayground.Examples/Example.Charts.cs
@@ -1,30 +1,55 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.IO;
 
 namespace ImagePlayground.Examples {
     internal partial class Example {
+        public static void ChartsExamples(string folderPath) {
+            Console.WriteLine("[*] Creating Bar chart");
+            string bar = Path.Combine(folderPath, "ChartsBar.png");
+            var bars = new List<Charts.ChartDefinition> {
+                new Charts.ChartBar("C#", new List<double> { 5 }),
+                new Charts.ChartBar("C++", new List<double> { 12 }),
+                new Charts.ChartBar("PowerShell", new List<double> { 10 })
+            };
+            Charts.Generate(bars, bar, 500, 500);
 
-        public static void Charts1(string folderPath) {
-            //var plt = new ScottPlot.Plot(600, 400);
-            // plt.
+            Console.WriteLine("[*] Creating Pie chart");
+            string pie = Path.Combine(folderPath, "ChartsPie.png");
+            var pies = new List<Charts.ChartDefinition> {
+                new Charts.ChartPie("C#", 5),
+                new Charts.ChartPie("C++", 12),
+                new Charts.ChartPie("PowerShell", 10)
+            };
+            Charts.Generate(pies, pie, 500, 500);
 
-            //// create sample data
-            //double[] values = { 26, 20, 23, 7, 16 };
+            Console.WriteLine("[*] Creating Line chart");
+            string line = Path.Combine(folderPath, "ChartsLine.png");
+            var lines = new List<Charts.ChartDefinition> {
+                new Charts.ChartLine("C#", new List<double> { 5, 10, 12, 18, 10, 13 }),
+                new Charts.ChartLine("C++", new List<double> { 10, 15, 30, 40, 50, 60 }),
+                new Charts.ChartLine("PowerShell", new List<double> { 10, 5, 12, 18, 30, 60 })
+            };
+            Charts.Generate(lines, line, 500, 500);
 
-            //// add a bar graph to the plot
-            //plt.AddBar(values);
+            Console.WriteLine("[*] Creating Scatter chart");
+            string scatter = Path.Combine(folderPath, "ChartsScatter.png");
+            var scatters = new List<Charts.ChartDefinition> {
+                new Charts.ChartScatter("First", new List<double> { 1, 2, 3 }, new List<double> { 4, 5, 6 }),
+                new Charts.ChartScatter("Second", new List<double> { 1, 2, 3 }, new List<double> { 3, 2, 1 })
+            };
+            Charts.Generate(scatters, scatter, 500, 500);
 
-            //// adjust axis limits so there is no padding below the bar graph
-            //plt.SetAxisLimits(yMin: 0);
-
-
-            //string filePath = System.IO.Path.Combine(folderPath, "Chart.png");
-
-            //plt.SaveFig(filePath);
+            Console.WriteLine("[*] Creating Radial chart");
+            string radial = Path.Combine(folderPath, "ChartsRadial.png");
+            var radials = new List<Charts.ChartDefinition> {
+                new Charts.ChartRadial("C#", 5),
+                new Charts.ChartRadial("AutoIt v3", 50),
+                new Charts.ChartRadial("PowerShell", 10),
+                new Charts.ChartRadial("C++", 18),
+                new Charts.ChartRadial("F#", 100)
+            };
+            Charts.Generate(radials, radial, 500, 500);
         }
-
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartScatter.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartScatter.cs
@@ -1,0 +1,33 @@
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+/// <summary>Creates scatter chart data item.</summary>
+/// <example>
+///   <summary>Create scatter data</summary>
+///   <code>New-ImageChartScatter -Name 'Series1' -X 1,2,3 -Y 4,5,6 -Color Blue</code>
+/// </example>
+[Cmdlet(VerbsCommon.New, "ImageChartScatter")]
+public sealed class NewImageChartScatterCmdlet : PSCmdlet {
+    /// <summary>Label for the scatter series.</summary>
+    [Alias("Label")]
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>X values for the series.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public double[] X { get; set; } = System.Array.Empty<double>();
+
+    /// <summary>Y values for the series.</summary>
+    [Parameter(Mandatory = true, Position = 2)]
+    public double[] Y { get; set; } = System.Array.Empty<double>();
+
+    /// <summary>Series color.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color? Color { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        WriteObject(new ImagePlayground.Charts.ChartScatter(Name, X, Y, Color));
+    }
+}

--- a/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
+++ b/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
@@ -132,6 +132,18 @@ namespace ImagePlayground.Tests {
         }
 
         [Fact]
+        public void Test_ScatterChart() {
+            string file = Path.Combine(_directoryWithTests, "chart_scatter.png");
+            if (File.Exists(file)) File.Delete(file);
+            var defs = new List<Charts.ChartDefinition> {
+                new Charts.ChartScatter("First", new List<double>{1,2,3}, new List<double>{4,5,6}),
+                new Charts.ChartScatter("Second", new List<double>{1,2,3}, new List<double>{3,2,1})
+            };
+            Charts.Generate(defs, file, 300, 200);
+            Assert.True(File.Exists(file));
+        }
+
+        [Fact]
         public void Test_PieAndRadialCharts() {
             string pie = Path.Combine(_directoryWithTests, "chart_pie.png");
             if (File.Exists(pie)) File.Delete(pie);

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -15,6 +15,8 @@ public static class Charts {
         Bar,
         /// <summary>Line chart.</summary>
         Line,
+        /// <summary>Scatter chart.</summary>
+        Scatter,
         /// <summary>Pie chart.</summary>
         Pie,
         /// <summary>Radial gauge chart.</summary>
@@ -58,6 +60,24 @@ public static class Charts {
 
         public ChartLine(string name, IList<double> value, ImageColor? color = null) : base(ChartDefinitionType.Line, name) {
             Value = value;
+            Color = color;
+        }
+    }
+
+    /// <summary>Scatter chart definition.</summary>
+    public sealed class ChartScatter : ChartDefinition {
+        /// <summary>X values.</summary>
+        public IList<double> X { get; }
+
+        /// <summary>Y values.</summary>
+        public IList<double> Y { get; }
+
+        /// <summary>Point color.</summary>
+        public ImageColor? Color { get; }
+
+        public ChartScatter(string name, IList<double> x, IList<double> y, ImageColor? color = null) : base(ChartDefinitionType.Scatter, name) {
+            X = x;
+            Y = y;
             Color = color;
         }
     }
@@ -161,6 +181,17 @@ public static class Charts {
                     if (line.Color.HasValue) {
                         var px = line.Color.Value.ToPixel<Rgba32>();
                         sig.LineColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                    }
+                }
+                plot.ShowLegend();
+                break;
+            case ChartDefinitionType.Scatter:
+                foreach (var scatter in list.Cast<ChartScatter>()) {
+                    var sc = plot.Add.Scatter(scatter.X.ToArray(), scatter.Y.ToArray());
+                    sc.LegendText = scatter.Name;
+                    if (scatter.Color.HasValue) {
+                        var px = scatter.Color.Value.ToPixel<Rgba32>();
+                        sc.Color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
                     }
                 }
                 plot.ShowLegend();


### PR DESCRIPTION
## Summary
- implement scatter chart support with new `ChartScatter` and cmdlet
- update chart generator to draw scatter plots
- include C# example, PowerShell script and docs for scatter charts
- export new cmdlet in module manifest
- remove the scatter chart screenshot to avoid binary blobs

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --no-restore -c Release -v minimal` *(fails: .NETFramework v4.7.2 reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852f780dfc4832ea6e448a92194ae20