### PR TITLE
Add smoothing option for line charts

### DIFF
--- a/Docs/New-ImageChartLine.md
+++ b/Docs/New-ImageChartLine.md
@@ -13,7 +13,7 @@ Creates a line series definition for chart generation.
 ## SYNTAX
 
 ```
-New-ImageChartLine [[-Name] <String>] [[-Value] <Array>] [-Color <Color>] [-Marker <MarkerShape>] [<CommonParameters>]
+New-ImageChartLine [[-Name] <String>] [[-Value] <Array>] [-Color <Color>] [-Marker <MarkerShape>] [-Smooth] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -63,6 +63,21 @@ Aliases:
 Required: False
 Position: 1
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Smooth
+Render the line using smooth curves.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/README.MD
+++ b/README.MD
@@ -165,7 +165,7 @@ New-ImageChart {
 
 ```powershell
 New-ImageChart {
-    New-ImageChartLine -Value 5, 10, 12, 18, 10, 13 -Name "C#" -Marker FilledCircle
+    New-ImageChartLine -Value 5, 10, 12, 18, 10, 13 -Name "C#" -Marker FilledCircle -Smooth
     New-ImageChartLine -Value 10,15,30,40,50,60 -Name "C++" -Marker FilledSquare
     New-ImageChartLine -Value 10,5,12,18,30,60 -Name "PowerShell" -Marker OpenCircle
 } -Show -FilePath $PSScriptRoot\Output\ChartsLine1.png

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartLine.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartLine.cs
@@ -26,8 +26,12 @@ public sealed class NewImageChartLineCmdlet : PSCmdlet {
     [Parameter]
     public ScottPlot.MarkerShape Marker { get; set; } = ScottPlot.MarkerShape.None;
 
+    /// <summary>Render the line using a smooth curve.</summary>
+    [Parameter]
+    public SwitchParameter Smooth { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
-        WriteObject(new ImagePlayground.Charts.ChartLine(Name, Value, Color, Marker));
+        WriteObject(new ImagePlayground.Charts.ChartLine(Name, Value, Color, Marker, null, Smooth.IsPresent));
     }
 }

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -80,16 +80,21 @@ public static class Charts {
         /// <summary>Optional size of the markers.</summary>
         public float? MarkerSize { get; }
 
+        /// <summary>Render the line using a smooth curve.</summary>
+        public bool Smooth { get; }
+
         public ChartLine(
             string name,
             IList<double> value,
             ImageColor? color = null,
             MarkerShape markerShape = MarkerShape.None,
-            float? markerSize = null) : base(ChartDefinitionType.Line, name) {
+            float? markerSize = null,
+            bool smooth = false) : base(ChartDefinitionType.Line, name) {
             Value = value;
             Color = color;
             MarkerShape = markerShape;
             MarkerSize = markerSize;
+            Smooth = smooth;
         }
     }
 
@@ -278,6 +283,14 @@ public static class Charts {
             case ChartDefinitionType.Line:
                 foreach (var line in list.Cast<ChartLine>()) {
                     var sig = plot.Add.Signal(line.Value.ToArray());
+                    if (line.Smooth) {
+                        var prop = sig.GetType().GetProperty("SignalLineStyle");
+                        if (prop is not null) {
+                            var enumType = prop.PropertyType;
+                            var spline = Enum.Parse(enumType, "Spline");
+                            prop.SetValue(sig, spline);
+                        }
+                    }
                     sig.LegendText = line.Name;
                     sig.MarkerShape = line.MarkerShape;
                     if (line.MarkerSize.HasValue)


### PR DESCRIPTION
## Summary
- add `Smooth` flag to line chart definition
- support smooth curves via reflection in chart generation
- allow `-Smooth` in the `New-ImageChartLine` cmdlet
- document new parameter in docs and readme

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6856a2ce2658832eaaf4b303ed171be4