### PR TITLE
Fix PS5.1 import issue by skipping native dlls

### DIFF
--- a/ImagePlayground.psm1
+++ b/ImagePlayground.psm1
@@ -104,14 +104,17 @@ $Assembly = @(
         if ($PSEdition -eq 'Core') {
             Get-ChildItem -Path $DevelopmentPath\$DevelopmentFolderCore -Filter '*.dll' -Recurse | Where-Object { $_.FullName -notmatch '[\\/]runtimes[\\/]' }
         } else {
-            Get-ChildItem -Path $DevelopmentPath\$DevelopmentFolderDefault -Filter '*.dll' -Recurse | Where-Object { $_.FullName -notmatch '[\\/]runtimes[\\/]' }
+            # Exclude native runtime libraries placed in architecture specific directories
+            Get-ChildItem -Path $DevelopmentPath\$DevelopmentFolderDefault -Filter '*.dll' -Recurse |
+                Where-Object { $_.FullName -notmatch '[\\/](?:runtimes|x64|x86|arm64|arm)[\\/]' }
         }
     } else {
         if ($Framework -and $PSEdition -eq 'Core') {
             Get-ChildItem -Path $PSScriptRoot\Lib\$Framework -Filter '*.dll' -Recurse | Where-Object { $_.FullName -notmatch '[\\/]runtimes[\\/]' }
         }
         if ($FrameworkNet -and $PSEdition -ne 'Core') {
-            Get-ChildItem -Path $PSScriptRoot\Lib\$FrameworkNet -Filter '*.dll' -Recurse | Where-Object { $_.FullName -notmatch '[\\/]runtime(s[\\/]' }
+            Get-ChildItem -Path $PSScriptRoot\Lib\$FrameworkNet -Filter '*.dll' -Recurse |
+                Where-Object { $_.FullName -notmatch '[\\/](?:runtimes|x64|x86|arm64|arm)[\\/]' }
         }
     }
 )


### PR DESCRIPTION
## Summary
- avoid loading architecture specific native libraries when importing ImagePlayground

## Testing
- `pwsh -NoProfile -Command ./ImagePlayground.Tests.ps1` *(fails: Get-Image not recognized, unable to find compiled binaries)*

------
https://chatgpt.com/codex/tasks/task_e_6853b680ac98832e907c2ed8e85fba25