### PR TITLE
Add marker support for line charts

### DIFF
--- a/Docs/New-ImageChartLine.md
+++ b/Docs/New-ImageChartLine.md
@@ -8,30 +8,31 @@ schema: 2.0.0
 # New-ImageChartLine
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Creates a line series definition for chart generation.
 
 ## SYNTAX
 
 ```
-New-ImageChartLine [[-Name] <String>] [[-Value] <Array>] [<CommonParameters>]
+New-ImageChartLine [[-Name] <String>] [[-Value] <Array>] [-Color <Color>] [-Marker <MarkerShape>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Creates an object describing a single line series that can be passed to `New-ImageChart`.
+The object includes optional color information and marker shape.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> New-ImageChartLine -Name 'Series' -Value 1,2,3 -Marker FilledCircle
 ```
 
-{{ Add example description here }}
+Creates a line series with circular markers.
 
 ## PARAMETERS
 
 ### -Name
-{{ Fill Name Description }}
+Name displayed in chart legend.
 
 ```yaml
 Type: String
@@ -46,7 +47,13 @@ Accept wildcard characters: False
 ```
 
 ### -Value
-{{ Fill Value Description }}
+Array of Y values for the line.
+
+### -Color
+Optional line color.
+
+### -Marker
+Shape of markers used on data points.
 
 ```yaml
 Type: Array

--- a/Examples/Charts.Annotation.ps1
+++ b/Examples/Charts.Annotation.ps1
@@ -1,7 +1,7 @@
 Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
 
 New-ImageChart -ChartsDefinition {
-    New-ImageChartLine -Name 'Sample' -Value 1,3,2,5
+    New-ImageChartLine -Name 'Sample' -Value 1,3,2,5 -Marker FilledCircle
 } -AnnotationsDefinition {
     New-ImageChartAnnotation -X 3 -Y 5 -Text 'Peak' -Arrow
 } -Show -FilePath $PSScriptRoot\Samples\ChartsAnnotated.png -Width 500 -Height 300

--- a/Examples/Charts.Line.ps1
+++ b/Examples/Charts.Line.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
 
 New-ImageChart {
-    New-ImageChartLine -Value 5, 10, 12, 18, 10, 13 -Name "C#"
-    New-ImageChartLine -Value 10,15,30,40,50,60 -Name "C++"
-    New-ImageChartLine -Value 10,5,12,18,30,60 -Name "PowerShell"
+    New-ImageChartLine -Value 5, 10, 12, 18, 10, 13 -Name "C#" -Marker FilledCircle
+    New-ImageChartLine -Value 10,15,30,40,50,60 -Name "C++" -Marker FilledSquare
+    New-ImageChartLine -Value 10,5,12,18,30,60 -Name "PowerShell" -Marker OpenCircle
 } -Show -FilePath $PSScriptRoot\Output\ChartsLine.png -Width 500 -Height 500

--- a/README.MD
+++ b/README.MD
@@ -128,9 +128,9 @@ New-ImageChart {
 
 ```powershell
 New-ImageChart {
-    New-ImageChartLine -Value 5, 10, 12, 18, 10, 13 -Name "C#"
-    New-ImageChartLine -Value 10,15,30,40,50,60 -Name "C++"
-    New-ImageChartLine -Value 10,5,12,18,30,60 -Name "PowerShell"
+    New-ImageChartLine -Value 5, 10, 12, 18, 10, 13 -Name "C#" -Marker FilledCircle
+    New-ImageChartLine -Value 10,15,30,40,50,60 -Name "C++" -Marker FilledSquare
+    New-ImageChartLine -Value 10,5,12,18,30,60 -Name "PowerShell" -Marker OpenCircle
 } -Show -FilePath $PSScriptRoot\Output\ChartsLine1.png
 ```
 
@@ -193,7 +193,7 @@ New-ImageChart {
 
 ```powershell
 New-ImageChart -ChartsDefinition {
-    New-ImageChartLine -Name 'Sample' -Value 1,3,2,5
+    New-ImageChartLine -Name 'Sample' -Value 1,3,2,5 -Marker FilledCircle
 } -AnnotationsDefinition {
     New-ImageChartAnnotation -X 3 -Y 5 -Text 'Peak' -Arrow
 } -Show -FilePath $PSScriptRoot\Samples\ChartsAnnotated.png -Width 500 -Height 300

