### PR TITLE
Add histogram chart support

### DIFF
--- a/Docs/New-ImageChartHistogram.md
+++ b/Docs/New-ImageChartHistogram.md
@@ -1,0 +1,47 @@
+---
+external help file: ImagePlayground-help.xml
+Module Name: ImagePlayground
+online version:
+schema: 2.0.0
+---
+
+# New-ImageChartHistogram
+
+## SYNOPSIS
+Creates histogram chart data.
+
+## SYNTAX
+```
+New-ImageChartHistogram [[-Name] <String>] [[-Values] <Array>] [-BinSize <Int32>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+`New-ImageChartHistogram` prepares values for a histogram chart.
+
+## EXAMPLES
+### Example 1
+```powershell
+New-ImageChartHistogram -Name 'Sample' -Values 1,2,3,3,4 -BinSize 2
+```
+Creates histogram data with a bin size of 2.
+
+## PARAMETERS
+### -Name
+Label for the dataset.
+### -Values
+Array of numeric values.
+### -BinSize
+Optional size of each bin.
+
+### CommonParameters
+This cmdlet supports the common parameters.
+
+## INPUTS
+None
+
+## OUTPUTS
+System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/Examples/Charts.Histogram.ps1
+++ b/Examples/Charts.Histogram.ps1
@@ -1,0 +1,5 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+New-ImageChart {
+    New-ImageChartHistogram -Name 'Data' -Values 1,2,3,3,4,5 -BinSize 2
+} -Show -FilePath $PSScriptRoot\Output\ChartsHistogram.png -Width 500 -Height 500

--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -23,6 +23,7 @@
         'New-ImageChartPie',
         'New-ImageChartRadial',
         'New-ImageChartHeatmap',
+        'New-ImageChartHistogram',
         'New-ImageGrid',
         'New-ImageIcon',
         'New-ImageQRCode',

--- a/README.MD
+++ b/README.MD
@@ -165,6 +165,14 @@ New-ImageChart {
 } -Show -FilePath $PSScriptRoot\Output\ChartsHeatmap.png -Width 500 -Height 500
 ```
 
+#### Histogram charts
+
+```powershell
+New-ImageChart {
+    New-ImageChartHistogram -Name 'Data' -Values 1,2,3,3,4,5 -BinSize 2
+} -Show -FilePath $PSScriptRoot\Output\ChartsHistogram.png -Width 500 -Height 500
+```
+
 #### Charts with annotations
 
 ```powershell

--- a/Sources/ImagePlayground.Examples/Example.Charts.cs
+++ b/Sources/ImagePlayground.Examples/Example.Charts.cs
@@ -64,6 +64,13 @@ namespace ImagePlayground.Examples {
                 new Charts.ChartHeatmap("Heat", new double[,] { { 1, 2 }, { 3, 4 } })
             };
             Charts.Generate(maps, heatmap, 500, 500);
+
+            Console.WriteLine("[*] Creating Histogram chart");
+            string hist = Path.Combine(folderPath, "ChartsHistogram.png");
+            var hists = new List<Charts.ChartDefinition> {
+                new Charts.ChartHistogram("Data", new double[] { 1, 2, 3, 3, 4, 5 }, 2)
+            };
+            Charts.Generate(hists, hist, 500, 500);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartHistogram.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartHistogram.cs
@@ -1,0 +1,29 @@
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+/// <summary>Creates histogram chart data item.</summary>
+/// <example>
+///   <summary>Create histogram data</summary>
+///   <code>New-ImageChartHistogram -Name 'Data' -Values @(1,2,3) -BinSize 2</code>
+/// </example>
+[Cmdlet(VerbsCommon.New, "ImageChartHistogram")]
+public sealed class NewImageChartHistogramCmdlet : PSCmdlet {
+    /// <summary>Label for the histogram.</summary>
+    [Alias("Label")]
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Data values.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public double[] Values { get; set; } = System.Array.Empty<double>();
+
+    /// <summary>Optional bin size.</summary>
+    [Parameter]
+    public int? BinSize { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        WriteObject(new ImagePlayground.Charts.ChartHistogram(Name, Values, BinSize));
+    }
+}

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -22,7 +22,9 @@ public static class Charts {
         /// <summary>Radial gauge chart.</summary>
         Radial,
         /// <summary>Heatmap chart.</summary>
-        Heatmap
+        Heatmap,
+        /// <summary>Histogram chart.</summary>
+        Histogram
     }
 
     /// <summary>Available chart themes.</summary>
@@ -129,6 +131,20 @@ public static class Charts {
 
         public ChartHeatmap(string name, double[,] data) : base(ChartDefinitionType.Heatmap, name) {
             Data = data;
+        }
+    }
+
+    /// <summary>Histogram chart definition.</summary>
+    public sealed class ChartHistogram : ChartDefinition {
+        /// <summary>Values for the histogram.</summary>
+        public double[] Values { get; }
+
+        /// <summary>Size of each bin.</summary>
+        public int? BinSize { get; }
+
+        public ChartHistogram(string name, double[] values, int? binSize = null) : base(ChartDefinitionType.Histogram, name) {
+            Values = values;
+            BinSize = binSize;
         }
     }
 
@@ -282,6 +298,19 @@ public static class Charts {
                 foreach (var map in list.Cast<ChartHeatmap>()) {
                     plot.Add.Heatmap(map.Data);
                 }
+                break;
+            case ChartDefinitionType.Histogram:
+                foreach (var hist in list.Cast<ChartHistogram>()) {
+                    var histogram = hist.BinSize.HasValue
+                        ? ScottPlot.Statistics.Histogram.WithBinSize(hist.BinSize.Value, hist.Values)
+                        : ScottPlot.Statistics.Histogram.WithBinCount(10, hist.Values);
+                    var bp = plot.Add.Bars(histogram.Bins, histogram.Counts);
+                    bp.LegendText = hist.Name;
+                    foreach (var bar in bp.Bars) {
+                        bar.Size = histogram.FirstBinSize * 0.8;
+                    }
+                }
+                plot.ShowLegend();
                 break;
         }
 


### PR DESCRIPTION
## Summary
- support ChartHistogram for ScottPlot
- add `New-ImageChartHistogram` cmdlet
- document histogram usage in help and README

## Testing
- `dotnet build Sources/ImagePlayground.sln -v minimal`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68557b1045dc832eab9dbe401f6199aa