### PR TITLE
Add tiled watermark option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -245,6 +245,7 @@ RotateFlip        Method     void RotateFlip(SixLabors.ImageSharp.Processing.Rot
 Saturate          Method     void Saturate(float amount)
 Watermark         Method     void Watermark(string text, float x, float y, SixLabors.ImageSharp.Color color, float fontSize = 16, string fontFamilyName = "Arial", float padding = 18), void Watermark(string text, ImagePlayground.Image+WatermarkPlacement placement, SixLabors.ImageSharp.Color color, float fontSize = 16, string fontFamilyName = "Arial", fl…
 WatermarkImage    Method     void WatermarkImage(string filePath, ImagePlayground.Image+WatermarkPlacement placement, float opacity = 1, float padding = 18, int rotate = 0, SixLabors.ImageSharp.Processing.FlipMode flipMode = SixLabors.ImageSharp.Processing.FlipMode.None, int watermarkPercentage = 20)
+WatermarkImageTiled Method     void WatermarkImageTiled(string filePath, int spacing, float opacity = 1, int rotate = 0, SixLabors.ImageSharp.Processing.FlipMode flipMode = SixLabors.ImageSharp.Processing.FlipMode.None, int watermarkPercentage = 20)
 ```
 
 #### Converting images
@@ -286,8 +287,11 @@ $Image = Get-Image -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.j
 $Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png",[ImagePlayground.Image+WatermarkPlacement]::Middle, 0.5, 0.5)
 # Add watermark with rotation 90 degrees
 $Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png",[ImagePlayground.Image+WatermarkPlacement]::TopLeft, 1, 18, 90)
+# Tile watermark across the image with spacing 100
+$Image.WatermarkImageTiled("$PSScriptRoot\Samples\LogoEvotec.png", 100)
 # Use cmdlet for a quick overlay
 Add-ImageWatermark -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg -OutputPath $PSScriptRoot\Output\Watermark.png -WatermarkPath $PSScriptRoot\Samples\LogoEvotec.png
+Add-ImageWatermark -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg -OutputPath $PSScriptRoot\Output\WatermarkTiled.png -WatermarkPath $PSScriptRoot\Samples\LogoEvotec.png -Spacing 100
 
 # Resize 200% in the same image
 $Image.Resize(200)
@@ -305,6 +309,8 @@ $Image = Get-Image -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.j
 $Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.Image+WatermarkPlacement]::Middle, 0.5, 0.5)
 # Add watermark with rotation 90 degrees
 $Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.Image+WatermarkPlacement]::TopLeft, 1, 18, 90)
+# Tile watermark across the image with spacing 100
+$Image.WatermarkImageTiled("$PSScriptRoot\Samples\LogoEvotec.png", 100)
 # Add watermark with text
 # There are 2 methods to add watermark with text
 #void Watermark(string text, float x, float y, SixLabors.ImageSharp.Color color, float fontSize = 16, string fontFamilyName = "Arial", float padding = 18)

--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
@@ -58,6 +58,10 @@ namespace ImagePlayground.PowerShell {
         [Parameter]
         public int WatermarkPercentage { get; set; } = 20;
 
+        /// <summary>Tile watermark across the image with given spacing.</summary>
+        [Parameter]
+        public int? Spacing { get; set; }
+
         /// <inheritdoc />
         protected override void ProcessRecord() {
             var filePath = Helpers.ResolvePath(FilePath);
@@ -72,7 +76,9 @@ namespace ImagePlayground.PowerShell {
             }
             var output = Helpers.ResolvePath(OutputPath);
 
-            if (ParameterSetName == ParameterSetCoordinates) {
+            if (Spacing != null) {
+                ImagePlayground.ImageHelper.WatermarkImageTiled(filePath, output, watermark, Spacing.Value, Opacity, Rotate, FlipMode, WatermarkPercentage);
+            } else if (ParameterSetName == ParameterSetCoordinates) {
                 ImagePlayground.ImageHelper.WatermarkImage(filePath, output, watermark, X, Y, Opacity, Rotate, FlipMode, WatermarkPercentage);
             } else {
                 ImagePlayground.ImageHelper.WatermarkImage(filePath, output, watermark, Placement, Opacity, Padding, Rotate, FlipMode, WatermarkPercentage);

--- a/Sources/ImagePlayground/Image.Watermark.cs
+++ b/Sources/ImagePlayground/Image.Watermark.cs
@@ -139,5 +139,39 @@ namespace ImagePlayground {
                 AddImage(image, location, opacity);
             }
         }
+
+        public void WatermarkImageTiled(string filePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+            string fullPath = Helpers.ResolvePath(filePath);
+            if (watermarkPercentage < 1 || watermarkPercentage > 100) {
+                throw new ArgumentOutOfRangeException(nameof(watermarkPercentage), "Watermark percentage must be between 1 and 100.");
+            }
+
+            using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {
+                var watermarkWidth = image.Width * watermarkPercentage / 100;
+                var watermarkHeight = image.Height * watermarkPercentage / 100;
+
+                if (watermarkPercentage != 100 || rotate != 0 || flipMode != FlipMode.None) {
+                    image.Mutate(mx => {
+                        if (watermarkPercentage != 100) {
+                            mx.Resize(watermarkWidth, watermarkHeight);
+                        }
+
+                        if (flipMode != FlipMode.None) {
+                            mx.Flip(flipMode);
+                        }
+
+                        if (rotate != 0) {
+                            mx.Rotate(rotate);
+                        }
+                    });
+                }
+
+                for (int y = spacing; y < _image.Height; y += image.Height + spacing) {
+                    for (int x = spacing; x < _image.Width; x += image.Width + spacing) {
+                        AddImage(image, x, y, opacity);
+                    }
+                }
+            }
+        }
     }
 }

--- a/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
@@ -19,5 +19,13 @@ namespace ImagePlayground {
             img.WatermarkImage(watermarkFilePath, x, y, opacity, rotate, flipMode, watermarkPercentage);
             img.Save(outFullPath);
         }
+
+        public static void WatermarkImageTiled(string filePath, string outFilePath, string watermarkFilePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+            string fullPath = Helpers.ResolvePath(filePath);
+            string outFullPath = Helpers.ResolvePath(outFilePath);
+            using var img = Image.Load(fullPath);
+            img.WatermarkImageTiled(watermarkFilePath, spacing, opacity, rotate, flipMode, watermarkPercentage);
+            img.Save(outFullPath);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add WatermarkImageTiled API for repeating watermark image
- expose Spacing parameter on Add-ImageWatermark cmdlet
- document WatermarkImageTiled usage in README

## Testing
- `dotnet --version`
- `pwsh -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion'`

------
https://chatgpt.com/codex/tasks/task_e_6855b0e175bc832e96158885ed0cc232