### PR TITLE
Add more unit tests

### DIFF
--- a/Sources/ImagePlayground.Tests/AvatarAndIcon.cs
+++ b/Sources/ImagePlayground.Tests/AvatarAndIcon.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using SixLabors.ImageSharp;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_SaveAsAvatar_File() {
+            string src = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string dest = Path.Combine(_directoryWithTests, "avatar.png");
+            if (File.Exists(dest)) File.Delete(dest);
+            using var img = Image.Load(src);
+            img.SaveAsAvatar(dest, 64, 64, 10f);
+            Assert.True(File.Exists(dest));
+            using var avatar = Image.Load(dest);
+            Assert.Equal(64, avatar.Width);
+            Assert.Equal(64, avatar.Height);
+        }
+
+        [Fact]
+        public void Test_SaveAsCircularAvatar_File() {
+            string src = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string dest = Path.Combine(_directoryWithTests, "avatar_circular.png");
+            if (File.Exists(dest)) File.Delete(dest);
+            using var img = Image.Load(src);
+            img.SaveAsCircularAvatar(dest, 50);
+            Assert.True(File.Exists(dest));
+            using var avatar = Image.Load(dest);
+            Assert.Equal(50, avatar.Width);
+            Assert.Equal(50, avatar.Height);
+        }
+
+        [Fact]
+        public void Test_SaveAsCircularAvatar_Stream() {
+            string src = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            using var img = Image.Load(src);
+            using var ms = new MemoryStream();
+            img.SaveAsCircularAvatar(ms, 32);
+            Assert.Equal(0, ms.Position);
+            Assert.True(ms.Length > 0);
+            ms.Position = 0;
+            using var avatar = SixLabors.ImageSharp.Image.Load(ms);
+            Assert.Equal(32, avatar.Width);
+            Assert.Equal(32, avatar.Height);
+        }
+
+        [Fact]
+        public void Test_SaveAsIcon_CreatesFile() {
+            string src = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string dest = Path.Combine(_directoryWithTests, "icon.ico");
+            if (File.Exists(dest)) File.Delete(dest);
+            using var img = Image.Load(src);
+            img.SaveAsIcon(dest);
+            Assert.True(File.Exists(dest));
+            Assert.True(new FileInfo(dest).Length > 0);
+        }
+
+        [Fact]
+        public void Test_SaveAsIcon_MultipleSizes() {
+            string src = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string dest = Path.Combine(_directoryWithTests, "icon_multi.ico");
+            if (File.Exists(dest)) File.Delete(dest);
+            using var img = Image.Load(src);
+            img.SaveAsIcon(dest, 16, 32, 48);
+            Assert.True(File.Exists(dest));
+            Assert.True(new FileInfo(dest).Length > 0);
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/GifAndEncoder.cs
+++ b/Sources/ImagePlayground.Tests/GifAndEncoder.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_GifGenerate_Success() {
+            string dest = Path.Combine(_directoryWithTests, "anim.gif");
+            if (File.Exists(dest)) File.Delete(dest);
+            var frames = new List<string> {
+                Path.Combine(_directoryWithImages, "QRCode1.png")
+            };
+            Gif.Generate(frames, dest, 50);
+            Assert.True(File.Exists(dest));
+            using var img = Image.Load(dest);
+            Assert.True(img.Frames.Count >= 1);
+        }
+
+        [Fact]
+        public void Test_GifGenerate_NullSourceThrows() {
+            Assert.Throws<ArgumentNullException>(() => Gif.Generate(null!, Path.Combine(_directoryWithTests, "x.gif")));
+        }
+
+        [Fact]
+        public void Test_GifGenerate_EmptySourceThrows() {
+            Assert.Throws<ArgumentException>(() => Gif.Generate(new List<string>(), Path.Combine(_directoryWithTests, "x.gif")));
+        }
+
+        [Fact]
+        public void Test_GifGenerate_MissingFrameThrows() {
+            var frames = new List<string> { Path.Combine(_directoryWithImages, "missing.png") };
+            Assert.Throws<FileNotFoundException>(() => Gif.Generate(frames, Path.Combine(_directoryWithTests, "x.gif")));
+        }
+
+        [Fact]
+        public void Test_GetEncoder_PngCompressionClamped() {
+            var enc = Helpers.GetEncoder(".png", null, 15) as PngEncoder;
+            Assert.NotNull(enc);
+            Assert.Equal(PngCompressionLevel.BestCompression, enc.CompressionLevel);
+        }
+
+        [Fact]
+        public void Test_GetEncoder_JpegQualityClamped() {
+            var enc = Helpers.GetEncoder(".jpg", 200, null) as JpegEncoder;
+            Assert.NotNull(enc);
+            Assert.Equal(100, enc.Quality);
+        }
+
+        [Fact]
+        public void Test_GetEncoder_UnknownExtensionThrows() {
+            Assert.Throws<SixLabors.ImageSharp.UnknownImageFormatException>(() => Helpers.GetEncoder(".xyz", null, null));
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/HelpersPath.cs
+++ b/Sources/ImagePlayground.Tests/HelpersPath.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_ResolvePath_ExpandsEnvironment() {
+            string testDir = _directoryWithTests;
+            Environment.SetEnvironmentVariable("TEST_PATH", testDir);
+            string result = Helpers.ResolvePath("%TEST_PATH%/file.txt");
+            Assert.Equal(Path.Combine(testDir, "file.txt"), result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Test_ResolvePath_Invalid(string value) {
+            Assert.Throws<ArgumentException>(() => Helpers.ResolvePath(value!));
+        }
+
+        [Fact]
+        public void Test_ReadFileChecked_ReturnsContent() {
+            string file = Path.Combine(_directoryWithTests, "readme.txt");
+            File.WriteAllText(file, "hello");
+            string content = Helpers.ReadFileChecked(file);
+            Assert.Equal("hello", content);
+        }
+
+        [Fact]
+        public void Test_ReadFileChecked_ThrowsWhenMissing() {
+            string file = Path.Combine(_directoryWithTests, "missing.txt");
+            if (File.Exists(file)) File.Delete(file);
+            Assert.Throws<FileNotFoundException>(() => Helpers.ReadFileChecked(file));
+        }
+
+        [Fact]
+        public async Task Test_ReadFileCheckedAsync_ReturnsContent() {
+            string file = Path.Combine(_directoryWithTests, "readme_async.txt");
+            File.WriteAllText(file, "async");
+            string content = await Helpers.ReadFileCheckedAsync(file);
+            Assert.Equal("async", content);
+        }
+
+        [Fact]
+        public async Task Test_ReadFileCheckedAsync_ThrowsWhenMissing() {
+            string file = Path.Combine(_directoryWithTests, "missing_async.txt");
+            if (File.Exists(file)) File.Delete(file);
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await Helpers.ReadFileCheckedAsync(file));
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/StreamTests.cs
+++ b/Sources/ImagePlayground.Tests/StreamTests.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using SixLabors.ImageSharp;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_Image_ToStream_ReturnsResetStream() {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            using var img = Image.Load(src);
+            using var ms = img.ToStream();
+            Assert.Equal(0, ms.Position);
+            Assert.True(ms.Length > 0);
+        }
+
+        [Fact]
+        public void Test_Image_SaveStream_ResetsPosition() {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            using var img = Image.Load(src);
+            using var ms = new MemoryStream();
+            img.Save(ms, quality: 50, compressionLevel: 5);
+            Assert.Equal(0, ms.Position);
+            Assert.True(ms.Length > 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering Helpers.Path
- test avatar and icon methods
- add Gif and encoder checks
- test stream-related methods

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --no-build --framework net8.0`
- `pwsh ./ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6855a0fe9d1c832eb1922e38e4a92093