### PR TITLE
Add annotation examples

### DIFF
--- a/Examples/Charts.Annotation.ps1
+++ b/Examples/Charts.Annotation.ps1
@@ -1,0 +1,8 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+New-ImageChart -ChartsDefinition {
+    New-ImageChartLine -Name 'Sample' -Value 1,3,2,5
+} -AnnotationsDefinition {
+    New-ImageChartAnnotation -X 3 -Y 5 -Text 'Peak' -Arrow
+} -Show -FilePath $PSScriptRoot\Samples\ChartsAnnotated.png -Width 500 -Height 300
+

--- a/README.MD
+++ b/README.MD
@@ -152,6 +152,16 @@ New-ImageChart {
 
 ![ChartsRadial.png](https://raw.githubusercontent.com/EvotecIT/ImagePlayground/master/Examples/Samples/ChartsRadial.png)
 
+#### Charts with annotations
+
+```powershell
+New-ImageChart -ChartsDefinition {
+    New-ImageChartLine -Name 'Sample' -Value 1,3,2,5
+} -AnnotationsDefinition {
+    New-ImageChartAnnotation -X 3 -Y 5 -Text 'Peak' -Arrow
+} -Show -FilePath $PSScriptRoot\Samples\ChartsAnnotated.png -Width 500 -Height 300
+```
+
 ### Reading bar codes
 
 ```powershell

--- a/Sources/ImagePlayground.Examples/Example.Charts.cs
+++ b/Sources/ImagePlayground.Examples/Example.Charts.cs
@@ -50,6 +50,13 @@ namespace ImagePlayground.Examples {
                 new Charts.ChartRadial("F#", 100)
             };
             Charts.Generate(radials, radial, 500, 500);
+
+            Console.WriteLine("[*] Creating Line chart with annotations");
+            string annotated = Path.Combine(folderPath, "ChartsAnnotated.png");
+            var anns = new List<Charts.ChartAnnotation> {
+                new Charts.ChartAnnotation(1, 12, "first", true)
+            };
+            Charts.Generate(lines, annotated, 500, 500, null, null, null, false, Charts.ChartTheme.Default, anns);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -19,6 +19,14 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
     [Parameter(ValueFromPipeline = true)]
     public Charts.ChartDefinition[]? Definition { get; set; }
 
+    /// <summary>ScriptBlock producing annotations.</summary>
+    [Parameter]
+    public ScriptBlock? AnnotationsDefinition { get; set; }
+
+    /// <summary>Annotations for the chart.</summary>
+    [Parameter]
+    public Charts.ChartAnnotation[]? Annotation { get; set; }
+
     /// <summary>Width of the chart.</summary>
     [Parameter]
     public int Width { get; set; } = 600;
@@ -71,8 +79,22 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
             return;
         }
 
+        var annotations = new List<Charts.ChartAnnotation>();
+        if (Annotation is not null) {
+            annotations.AddRange(Annotation);
+        }
+        if (AnnotationsDefinition != null) {
+            var ares = AnnotationsDefinition.Invoke();
+            foreach (var o in ares) {
+                var obj = o is PSObject ps ? ps.BaseObject : o;
+                if (obj is Charts.ChartAnnotation ann) {
+                    annotations.Add(ann);
+                }
+            }
+        }
+
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.Charts.Generate(list, output, Width, Height, null, XTitle, YTitle, ShowGrid.IsPresent, Theme);
+        ImagePlayground.Charts.Generate(list, output, Width, Height, null, XTitle, YTitle, ShowGrid.IsPresent, Theme, annotations);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartAnnotation.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartAnnotation.cs
@@ -1,0 +1,32 @@
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+/// <summary>Creates chart annotation data item.</summary>
+/// <example>
+///   <summary>Create annotation</summary>
+///   <code>New-ImageChartAnnotation -X 1 -Y 2 -Text 'Hello' -Arrow</code>
+/// </example>
+[Cmdlet(VerbsCommon.New, "ImageChartAnnotation")]
+public sealed class NewImageChartAnnotationCmdlet : PSCmdlet {
+    /// <summary>X coordinate for annotation.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public double X { get; set; }
+
+    /// <summary>Y coordinate for annotation.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public double Y { get; set; }
+
+    /// <summary>Annotation text.</summary>
+    [Parameter(Mandatory = true, Position = 2)]
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Display arrow.</summary>
+    [Parameter]
+    public SwitchParameter Arrow { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        WriteObject(new ImagePlayground.Charts.ChartAnnotation(X, Y, Text, Arrow.IsPresent));
+    }
+}

--- a/Sources/ImagePlayground.Tests/Charts.cs
+++ b/Sources/ImagePlayground.Tests/Charts.cs
@@ -82,5 +82,22 @@ namespace ImagePlayground.Tests {
         public void Test_GenerateEmptyDefinitionsThrows() {
             Assert.Throws<ArgumentException>(() => Charts.Generate(new List<Charts.ChartDefinition>(), Path.Combine(_directoryWithTests, "empty.png")));
         }
+
+        [Fact]
+        public void Test_GenerateWithAnnotations() {
+            string file = Path.Combine(_directoryWithTests, "chart_annotation.png");
+            if (File.Exists(file)) File.Delete(file);
+
+            var defs = new List<Charts.ChartDefinition> {
+                new Charts.ChartBar("A", new List<double> { 1 })
+            };
+            var anns = new List<Charts.ChartAnnotation> {
+                new Charts.ChartAnnotation(0, 1, "first", true)
+            };
+
+            Charts.Generate(defs, file, 300, 200, null, null, null, false, Charts.ChartTheme.Default, anns);
+
+            Assert.True(File.Exists(file));
+        }
     }
 }

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -130,6 +130,26 @@ public static class Charts {
         }
     }
 
+
+    /// <summary>Chart annotation definition.</summary>
+    public sealed class ChartAnnotation {
+        /// <summary>X coordinate of the annotation.</summary>
+        public double X { get; }
+        /// <summary>Y coordinate of the annotation.</summary>
+        public double Y { get; }
+        /// <summary>Annotation text.</summary>
+        public string Text { get; }
+        /// <summary>Display arrow.</summary>
+        public bool Arrow { get; }
+
+        public ChartAnnotation(double x, double y, string text, bool arrow = false) {
+            X = x;
+            Y = y;
+            Text = text;
+            Arrow = arrow;
+        }
+    }
+
     /// <summary>Generate a chart based on provided definitions.</summary>
     public static void Generate(
         IEnumerable<ChartDefinition> definitions,
@@ -140,7 +160,8 @@ public static class Charts {
         string? xTitle = null,
         string? yTitle = null,
         bool showGrid = false,
-        ChartTheme theme = ChartTheme.Default) {
+        ChartTheme theme = ChartTheme.Default,
+        IEnumerable<ChartAnnotation>? annotations = null) {
         if (definitions is null) throw new ArgumentNullException(nameof(definitions));
         var list = definitions.ToList();
         if (list.Count == 0) throw new ArgumentException("No chart definitions provided", nameof(definitions));
@@ -259,6 +280,15 @@ public static class Charts {
             plot.ShowGrid();
         } else {
             plot.HideGrid();
+        }
+
+        if (annotations is not null) {
+            foreach (var ann in annotations) {
+                var callout = plot.Add.Callout(ann.Text, new Coordinates(ann.X, ann.Y), new Coordinates(ann.X, ann.Y));
+                if (!ann.Arrow) {
+                    callout.ArrowLineWidth = 0;
+                }
+            }
         }
 
         filePath = Helpers.ResolvePath(filePath);


### PR DESCRIPTION
## Summary
- demonstrate annotations in C# example project
- show how to call annotation cmdlets in PowerShell example
- document annotation sample in README

## Testing
- `dotnet test Sources/ImagePlayground.sln -c Release` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_685429e9a4f4832ea5ddde520d2c1284