### PR TITLE
Add polar chart support

### DIFF
--- a/Examples/Charts.Polar.Advanced.ps1
+++ b/Examples/Charts.Polar.Advanced.ps1
@@ -1,0 +1,5 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+New-ImageChart -ChartsDefinition {
+    New-ImageChartPolar -Name "Demo" -Angle 0,1.57,3.14 -Value 1,2,1 -Color ([SixLabors.ImageSharp.Color]::Red)
+} -XTitle 'Angle (rad)' -YTitle 'Radius' -ShowGrid -FilePath $PSScriptRoot\Output\ChartsPolarAdvanced.png -Width 600 -Height 400

--- a/Examples/Charts.Polar.ps1
+++ b/Examples/Charts.Polar.ps1
@@ -1,0 +1,6 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+New-ImageChart {
+    New-ImageChartPolar -Name "Series1" -Angle 0,1.57 -Value 1,2
+    New-ImageChartPolar -Name "Series2" -Angle 0.5,2.2 -Value 2,1.5
+} -Show -FilePath $PSScriptRoot\Output\ChartsPolar.png -Width 500 -Height 500

--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -20,6 +20,7 @@
         'New-ImageChartBarOptions',
         'New-ImageChartLine',
         'New-ImageChartScatter',
+        'New-ImageChartPolar',
         'New-ImageChartPie',
         'New-ImageChartRadial',
         'New-ImageChartHeatmap',

--- a/README.MD
+++ b/README.MD
@@ -144,6 +144,15 @@ New-ImageChart {
 } -Show -FilePath $PSScriptRoot\Output\ChartsScatter.png -Width 500 -Height 500
 ```
 
+#### Polar charts
+
+```powershell
+New-ImageChart {
+    New-ImageChartPolar -Name "Series1" -Angle 0,1.57 -Value 1,2
+    New-ImageChartPolar -Name "Series2" -Angle 0.5,2.2 -Value 2,1.5
+} -Show -FilePath $PSScriptRoot\Output\ChartsPolar.png -Width 500 -Height 500
+```
+
 #### Radar charts
 
 ```powershell

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartPolar.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartPolar.cs
@@ -7,6 +7,10 @@ namespace ImagePlayground.PowerShell;
 ///   <summary>Create polar data</summary>
 ///   <code>New-ImageChartPolar -Name 'Series1' -Angle 0,1.57 -Value 1,2 -Color Blue</code>
 /// </example>
