### PR TITLE
Add Add-TextBox example

### DIFF
--- a/Docs/Add-ImageText.md
+++ b/Docs/Add-ImageText.md
@@ -48,6 +48,17 @@ ImageHelper.AddText(
 ```
 Adds plain text using C#.
 
+### Example 4
+```csharp
+using SixLabors.ImageSharp;
+
+using var img = Image.Load("input.png");
+img.AddText(10, 10, "Demo", Color.Red, 24);
+img.AddTextBox(10, 40, "Wrapped demo text", 120, Color.Blue, 24);
+img.Save("out2.png");
+```
+Adds both text and a wrapped text box using C#.
+
 ## PARAMETERS
 
 ### -FilePath

--- a/Docs/Add-ImageTextBox.md
+++ b/Docs/Add-ImageTextBox.md
@@ -26,6 +26,15 @@ PS C:\> Add-ImageTextBox -FilePath .\input.png -OutputPath .\out.png -Text 'Long
 Draws the text in a 150 pixel wide box starting at (10,10).
 
 ### Example 2
+```powershell
+PS C:\> $img = Get-Image -FilePath .\input.png
+PS C:\> $img.AddText(50,50,'Add-Text',[SixLabors.ImageSharp.Color]::Red,32)
+PS C:\> $img.AddTextBox(50,100,'Add-TextBox wraps this very long line of text.',400,[SixLabors.ImageSharp.Color]::Blue,32)
+PS C:\> Save-Image -Image $img -FilePath .\out.png
+```
+Shows both `Add-Text` and `Add-TextBox` on the same image.
+
+### Example 3
 ```csharp
 using SixLabors.ImageSharp;
 
@@ -43,6 +52,17 @@ ImageHelper.AddTextBox(
     verticalAlignment: SixLabors.Fonts.VerticalAlignment.Center);
 ```
 Draws centered wrapped text using C#.
+
+### Example 4
+```csharp
+using SixLabors.ImageSharp;
+
+using var image = Image.Load("input.png");
+image.AddText(10, 10, "Example", Color.Green, 24);
+image.AddTextBox(10, 40, "Add-TextBox with narrow width wraps quickly", 150, Color.Orange, 24);
+image.Save("out2.png");
+```
+Demonstrates placing text and wrapped text together using C#.
 
 ## PARAMETERS
 See `Add-ImageText` for details on shared parameters.

--- a/Examples/Images.TextAndTextBox.ps1
+++ b/Examples/Images.TextAndTextBox.ps1
@@ -1,0 +1,12 @@
+Import-Module $PSScriptRoot/..\ImagePlayground.psd1 -Force
+
+$Sample = Join-Path $PSScriptRoot 'Samples/PrzemyslawKlysAndKulkozaurr.jpg'
+$Image = Get-Image -FilePath $Sample
+
+$Image.AddText(50, 50, 'Add-Text example', [SixLabors.ImageSharp.Color]::Red, 32)
+
+$Image.AddTextBox(50, 100, 'Add-TextBox wraps this very long line of text inside a specified width to show the difference.', 400, [SixLabors.ImageSharp.Color]::Blue, 32)
+
+$Output = Join-Path $PSScriptRoot 'Output/TextAndTextBox.jpg'
+Save-Image -Image $Image -FilePath $Output
+

--- a/Examples/Images.TextAndTextBox2.ps1
+++ b/Examples/Images.TextAndTextBox2.ps1
@@ -1,0 +1,10 @@
+Import-Module $PSScriptRoot/..\ImagePlayground.psd1 -Force
+
+$Sample = Join-Path $PSScriptRoot 'Samples/PrzemyslawKlysAndKulkozaurr.jpg'
+$Image = Get-Image -FilePath $Sample
+
+$Image.AddText(10, 10, 'Top-left text', [SixLabors.ImageSharp.Color]::Green, 24)
+$Image.AddTextBox(10, 40, 'Add-TextBox with narrow width wraps quickly for comparison.', 150, [SixLabors.ImageSharp.Color]::Orange, 24)
+
+$Output = Join-Path $PSScriptRoot 'Output/TextAndTextBox2.jpg'
+Save-Image -Image $Image -FilePath $Output

--- a/README.MD
+++ b/README.MD
@@ -263,6 +263,20 @@ Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\PrzemyslawKlysAndK
 
 ![PrzemyslawKlysAndKulkozaurrWatermarkWithText.jpg](https://github.com/EvotecIT/ImagePlayground/blob/feb33319f00df1933f53a4df89d65aa498278e41/Examples/Samples/PrzemyslawKlysAndKulkozaurrWatermarkWithText.jpg)
 
+#### Add text vs text box
+```powershell
+$Image = Get-Image -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg
+$Image.AddText(50,50,'Add-Text example',[SixLabors.ImageSharp.Color]::Red,32)
+$Image.AddTextBox(50,100,'Add-TextBox wraps this very long line of text inside a specified width to show the difference.',400,[SixLabors.ImageSharp.Color]::Blue,32)
+Save-Image -Image $Image -FilePath $PSScriptRoot\Output\TextAndTextBox.jpg
+```
+```powershell
+$Image = Get-Image -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg
+$Image.AddText(10,10,'Top-left text',[SixLabors.ImageSharp.Color]::Green,24)
+$Image.AddTextBox(10,40,'Add-TextBox with narrow width wraps quickly for comparison.',150,[SixLabors.ImageSharp.Color]::Orange,24)
+Save-Image -Image $Image -FilePath $PSScriptRoot\Output\TextAndTextBox2.jpg
+```
+
 #### Get EXIF data
 
 ```powershell

--- a/Sources/ImagePlayground.Examples/Example.TextAndTextBox.cs
+++ b/Sources/ImagePlayground.Examples/Example.TextAndTextBox.cs
@@ -1,0 +1,28 @@
+using System;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground.Examples {
+    internal partial class Example {
+        public static void TextAndTextBox1(string folderPath) {
+            Console.WriteLine("[*] AddText vs AddTextBox example 1");
+            string src = System.IO.Path.Combine(folderPath, "PrzemyslawKlysAndKulkozaurr.jpg");
+            string dest = System.IO.Path.Combine(folderPath, "TextAndTextBox.jpg");
+            using (var image = Image.Load(src)) {
+                image.AddText(50, 50, "Add-Text example", Color.Red, 32);
+                image.AddTextBox(50, 100, "Add-TextBox wraps this very long line of text inside a specified width to show the difference.", 400, Color.Blue, 32);
+                image.Save(dest);
+            }
+        }
+
+        public static void TextAndTextBox2(string folderPath) {
+            Console.WriteLine("[*] AddText vs AddTextBox example 2");
+            string src = System.IO.Path.Combine(folderPath, "PrzemyslawKlysAndKulkozaurr.jpg");
+            string dest = System.IO.Path.Combine(folderPath, "TextAndTextBox2.jpg");
+            using (var image = Image.Load(src)) {
+                image.AddText(10, 10, "Top-left text", Color.Green, 24);
+                image.AddTextBox(10, 40, "Add-TextBox with narrow width wraps quickly for comparison.", 150, Color.Orange, 24);
+                image.Save(dest);
+            }
+        }
+    }
+}

--- a/Tests/Add-ImageText.Tests.ps1
+++ b/Tests/Add-ImageText.Tests.ps1
@@ -39,5 +39,17 @@ Describe 'Add-ImageText' {
 
     }
 
+    It 'adds text and textbox on same image' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'text_and_box.png'
+        if (Test-Path $dest) { Remove-Item $dest }
+        $img = Get-Image -FilePath $src
+        $img.AddText(10,10,'Demo',[SixLabors.ImageSharp.Color]::Green,12)
+        $img.AddTextBox(10,30,'Long text for wrap',80,[SixLabors.ImageSharp.Color]::Blue,12)
+        Save-Image -Image $img -FilePath $dest
+        $img.Dispose()
+        Test-Path $dest | Should -BeTrue
+    }
+
 }
 

