### PR TITLE
Add thumbnail creation cmdlet

### DIFF
--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -30,6 +30,7 @@
         'New-ImageQRCodeWiFi',
         'New-ImageQRContact',
         'New-ImageGif',
+        'New-ImageThumbnail',
         'Remove-ImageExif',
         'Resize-Image',
         'Save-Image',

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
@@ -1,0 +1,44 @@
+using ImagePlayground;
+using System.IO;
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+/// <summary>Creates thumbnails for all images in a directory.</summary>
+/// <example>
+///   <summary>Create 64x64 thumbnails</summary>
+///   <code>New-ImageThumbnail -DirectoryPath images -OutputDirectory thumbs -Width 64 -Height 64</code>
+/// </example>
+[Cmdlet(VerbsCommon.New, "ImageThumbnail")]
+public sealed class NewImageThumbnailCmdlet : PSCmdlet {
+    /// <summary>Directory containing images.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string DirectoryPath { get; set; } = string.Empty;
+
+    /// <summary>Destination directory for thumbnails.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string OutputDirectory { get; set; } = string.Empty;
+
+    /// <summary>Thumbnail width.</summary>
+    [Parameter]
+    public int Width { get; set; } = 100;
+
+    /// <summary>Thumbnail height.</summary>
+    [Parameter]
+    public int Height { get; set; } = 100;
+
+    /// <summary>Ignore aspect ratio.</summary>
+    [Parameter]
+    public SwitchParameter DontRespectAspectRatio { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        var dir = Helpers.ResolvePath(DirectoryPath);
+        if (!Directory.Exists(dir)) {
+            WriteWarning($"New-ImageThumbnail - Directory {DirectoryPath} not found. Please check the path.");
+            return;
+        }
+        var output = Helpers.ResolvePath(OutputDirectory);
+        ImagePlayground.ImageHelper.GenerateThumbnails(dir, output, Width, Height, !DontRespectAspectRatio.IsPresent);
+    }
+}

--- a/Sources/ImagePlayground/ImageHelper.Thumbnails.cs
+++ b/Sources/ImagePlayground/ImageHelper.Thumbnails.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground {
+    public partial class ImageHelper {
+        public static void GenerateThumbnails(string directoryPath, string outputDirectory, int width, int height, bool keepAspectRatio = true, Image.Sampler? sampler = null) {
+            string inputDir = Helpers.ResolvePath(directoryPath);
+            string outDir = Helpers.ResolvePath(outputDirectory);
+
+            if (!Directory.Exists(inputDir)) {
+                throw new DirectoryNotFoundException($"Input directory not found: {directoryPath}");
+            }
+
+            if (!Directory.Exists(outDir)) {
+                Directory.CreateDirectory(outDir);
+            }
+
+            foreach (var file in Directory.EnumerateFiles(inputDir)) {
+                try {
+                    using var inStream = File.OpenRead(file);
+                    using SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream);
+                    Resize(image, width, height, keepAspectRatio, sampler);
+                    string destPath = Path.Combine(outDir, Path.GetFileName(file));
+                    try {
+                        image.Save(destPath);
+                    } catch (Exception ex) when (ex is SixLabors.ImageSharp.UnknownImageFormatException || ex is NotSupportedException) {
+                        File.Copy(file, destPath, true);
+                    }
+                } catch (SixLabors.ImageSharp.UnknownImageFormatException) {
+                }
+            }
+        }
+    }
+}

--- a/Tests/New-ImageThumbnail.Tests.ps1
+++ b/Tests/New-ImageThumbnail.Tests.ps1
@@ -1,0 +1,22 @@
+Describe 'New-ImageThumbnail' {
+
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
+        $TestDir = Join-Path $PSScriptRoot 'Artifacts'
+        if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
+    }
+
+    It 'creates thumbnails in output directory' {
+        $srcDir = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images'
+        $outDir = Join-Path $TestDir 'thumbs'
+        if (Test-Path $outDir) { Remove-Item $outDir -Recurse -Force }
+        New-ImageThumbnail -DirectoryPath $srcDir -OutputDirectory $outDir -Width 20 -Height 20
+        (Test-Path $outDir) | Should -BeTrue
+        (Get-ChildItem -Path $outDir -File | Measure-Object).Count | Should -BeGreaterThan 0
+        $file = Get-ChildItem -Path $outDir -File | Select-Object -First 1
+        $img = [ImagePlayground.Image]::Load($file.FullName)
+        $img.Width | Should -Be 20
+        $img.Height | Should -Be 20
+        $img.Dispose()
+    }
+}


### PR DESCRIPTION
## Summary
- add `GenerateThumbnails` helper to resize images in a folder
- expose new `New-ImageThumbnail` PowerShell cmdlet
- export the cmdlet in the module manifest
- test thumbnail generation

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6855b0c45140832e94a7056668d21f3c