### PR TITLE
Add chart theme support

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -47,6 +47,10 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter ShowGrid { get; set; }
 
+    /// <summary>Chart theme.</summary>
+    [Parameter]
+    public Charts.ChartTheme Theme { get; set; } = Charts.ChartTheme.Default;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var list = new List<Charts.ChartDefinition>();
@@ -68,7 +72,7 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.Charts.Generate(list, output, Width, Height, null, XTitle, YTitle, ShowGrid.IsPresent);
+        ImagePlayground.Charts.Generate(list, output, Width, Height, null, XTitle, YTitle, ShowGrid.IsPresent, Theme);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -23,6 +23,16 @@ public static class Charts {
         Radial
     }
 
+    /// <summary>Available chart themes.</summary>
+    public enum ChartTheme {
+        /// <summary>Use the default ScottPlot style.</summary>
+        Default,
+        /// <summary>Apply the dark theme.</summary>
+        Dark,
+        /// <summary>Apply the light theme.</summary>
+        Light
+    }
+
     /// <summary>Base class for chart definitions.</summary>
     public abstract class ChartDefinition {
         /// <summary>Chart type.</summary>
@@ -129,12 +139,21 @@ public static class Charts {
         ChartBarOptions? barOptions = null,
         string? xTitle = null,
         string? yTitle = null,
-        bool showGrid = false) {
+        bool showGrid = false,
+        ChartTheme theme = ChartTheme.Default) {
         if (definitions is null) throw new ArgumentNullException(nameof(definitions));
         var list = definitions.ToList();
         if (list.Count == 0) throw new ArgumentException("No chart definitions provided", nameof(definitions));
 
         var plot = new Plot();
+        switch (theme) {
+            case ChartTheme.Dark:
+                new ScottPlot.PlotStyles.Dark().Apply(plot);
+                break;
+            case ChartTheme.Light:
+                new ScottPlot.PlotStyles.Light().Apply(plot);
+                break;
+        }
         var type = list[0].Type;
         if (list.Any(d => d.Type != type))
             throw new ArgumentException("Mixed chart definition types provided. All chart definitions must have the same ChartDefinitionType.", nameof(definitions));


### PR DESCRIPTION
## Summary
- add `ChartTheme` enum
- support `-Theme` parameter in `New-ImageChart`
- apply ScottPlot theme helpers in chart generation

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `dotnet test Sources/ImagePlayground.sln` *(fails to run .NET Framework tests due to missing mono)*

------
https://chatgpt.com/codex/tasks/task_e_6853fb1318dc832eaf47277231c1a8eb