--- a/Tests/Add-ImageTextBox.Tests.ps1
+++ b/Tests/Add-ImageTextBox.Tests.ps1
@@ -12,4 +12,12 @@ Describe 'Add-ImageTextBox' {
         Add-ImageTextBox -FilePath $src -OutputPath $dest -Text 'Test Wrap' -X 1 -Y 1 -Width 100 -Color ([SixLabors.ImageSharp.Color]::Red)
         Test-Path $dest | Should -BeTrue
     }
+
+    It 'wraps text when width is small' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'textbox_wrap.png'
+        if (Test-Path $dest) { Remove-Item $dest }
+        Add-ImageTextBox -FilePath $src -OutputPath $dest -Text 'Long text to wrap properly' -X 1 -Y 1 -Width 50 -Color ([SixLabors.ImageSharp.Color]::Blue)
+        Test-Path $dest | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- add script demonstrating Add-Text and Add-TextBox
- document the new example in README
- add a second AddTextBox PowerShell sample
- include C# examples of AddText and AddTextBox
- expand tests for AddText and AddTextBox

## Testing
- `pwsh -NoProfile -File ./Examples/Images.TextAndTextBox.ps1`
- `pwsh -NoProfile -File ./Examples/Images.TextAndTextBox2.ps1`
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6853ba63cad4832eae357407490070de