--- a/Sources/ImagePlayground.Examples/Example.Charts.cs
+++ b/Sources/ImagePlayground.Examples/Example.Charts.cs
@@ -26,9 +26,21 @@ namespace ImagePlayground.Examples {
             Console.WriteLine("[*] Creating Line chart");
             string line = Path.Combine(folderPath, "ChartsLine.png");
             var lines = new List<Charts.ChartDefinition> {
-                new Charts.ChartLine("C#", new List<double> { 5, 10, 12, 18, 10, 13 }),
-                new Charts.ChartLine("C++", new List<double> { 10, 15, 30, 40, 50, 60 }),
-                new Charts.ChartLine("PowerShell", new List<double> { 10, 5, 12, 18, 30, 60 })
+                new Charts.ChartLine(
+                    "C#",
+                    new List<double> { 5, 10, 12, 18, 10, 13 },
+                    markerShape: ScottPlot.MarkerShape.FilledCircle,
+                    markerSize: 7),
+                new Charts.ChartLine(
+                    "C++",
+                    new List<double> { 10, 15, 30, 40, 50, 60 },
+                    markerShape: ScottPlot.MarkerShape.FilledSquare,
+                    markerSize: 7),
+                new Charts.ChartLine(
+                    "PowerShell",
+                    new List<double> { 10, 5, 12, 18, 30, 60 },
+                    markerShape: ScottPlot.MarkerShape.OpenCircle,
+                    markerSize: 7)
             };
             Charts.Generate(lines, line, 500, 500);
 

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartLine.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartLine.cs
@@ -22,8 +22,12 @@ public sealed class NewImageChartLineCmdlet : PSCmdlet {
     [Parameter]
     public SixLabors.ImageSharp.Color? Color { get; set; }
 
+    /// <summary>Shape of markers placed on data points.</summary>
+    [Parameter]
+    public ScottPlot.MarkerShape Marker { get; set; } = ScottPlot.MarkerShape.None;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        WriteObject(new ImagePlayground.Charts.ChartLine(Name, Value, Color));
+        WriteObject(new ImagePlayground.Charts.ChartLine(Name, Value, Color, Marker));
     }
 }

--- a/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
+++ b/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
@@ -132,6 +132,22 @@ namespace ImagePlayground.Tests {
         }
 
         [Fact]
+        public void Test_LineChart_WithMarkers() {
+            string file = Path.Combine(_directoryWithTests, "chart_line_marker.png");
+            if (File.Exists(file)) File.Delete(file);
+            var defs = new List<Charts.ChartDefinition> {
+                new Charts.ChartLine(
+                    "First",
+                    new List<double>{1,2,3},
+                    null,
+                    ScottPlot.MarkerShape.FilledCircle,
+                    5)
+            };
+            Charts.Generate(defs, file, 300, 200);
+            Assert.True(File.Exists(file));
+        }
+
+        [Fact]
         public void Test_ScatterChart() {
             string file = Path.Combine(_directoryWithTests, "chart_scatter.png");
             if (File.Exists(file)) File.Delete(file);

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -74,9 +74,22 @@ public static class Charts {
         /// <summary>Line color.</summary>
         public ImageColor? Color { get; }
 
-        public ChartLine(string name, IList<double> value, ImageColor? color = null) : base(ChartDefinitionType.Line, name) {
+        /// <summary>Shape of markers used for data points.</summary>
+        public MarkerShape MarkerShape { get; }
+
+        /// <summary>Optional size of the markers.</summary>
+        public float? MarkerSize { get; }
+
+        public ChartLine(
+            string name,
+            IList<double> value,
+            ImageColor? color = null,
+            MarkerShape markerShape = MarkerShape.None,
+            float? markerSize = null) : base(ChartDefinitionType.Line, name) {
             Value = value;
             Color = color;
+            MarkerShape = markerShape;
+            MarkerSize = markerSize;
         }
     }
 
@@ -266,6 +279,9 @@ public static class Charts {
                 foreach (var line in list.Cast<ChartLine>()) {
                     var sig = plot.Add.Signal(line.Value.ToArray());
                     sig.LegendText = line.Name;
+                    sig.MarkerShape = line.MarkerShape;
+                    if (line.MarkerSize.HasValue)
+                        sig.MarkerSize = line.MarkerSize.Value;
                     if (line.Color.HasValue) {
                         var px = line.Color.Value.ToPixel<Rgba32>();
                         sig.LineColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);


### PR DESCRIPTION
## Summary
- allow specifying line marker shape for line charts
- expose `-Marker` in `New-ImageChartLine`
- display markers when rendering line charts
- document usage and provide new examples
- test line charts with markers

## Testing
- `dotnet test Sources/ImagePlayground.sln --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6855c08a6fdc832e9b5a46c7add70869