### PR TITLE
Disable PS5.1 workflow

### DIFF
--- a/.github/workflows/test_powershell.yml
+++ b/.github/workflows/test_powershell.yml
@@ -44,6 +44,7 @@ jobs:
           path: ImagePlayground.psd1
 
   test-windows-ps5:
+    if: false # Temporarily disabled
     needs: refresh-psd1
     name: 'Windows PowerShell 5.1'
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- temporarily disable Windows PowerShell 5.1 tests to speed up CI

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -c Debug -f net8.0 --no-build --verbosity minimal`
- `pwsh -NoProfile -c "Invoke-Pester -Path Tests -Output Minimal"`

------
https://chatgpt.com/codex/tasks/task_e_68559c8ba068832e9ee80c0f6a120a8e