+/// <example>
+///   <summary>Create advanced polar data</summary>
+///   <code>New-ImageChartPolar -Name 'Advanced' -Angle 0,1.57,3.14 -Value 1,2,1 -Color Red</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageChartPolar")]
 public sealed class NewImageChartPolarCmdlet : PSCmdlet {
     /// <summary>Label for the series.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartPolar.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartPolar.cs
@@ -1,0 +1,33 @@
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+/// <summary>Creates polar chart data item.</summary>
+/// <example>
+///   <summary>Create polar data</summary>
+///   <code>New-ImageChartPolar -Name 'Series1' -Angle 0,1.57 -Value 1,2 -Color Blue</code>
+/// </example>
+[Cmdlet(VerbsCommon.New, "ImageChartPolar")]
+public sealed class NewImageChartPolarCmdlet : PSCmdlet {
+    /// <summary>Label for the series.</summary>
+    [Alias("Label")]
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Angle values for the series.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public double[] Angle { get; set; } = System.Array.Empty<double>();
+
+    /// <summary>Radius values for the series.</summary>
+    [Parameter(Mandatory = true, Position = 2)]
+    public double[] Value { get; set; } = System.Array.Empty<double>();
+
+    /// <summary>Series color.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color? Color { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        WriteObject(new ImagePlayground.Charts.ChartPolar(Name, Angle, Value, Color));
+    }
+}

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -17,6 +17,8 @@ public static class Charts {
         Line,
         /// <summary>Scatter chart.</summary>
         Scatter,
+        /// <summary>Polar plot.</summary>
+        Polar,
         /// <summary>Pie chart.</summary>
         Pie,
         /// <summary>Radial gauge chart.</summary>
@@ -92,6 +94,24 @@ public static class Charts {
         public ChartScatter(string name, IList<double> x, IList<double> y, ImageColor? color = null) : base(ChartDefinitionType.Scatter, name) {
             X = x;
             Y = y;
+            Color = color;
+        }
+    }
+
+    /// <summary>Polar plot definition.</summary>
+    public sealed class ChartPolar : ChartDefinition {
+        /// <summary>Angle values.</summary>
+        public IList<double> Angle { get; }
+
+        /// <summary>Radius values.</summary>
+        public IList<double> Value { get; }
+
+        /// <summary>Line color.</summary>
+        public ImageColor? Color { get; }
+
+        public ChartPolar(string name, IList<double> angle, IList<double> value, ImageColor? color = null) : base(ChartDefinitionType.Polar, name) {
+            Angle = angle;
+            Value = value;
             Color = color;
         }
     }
@@ -260,6 +280,17 @@ public static class Charts {
                     if (scatter.Color.HasValue) {
                         var px = scatter.Color.Value.ToPixel<Rgba32>();
                         sc.Color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                    }
+                }
+                plot.ShowLegend();
+                break;
+            case ChartDefinitionType.Polar:
+                foreach (var polar in list.Cast<ChartPolar>()) {
+                    var pp = plot.Add.Polar(polar.Angle.ToArray(), polar.Value.ToArray());
+                    pp.LegendText = polar.Name;
+                    if (polar.Color.HasValue) {
+                        var px = polar.Color.Value.ToPixel<Rgba32>();
+                        pp.Color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
                     }
                 }
                 plot.ShowLegend();

--- a/Sources/ImagePlayground/Helpers.PlotExtensions.cs
+++ b/Sources/ImagePlayground/Helpers.PlotExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using ScottPlot;
+
+namespace ImagePlayground {
+    /// <summary>Extension methods for ScottPlot.</summary>
+    public static class PlotExtensions {
+        /// <summary>Add a polar scatter plot.</summary>
+        /// <param name="add">Plottable adder.</param>
+        /// <param name="angles">Angle values in radians.</param>
+        /// <param name="values">Radius values.</param>
+        public static ScottPlot.Plottables.Scatter Polar(this PlottableAdder add, double[] angles, double[] values) {
+            if (angles is null) throw new ArgumentNullException(nameof(angles));
+            if (values is null) throw new ArgumentNullException(nameof(values));
+            if (angles.Length != values.Length) throw new ArgumentException("Angles and values must have the same length.");
+            var xs = new double[angles.Length];
+            var ys = new double[angles.Length];
+            for (int i = 0; i < angles.Length; i++) {
+                xs[i] = values[i] * Math.Cos(angles[i]);
+                ys[i] = values[i] * Math.Sin(angles[i]);
+            }
+            return add.Scatter(xs, ys);
+        }
+    }
+}

--- a/Tests/New-ImageChart.Tests.ps1
+++ b/Tests/New-ImageChart.Tests.ps1
@@ -40,4 +40,15 @@ Describe 'New-ImageChart' {
 
         Test-Path $file | Should -BeTrue
     }
+
+    It 'creates a polar chart' -Skip:(-not $IsWindows) {
+        $file = Join-Path $TestDir 'chart_polar.png'
+        if (Test-Path $file) { Remove-Item $file }
+
+        New-ImageChart -ChartsDefinition {
+            New-ImageChartPolar -Name 'S1' -Angle @(0,1) -Value @(1,2)
+        } -FilePath $file -Width 200 -Height 150
+
+        Test-Path $file | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- support polar charts
- add PowerShell cmdlet to create polar chart data
- allow `plot.Add.Polar` usage via helper extension

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh -NoLogo -NoProfile -Command ./Tests/New-ImageChart.Tests.ps1` *(fails: Describe not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6855b0a9b2c8832ebc76cfc0adb4615c