### PR TITLE
Add Heatmap chart support

### DIFF
--- a/Examples/Charts.Heatmap.ps1
+++ b/Examples/Charts.Heatmap.ps1
@@ -1,0 +1,11 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+$matrix = [double[,]]::new(2,2)
+$matrix[0,0] = 1
+$matrix[0,1] = 2
+$matrix[1,0] = 3
+$matrix[1,1] = 4
+
+New-ImageChart {
+    New-ImageChartHeatmap -Name 'Heat' -Matrix $matrix
+} -Show -FilePath $PSScriptRoot\Output\ChartsHeatmap.png -Width 500 -Height 500

--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -22,6 +22,7 @@
         'New-ImageChartScatter',
         'New-ImageChartPie',
         'New-ImageChartRadial',
+        'New-ImageChartHeatmap',
         'New-ImageGrid',
         'New-ImageIcon',
         'New-ImageQRCode',

--- a/README.MD
+++ b/README.MD
@@ -152,6 +152,19 @@ New-ImageChart {
 
 ![ChartsRadial.png](https://raw.githubusercontent.com/EvotecIT/ImagePlayground/master/Examples/Samples/ChartsRadial.png)
 
+#### Heatmap charts
+
+```powershell
+$matrix = [double[,]]::new(2,2)
+$matrix[0,0] = 1
+$matrix[0,1] = 2
+$matrix[1,0] = 3
+$matrix[1,1] = 4
+New-ImageChart {
+    New-ImageChartHeatmap -Name 'Heat' -Matrix $matrix
+} -Show -FilePath $PSScriptRoot\Output\ChartsHeatmap.png -Width 500 -Height 500
+```
+
 #### Charts with annotations
 
 ```powershell

--- a/Sources/ImagePlayground.Examples/Example.Charts.cs
+++ b/Sources/ImagePlayground.Examples/Example.Charts.cs
@@ -57,6 +57,13 @@ namespace ImagePlayground.Examples {
                 new Charts.ChartAnnotation(1, 12, "first", true)
             };
             Charts.Generate(lines, annotated, 500, 500, null, null, null, false, Charts.ChartTheme.Default, anns);
+
+            Console.WriteLine("[*] Creating Heatmap chart");
+            string heatmap = Path.Combine(folderPath, "ChartsHeatmap.png");
+            var maps = new List<Charts.ChartDefinition> {
+                new Charts.ChartHeatmap("Heat", new double[,] { { 1, 2 }, { 3, 4 } })
+            };
+            Charts.Generate(maps, heatmap, 500, 500);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartHeatmap.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartHeatmap.cs
@@ -1,0 +1,25 @@
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+/// <summary>Creates heatmap chart data item.</summary>
+/// <example>
+///   <summary>Create heatmap data</summary>
+///   <code>New-ImageChartHeatmap -Name 'Matrix' -Matrix ((1,2),(3,4))</code>
+/// </example>
+[Cmdlet(VerbsCommon.New, "ImageChartHeatmap")]
+public sealed class NewImageChartHeatmapCmdlet : PSCmdlet {
+    /// <summary>Label for the heatmap.</summary>
+    [Alias("Label")]
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Matrix data for the heatmap.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public double[,] Matrix { get; set; } = new double[0, 0];
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        WriteObject(new ImagePlayground.Charts.ChartHeatmap(Name, Matrix));
+    }
+}

--- a/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
+++ b/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
@@ -164,5 +164,17 @@ namespace ImagePlayground.Tests {
             Charts.Generate(radials, radial, 300, 200);
             Assert.True(File.Exists(radial));
         }
+
+        [Fact]
+        public void Test_HeatmapChart() {
+            string file = Path.Combine(_directoryWithTests, "chart_heatmap.png");
+            if (File.Exists(file)) File.Delete(file);
+            var map = new double[,] { { 1, 2 }, { 3, 4 } };
+            var defs = new List<Charts.ChartDefinition> {
+                new Charts.ChartHeatmap("H", map)
+            };
+            Charts.Generate(defs, file, 100, 100);
+            Assert.True(File.Exists(file));
+        }
     }
 }

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -20,7 +20,9 @@ public static class Charts {
         /// <summary>Pie chart.</summary>
         Pie,
         /// <summary>Radial gauge chart.</summary>
-        Radial
+        Radial,
+        /// <summary>Heatmap chart.</summary>
+        Heatmap
     }
 
     /// <summary>Available chart themes.</summary>
@@ -117,6 +119,16 @@ public static class Charts {
         public ChartRadial(string name, double value, ImageColor? color = null) : base(ChartDefinitionType.Radial, name) {
             Value = value;
             Color = color;
+        }
+    }
+
+    /// <summary>Heatmap chart definition.</summary>
+    public sealed class ChartHeatmap : ChartDefinition {
+        /// <summary>Values of the heatmap.</summary>
+        public double[,] Data { get; }
+
+        public ChartHeatmap(string name, double[,] data) : base(ChartDefinitionType.Heatmap, name) {
+            Data = data;
         }
     }
 
@@ -265,6 +277,11 @@ public static class Charts {
                     }).ToArray();
                 }
                 plot.ShowLegend();
+                break;
+            case ChartDefinitionType.Heatmap:
+                foreach (var map in list.Cast<ChartHeatmap>()) {
+                    plot.Add.Heatmap(map.Data);
+                }
                 break;
         }
 


### PR DESCRIPTION
## Summary
- add `ChartHeatmap` definition
- support heatmap charts in `Charts.Generate`
- add PowerShell cmdlet `New-ImageChartHeatmap`
- include heatmap test case and update module manifest

## Testing
- `dotnet build Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --framework net8.0`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --framework net8.0 --no-build --verbosity normal`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68545ce36c94832ebfef7e86750123b0