### PR TITLE
Add image Base64 conversion support

### DIFF
--- a/Docs/ConvertFrom-ImageBase64.md
+++ b/Docs/ConvertFrom-ImageBase64.md
@@ -1,0 +1,80 @@
+---
+external help file: ImagePlayground-help.xml
+Module Name: ImagePlayground
+online version:
+schema: 2.0.0
+---
+
+# ConvertFrom-ImageBase64
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+```powershell
+ConvertFrom-ImageBase64 [-Base64] <String> [-OutputPath] <String> [-Open] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+{{ Add example description here }}
+
+## PARAMETERS
+### -Base64
+{{ Fill Base64 Description }}
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputPath
+{{ Fill OutputPath Description }}
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Open
+{{ Fill Open Description }}
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+None
+
+## OUTPUTS
+None
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/ConvertTo-ImageBase64.md
+++ b/Docs/ConvertTo-ImageBase64.md
@@ -1,0 +1,52 @@
+---
+external help file: ImagePlayground-help.xml
+Module Name: ImagePlayground
+online version:
+schema: 2.0.0
+---
+
+# ConvertTo-ImageBase64
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+```powershell
+ConvertTo-ImageBase64 [-FilePath] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+{{ Add example description here }}
+
+## PARAMETERS
+### -FilePath
+{{ Fill FilePath Description }}
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+None
+
+## OUTPUTS
+### System.String
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -13,6 +13,10 @@ Locale: en-US
 ## ImagePlayground Cmdlets
 ### [ConvertTo-Image](ConvertTo-Image.md)
 {{ Fill in the Synopsis }}
+### [ConvertTo-ImageBase64](ConvertTo-ImageBase64.md)
+{{ Fill in the Synopsis }}
+### [ConvertFrom-ImageBase64](ConvertFrom-ImageBase64.md)
+{{ Fill in the Synopsis }}
 
 ### [Get-Image](Get-Image.md)
 {{ Fill in the Synopsis }}

--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -6,6 +6,8 @@
         'Add-ImageWatermark',
         'Compare-Image',
         'ConvertTo-Image',
+        'ConvertTo-ImageBase64',
+        'ConvertFrom-ImageBase64',
         'Get-Image',
         'Get-ImageBarCode',
         'Get-ImageExif',

--- a/README.MD
+++ b/README.MD
@@ -50,6 +50,7 @@ It works fine when running in PowerShell 5.1 console, or ISE (shrug!).
 - ☑️ Image Grayscale
 - ☑️ Image Blur
 - ☑️ Image Sharpen
+- ☑️ Image Base64 conversion
 - ☑️ Many more
 
 ## Installation
@@ -198,6 +199,11 @@ WatermarkImage    Method     void WatermarkImage(string filePath, ImagePlaygroun
 
 ```powershell
 ConvertTo-Image -FilePath $PSScriptRoot\Samples\LogoEvotec.png -OutputPath $PSScriptRoot\Output\LogoEvotec.jpg
+```
+
+```powershell
+$b64 = ConvertTo-ImageBase64 -FilePath $PSScriptRoot\Samples\LogoEvotec.png
+ConvertFrom-ImageBase64 -Base64 $b64 -OutputPath $PSScriptRoot\Output\FromBase64.png
 ```
 
 #### Resizing images

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertFromImageBase64.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertFromImageBase64.cs
@@ -1,0 +1,22 @@
+using ImagePlayground;
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+[Cmdlet(VerbsData.ConvertFrom, "ImageBase64")]
+public sealed class ConvertFromImageBase64Cmdlet : PSCmdlet {
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Base64 { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true, Position = 1)]
+    public string OutputPath { get; set; } = string.Empty;
+
+    [Parameter]
+    public SwitchParameter Open { get; set; }
+
+    protected override void ProcessRecord() {
+        var output = Helpers.ResolvePath(OutputPath);
+        ImageHelper.ConvertFromBase64(Base64, output);
+        Helpers.Open(output, Open.IsPresent);
+    }
+}

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertToImageBase64.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertToImageBase64.cs
@@ -1,0 +1,23 @@
+using ImagePlayground;
+using System.IO;
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+[Cmdlet(VerbsData.ConvertTo, "ImageBase64")]
+[OutputType(typeof(string))]
+public sealed class ConvertToImageBase64Cmdlet : PSCmdlet {
+    [Parameter(Mandatory = true, Position = 0)]
+    public string FilePath { get; set; } = string.Empty;
+
+    protected override void ProcessRecord() {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
+            WriteWarning($"ConvertTo-ImageBase64 - File {FilePath} not found. Please check the path.");
+            return;
+        }
+
+        var result = ImageHelper.ConvertToBase64(filePath);
+        WriteObject(result);
+    }
+}

