### PR TITLE
Add extensive unit tests to boost coverage

### DIFF
--- a/Sources/ImagePlayground.Tests/ChartsAdditional.cs
+++ b/Sources/ImagePlayground.Tests/ChartsAdditional.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_GenerateHistogram() {
+            string file = Path.Combine(_directoryWithTests, "chart_histogram.png");
+            if (File.Exists(file)) File.Delete(file);
+            var defs = new List<Charts.ChartDefinition> {
+                new Charts.ChartHistogram("H", new double[] {1,2,3,4}, 1)
+            };
+            Charts.Generate(defs, file, 200, 150);
+            Assert.True(File.Exists(file));
+        }
+
+        [Fact]
+        public void Test_GenerateBarChart_DarkTheme() {
+            string file = Path.Combine(_directoryWithTests, "chart_dark.png");
+            if (File.Exists(file)) File.Delete(file);
+            var defs = new List<Charts.ChartDefinition> {
+                new Charts.ChartBar("A", new List<double> {1,2})
+            };
+            Charts.Generate(defs, file, 200, 150, null, null, null, false, Charts.ChartTheme.Dark);
+            Assert.True(File.Exists(file));
+        }
+
+        [Fact]
+        public void Test_GenerateBarChart_LightTheme() {
+            string file = Path.Combine(_directoryWithTests, "chart_light.png");
+            if (File.Exists(file)) File.Delete(file);
+            var defs = new List<Charts.ChartDefinition> {
+                new Charts.ChartBar("A", new List<double> {1,2})
+            };
+            Charts.Generate(defs, file, 200, 150, null, null, null, false, Charts.ChartTheme.Light);
+            Assert.True(File.Exists(file));
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/CombinePlacements.cs
+++ b/Sources/ImagePlayground.Tests/CombinePlacements.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using SixLabors.ImageSharp;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_Combine_Bottom() {
+            string file1 = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string file2 = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string dest = Path.Combine(_directoryWithTests, "combine_bottom.png");
+            if (File.Exists(dest)) File.Delete(dest);
+            ImageHelper.Combine(file1, file2, dest, false, ImagePlacement.Bottom);
+            Assert.True(File.Exists(dest));
+            using var img = Image.Load(dest);
+            Assert.Equal(1675, img.Width);
+            Assert.Equal(1193, img.Height);
+        }
+
+        [Fact]
+        public void Test_Combine_Top() {
+            string file1 = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string file2 = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string dest = Path.Combine(_directoryWithTests, "combine_top.png");
+            if (File.Exists(dest)) File.Delete(dest);
+            ImageHelper.Combine(file1, file2, dest, false, ImagePlacement.Top);
+            Assert.True(File.Exists(dest));
+            using var img = Image.Load(dest);
+            Assert.Equal(1675, img.Width);
+            Assert.Equal(1193, img.Height);
+        }
+
+        [Fact]
+        public void Test_Combine_Right() {
+            string file1 = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string file2 = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string dest = Path.Combine(_directoryWithTests, "combine_right.png");
+            if (File.Exists(dest)) File.Delete(dest);
+            ImageHelper.Combine(file1, file2, dest, false, ImagePlacement.Right);
+            Assert.True(File.Exists(dest));
+            using var img = Image.Load(dest);
+            Assert.Equal(2335, img.Width);
+            Assert.Equal(660, img.Height);
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/HelpersEncoding.cs
+++ b/Sources/ImagePlayground.Tests/HelpersEncoding.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        private class FakeHttpHandler : HttpMessageHandler {
+            private readonly HttpResponseMessage _response;
+            public FakeHttpHandler(HttpResponseMessage response) {
+                _response = response;
+            }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                return Task.FromResult(_response);
+            }
+        }
+
+        [Fact]
+        public async Task Test_GetStringWithProperEncoding_HeaderCharset() {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            string text = "zażółć";
+            var bytes = Encoding.GetEncoding("iso-8859-2").GetBytes(text);
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain") { CharSet = "iso-8859-2" };
+            using var client = new HttpClient(new FakeHttpHandler(response));
+            string result = await Helpers.GetStringWithProperEncodingAsync(client, "http://test");
+            Assert.Equal(text, result);
+        }
+
+        [Fact]
+        public async Task Test_GetStringWithProperEncoding_BomUtf8() {
+            byte[] bytes = Encoding.UTF8.GetPreamble();
+            bytes = bytes.Concat(Encoding.UTF8.GetBytes("hello")).ToArray();
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+            using var client = new HttpClient(new FakeHttpHandler(response));
+            string result = await Helpers.GetStringWithProperEncodingAsync(client, "http://test");
+            Assert.Equal("hello", result);
+        }
+
+        [Fact]
+        public async Task Test_GetStringWithProperEncoding_BomUtf16() {
+            byte[] prefix = Encoding.Unicode.GetPreamble();
+            byte[] bytes = prefix.Concat(Encoding.Unicode.GetBytes("hi")).ToArray();
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+            using var client = new HttpClient(new FakeHttpHandler(response));
+            string result = await Helpers.GetStringWithProperEncodingAsync(client, "http://test");
+            Assert.Equal("hi", result);
+        }
+
+        [Fact]
+        public async Task Test_GetStringWithProperEncoding_MetaTag() {
+            string html = "<meta charset=\"utf-8\">Hello";
+            byte[] bytes = Encoding.ASCII.GetBytes(html);
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
+            using var client = new HttpClient(new FakeHttpHandler(response));
+            string result = await Helpers.GetStringWithProperEncodingAsync(client, "http://test");
+            Assert.Equal("<meta charset=\"utf-8\">Hello", result);
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/QRCodeAdditional.cs
+++ b/Sources/ImagePlayground.Tests/QRCodeAdditional.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using QRCoder;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_QRCode_Bookmark() {
+            string file = Path.Combine(_directoryWithTests, "qr_bookmark.png");
+            if (File.Exists(file)) File.Delete(file);
+            QrCode.GenerateBookmark("https://example.com", "Example", file);
+            Assert.True(File.Exists(file));
+            var expected = new PayloadGenerator.Bookmark("https://example.com", "Example").ToString();
+            var read = QrCode.Read(file);
+            Assert.Equal(expected, read.Message);
+        }
+
+        [Fact]
+        public void Test_QRCode_Email() {
+            string file = Path.Combine(_directoryWithTests, "qr_email.png");
+            if (File.Exists(file)) File.Delete(file);
+            QrCode.GenerateEmail(file, "test@example.com", "hi", "body");
+            Assert.True(File.Exists(file));
+            var expected = new PayloadGenerator.Mail("test@example.com", "hi", "body", PayloadGenerator.Mail.MailEncoding.MAILTO).ToString();
+            var read = QrCode.Read(file);
+            Assert.Equal(expected, read.Message);
+        }
+
+        [Fact]
+        public void Test_QRCode_WhatsApp() {
+            string file = Path.Combine(_directoryWithTests, "qr_wa.png");
+            if (File.Exists(file)) File.Delete(file);
+            QrCode.GenerateWhatsAppMessage("hello there", file);
+            Assert.True(File.Exists(file));
+            var expected = new PayloadGenerator.WhatsAppMessage("hello there").ToString();
+            var read = QrCode.Read(file);
+            Assert.Equal(expected, read.Message);
+        }
+
+        [Fact]
+        public void Test_QRCode_Url() {
+            string file = Path.Combine(_directoryWithTests, "qr_url.png");
+            if (File.Exists(file)) File.Delete(file);
+            QrCode.GenerateUrl("https://example.com", file);
+            Assert.True(File.Exists(file));
+            var expected = new PayloadGenerator.Url("https://example.com").ToString();
+            var read = QrCode.Read(file);
+            Assert.Equal(expected, read.Message);
+        }
+
+        [Fact]
+        public void Test_QRCode_Mms() {
+            string file = Path.Combine(_directoryWithTests, "qr_mms.png");
+            if (File.Exists(file)) File.Delete(file);
+            QrCode.GenerateMMS(file, "+1234567890", "subj");
+            Assert.True(File.Exists(file));
+            var expected = new PayloadGenerator.MMS("+1234567890", "subj", PayloadGenerator.MMS.MMSEncoding.MMSTO).ToString();
+            var read = QrCode.Read(file);
+            Assert.Equal(expected, read.Message);
+        }
+
+        [Fact]
+        public void Test_QRCode_CalendarEvent() {
+            string file = Path.Combine(_directoryWithTests, "qr_event.png");
+            if (File.Exists(file)) File.Delete(file);
+            DateTime from = new DateTime(2024,1,1,12,0,0);
+            DateTime to = from.AddHours(1);
+            QrCode.GenerateCalendarEvent("Meeting", "Discuss", "Loc", from, to, file, false);
+            Assert.True(File.Exists(file));
+            var expected = new PayloadGenerator.CalendarEvent("Meeting","Discuss","Loc",from,to,false, PayloadGenerator.CalendarEvent.EventEncoding.iCalComplete).ToString();
+            var read = QrCode.Read(file);
+            Assert.Equal(expected, read.Message);
+        }
+
+        [Fact]
+        public void Test_QRCode_Contact() {
+            string file = Path.Combine(_directoryWithTests, "qr_contact.png");
+            if (File.Exists(file)) File.Delete(file);
+            QrCode.GenerateContact(file, PayloadGenerator.ContactData.ContactOutputType.VCard4, "John", "Doe");
+            Assert.True(File.Exists(file));
+            var expected = new PayloadGenerator.ContactData(PayloadGenerator.ContactData.ContactOutputType.VCard4, "John", "Doe", null, null, null, null, null, null, null, null, null, null, null, null, null, null, PayloadGenerator.ContactData.AddressOrder.Default, null, null).ToString();
+            var read = QrCode.Read(file);
+            Assert.Equal(expected, read.Message);
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/ResizeNoChange.cs
+++ b/Sources/ImagePlayground.Tests/ResizeNoChange.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using SixLabors.ImageSharp;
+using Xunit;
+using ImageSharpImage = SixLabors.ImageSharp.Image;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_Resize_NoChange_ReturnsSame() {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            using var img = SixLabors.ImageSharp.Image.Load(src);
+            var result = ImageHelper.Resize(img, img.Width, img.Height);
+            Assert.Same(img, result);
+            Assert.Equal(660, img.Width);
+            Assert.Equal(660, img.Height);
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/WatermarkCoordinates.cs
+++ b/Sources/ImagePlayground.Tests/WatermarkCoordinates.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using SixLabors.ImageSharp;
+using Xunit;
+
+namespace ImagePlayground.Tests {
+    public partial class ImagePlayground {
+        [Fact]
+        public void Test_WatermarkImage_Coordinates() {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string watermark = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string dest = Path.Combine(_directoryWithTests, "watermark_xy.png");
+            if (File.Exists(dest)) File.Delete(dest);
+
+            ImageHelper.WatermarkImage(src, dest, watermark, 5, 5);
+            Assert.True(File.Exists(dest));
+
+            using var orig = Image.Load(src);
+            using var result = Image.Load(dest);
+            Assert.True(orig.Compare(result).PixelErrorCount > 0);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(101)]
+        public void Test_WatermarkImage_Coordinates_InvalidPercentage(int perc) {
+            string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+            string watermark = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+            string dest = Path.Combine(_directoryWithTests, $"watermark_invalid_{perc}.png");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ImageHelper.WatermarkImage(src, dest, watermark, 1, 1, watermarkPercentage: perc));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create tests for encoding helper
- add watermark coordinate tests
- test various QR code generation helpers
- cover histogram and theme chart creation
- verify image combination placement logic
- ensure resize helper returns same instance when unchanged

## Testing
- `dotnet test Sources/ImagePlayground.sln -c Debug -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6855bb4fd814832eb96c6a17770c2b7c