### PR TITLE
Add shape cropping support

### DIFF
--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -24,6 +24,7 @@
         'New-ImageChartRadial',
         'New-ImageChartHeatmap',
         'New-ImageChartHistogram',
+        'New-ImageCrop',
         'New-ImageGrid',
         'New-ImageIcon',
         'New-ImageQRCode',

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageCrop.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageCrop.cs
@@ -1,0 +1,72 @@
+using ImagePlayground;
+using System.IO;
+using System.Management.Automation;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground.PowerShell;
+
+[Cmdlet(VerbsCommon.New, "ImageCrop", DefaultParameterSetName = ParameterSetRectangle)]
+public sealed class NewImageCropCmdlet : PSCmdlet {
+    private const string ParameterSetRectangle = "Rectangle";
+    private const string ParameterSetCircle = "Circle";
+    private const string ParameterSetPolygon = "Polygon";
+
+    [Parameter(Mandatory = true, Position = 0)]
+    public string FilePath { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true, Position = 1)]
+    public string OutputPath { get; set; } = string.Empty;
+
+    [Parameter(ParameterSetName = ParameterSetRectangle)]
+    public int X { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetRectangle)]
+    public int Y { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetRectangle)]
+    public int Width { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetRectangle)]
+    public int Height { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetCircle)]
+    public float CenterX { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetCircle)]
+    public float CenterY { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetCircle)]
+    public float Radius { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetPolygon)]
+    public PointF[] Points { get; set; } = System.Array.Empty<PointF>();
+
+    [Parameter]
+    public SwitchParameter Open { get; set; }
+
+    protected override void ProcessRecord() {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
+            WriteWarning($"New-ImageCrop - File {FilePath} not found. Please check the path.");
+            return;
+        }
+        var output = Helpers.ResolvePath(OutputPath);
+
+        if (ParameterSetName == ParameterSetCircle) {
+            ImageHelper.CropCircle(filePath, output, CenterX, CenterY, Radius);
+        } else if (ParameterSetName == ParameterSetPolygon) {
+            if (Points.Length < 3) {
+                WriteWarning("New-ImageCrop - At least three points are required for polygon crop.");
+                return;
+            }
+            ImageHelper.CropPolygon(filePath, output, Points);
+        } else {
+            var rect = new Rectangle(X, Y, Width, Height);
+            ImageHelper.Crop(filePath, output, rect);
+        }
+
+        if (Open.IsPresent) {
+            Helpers.Open(output, true);
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/ImageCropping.cs
+++ b/Sources/ImagePlayground.Tests/ImageCropping.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using PointF = SixLabors.ImageSharp.PointF;
+using ImagePlayground;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_CropCircle_MakesCornerTransparent() {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string dest = Path.Combine(_directoryWithTests, "crop_circle.png");
+            if (File.Exists(dest)) File.Delete(dest);
+            using var img = global::ImagePlayground.Image.Load(src);
+            img.CropCircle(img.Width / 2f, img.Height / 2f, img.Width / 4f);
+            img.Save(dest);
+            using var result = SixLabors.ImageSharp.Image.Load<Rgba32>(dest);
+            Assert.Equal(0, result[0, 0].A);
+        }
+
+        [Fact]
+        public void Test_CropPolygon_MakesCornerTransparent() {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string dest = Path.Combine(_directoryWithTests, "crop_polygon.png");
+            if (File.Exists(dest)) File.Delete(dest);
+            using var img = global::ImagePlayground.Image.Load(src);
+            var points = new[] { new PointF(0, 0), new PointF(img.Width, 0), new PointF(img.Width / 2f, img.Height / 2f) };
+            img.CropPolygon(points);
+            img.Save(dest);
+            using var result = SixLabors.ImageSharp.Image.Load<Rgba32>(dest);
+            Assert.Equal(0, result[result.Width - 1, result.Height - 1].A);
+        }
+    }
+}

--- a/Sources/ImagePlayground/Image.Crop.cs
+++ b/Sources/ImagePlayground/Image.Crop.cs
@@ -1,0 +1,27 @@
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace ImagePlayground {
+    public partial class Image : System.IDisposable {
+        public void CropCircle(float centerX, float centerY, float radius) {
+            var circle = new EllipsePolygon(centerX, centerY, radius);
+            ApplyClip(circle);
+        }
+
+        public void CropPolygon(params PointF[] points) {
+            var polygon = new Polygon(new LinearLineSegment(points));
+            ApplyClip(polygon);
+        }
+
+        private void ApplyClip(IPath shape) {
+            using var clone = _image.Clone(ctx => { });
+            _image.Mutate(x => {
+                x.Clear(Color.Transparent);
+                x.Clip(shape, ctx => ctx.DrawImage(clone, 1f));
+            });
+        }
+    }
+}

--- a/Sources/ImagePlayground/ImageHelper.Crop.cs
+++ b/Sources/ImagePlayground/ImageHelper.Crop.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground {
+    public partial class ImageHelper {
+        public static void Crop(string filePath, string outFilePath, Rectangle rectangle) {
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
+
+            using var img = Image.Load(fullPath);
+            img.Crop(rectangle);
+            img.Save(outFullPath);
+        }
+
+        public static void CropCircle(string filePath, string outFilePath, float centerX, float centerY, float radius) {
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
+
+            using var img = Image.Load(fullPath);
+            img.CropCircle(centerX, centerY, radius);
+            img.Save(outFullPath);
+        }
+
+        public static void CropPolygon(string filePath, string outFilePath, params PointF[] points) {
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
+
+            using var img = Image.Load(fullPath);
+            img.CropPolygon(points);
+            img.Save(outFullPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CropCircle` and `CropPolygon` image methods
- enable helper wrappers for cropping shapes
- add `New-ImageCrop` cmdlet with rectangle, circle and polygon options
- expose the new cmdlet in the module manifest
- test cropping routines

## Testing
- `dotnet test Sources/ImagePlayground.sln --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6855b0d070ec832e84ebb260b79e39b8