--- a/Sources/ImagePlayground.Tests/ImageHelperBase64.cs
+++ b/Sources/ImagePlayground.Tests/ImageHelperBase64.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_ConvertToAndFromBase64() {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string dest = Path.Combine(_directoryWithTests, "base64.png");
+            if (File.Exists(dest)) File.Delete(dest);
+
+            string b64 = ImageHelper.ConvertToBase64(src);
+            ImageHelper.ConvertFromBase64(b64, dest);
+
+            Assert.True(File.Exists(dest));
+            byte[] a = File.ReadAllBytes(src);
+            byte[] b = File.ReadAllBytes(dest);
+            Assert.Equal(a.Length, b.Length);
+        }
+    }
+}

--- a/Sources/ImagePlayground/ImageHelper.Base64.cs
+++ b/Sources/ImagePlayground/ImageHelper.Base64.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+
+namespace ImagePlayground {
+    public partial class ImageHelper {
+        public static string ConvertToBase64(string filePath) {
+            string fullPath = Helpers.ResolvePath(filePath);
+            using var stream = File.OpenRead(fullPath);
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            return Convert.ToBase64String(ms.ToArray());
+        }
+
+        public static void ConvertFromBase64(string base64, string outFilePath) {
+            string outFullPath = Helpers.ResolvePath(outFilePath);
+            var bytes = Convert.FromBase64String(base64);
+            File.WriteAllBytes(outFullPath, bytes);
+        }
+    }
+}

--- a/Tests/ConvertFrom-ImageBase64.Tests.ps1
+++ b/Tests/ConvertFrom-ImageBase64.Tests.ps1
@@ -1,0 +1,15 @@
+describe 'ConvertFrom-ImageBase64' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
+        $TestDir = Join-Path $PSScriptRoot 'Artifacts'
+        if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
+    }
+    It 'creates image from base64' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'fromb64.png'
+        if (Test-Path $dest) { Remove-Item $dest }
+        $b64 = ConvertTo-ImageBase64 -FilePath $src
+        ConvertFrom-ImageBase64 -Base64 $b64 -OutputPath $dest
+        Test-Path $dest | Should -BeTrue
+    }
+}

--- a/Tests/ConvertTo-ImageBase64.Tests.ps1
+++ b/Tests/ConvertTo-ImageBase64.Tests.ps1
@@ -1,0 +1,12 @@
+describe 'ConvertTo-ImageBase64' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
+        $TestDir = Join-Path $PSScriptRoot 'Artifacts'
+        if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
+    }
+    It 'returns base64 string' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $b64 = ConvertTo-ImageBase64 -FilePath $src
+        $b64 | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- enable base64 conversions in ImageHelper
- expose ConvertTo-ImageBase64 and ConvertFrom-ImageBase64 cmdlets
- document new cmdlets and update docs index
- add README sample usage and feature bullet
- cover conversions with unit tests

## Testing
- `dotnet build Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -c Debug`


------
https://chatgpt.com/codex/tasks/task_e_6853b883e38c832e8b445675e0ac4512