### PR TITLE
Add XML docs to image helpers

### DIFF
--- a/Sources/ImagePlayground/Image.Avatar.cs
+++ b/Sources/ImagePlayground/Image.Avatar.cs
@@ -7,26 +7,56 @@ using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
 public partial class Image : IDisposable {
+    /// <summary>
+    /// Converts the image into an avatar with the specified size and corner radius.
+    /// </summary>
+    /// <param name="width">Desired avatar width.</param>
+    /// <param name="height">Desired avatar height.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
     public void Avatar(int width, int height, float cornerRadius) {
         _image.Mutate(x => ConvertToAvatar(x, new Size(width, height), cornerRadius));
     }
 
+    /// <summary>
+    /// Saves the image as an avatar file.
+    /// </summary>
+    /// <param name="filePath">Destination file path.</param>
+    /// <param name="width">Width of the avatar.</param>
+    /// <param name="height">Height of the avatar.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
     public void SaveAsAvatar(string filePath, int width, int height, float cornerRadius) {
         string fullPath = Helpers.ResolvePath(filePath);
         using var clone = _image.Clone(x => ConvertToAvatar(x, new Size(width, height), cornerRadius));
         clone.Save(fullPath);
     }
 
+    /// <summary>
+    /// Writes the avatar image to a stream.
+    /// </summary>
+    /// <param name="stream">Stream to write the avatar to.</param>
+    /// <param name="width">Width of the avatar.</param>
+    /// <param name="height">Height of the avatar.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
     public void SaveAsAvatar(Stream stream, int width, int height, float cornerRadius) {
         using var clone = _image.Clone(x => ConvertToAvatar(x, new Size(width, height), cornerRadius));
         clone.SaveAsPng(stream);
         stream.Seek(0, SeekOrigin.Begin);
     }
 
+    /// <summary>
+    /// Saves the image as a circular avatar file.
+    /// </summary>
+    /// <param name="filePath">Destination file path.</param>
+    /// <param name="size">Diameter of the avatar.</param>
     public void SaveAsCircularAvatar(string filePath, int size) {
         SaveAsAvatar(filePath, size, size, size / 2f);
     }
 
+    /// <summary>
+    /// Writes a circular avatar to a stream.
+    /// </summary>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="size">Diameter of the avatar.</param>
     public void SaveAsCircularAvatar(Stream stream, int size) {
         SaveAsAvatar(stream, size, size, size / 2f);
     }

--- a/Sources/ImagePlayground/Image.Crop.cs
+++ b/Sources/ImagePlayground/Image.Crop.cs
@@ -6,11 +6,21 @@ using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
 public partial class Image : System.IDisposable {
+    /// <summary>
+    /// Crops the image to a circular region.
+    /// </summary>
+    /// <param name="centerX">Center X coordinate.</param>
+    /// <param name="centerY">Center Y coordinate.</param>
+    /// <param name="radius">Radius of the circle.</param>
     public void CropCircle(float centerX, float centerY, float radius) {
         var circle = new EllipsePolygon(centerX, centerY, radius);
         ApplyClip(circle);
     }
 
+    /// <summary>
+    /// Crops the image to the specified polygon.
+    /// </summary>
+    /// <param name="points">Polygon vertices.</param>
     public void CropPolygon(params PointF[] points) {
         var polygon = new Polygon(new LinearLineSegment(points));
         ApplyClip(polygon);

--- a/Sources/ImagePlayground/Image.Exif.cs
+++ b/Sources/ImagePlayground/Image.Exif.cs
@@ -3,9 +3,18 @@ using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 
 namespace ImagePlayground;
 public partial class Image {
+    /// <summary>
+    /// Gets all EXIF values from the image.
+    /// </summary>
+    /// <returns>List of EXIF values.</returns>
     public IReadOnlyList<IExifValue> GetExifValues() =>
         _image.Metadata.ExifProfile?.Values ?? new List<IExifValue>();
 
+    /// <summary>
+    /// Sets an EXIF value on the image.
+    /// </summary>
+    /// <param name="tag">Tag to set.</param>
+    /// <param name="value">Value for the tag.</param>
     public void SetExifValue(ExifTag tag, object value) {
         _image.Metadata.ExifProfile ??= new ExifProfile();
         var method = typeof(ExifProfile).GetMethod("SetValue")!;
@@ -13,6 +22,10 @@ public partial class Image {
         generic.Invoke(_image.Metadata.ExifProfile, new[] { tag, value });
     }
 
+    /// <summary>
+    /// Removes specific EXIF values from the image.
+    /// </summary>
+    /// <param name="tags">Tags to remove.</param>
     public void RemoveExifValues(params ExifTag[] tags) {
         var profile = _image.Metadata.ExifProfile;
         if (profile is null) { return; }
@@ -21,6 +34,9 @@ public partial class Image {
         }
     }
 
+    /// <summary>
+    /// Clears all EXIF values from the image.
+    /// </summary>
     public void ClearExifValues() {
         var profile = _image.Metadata.ExifProfile;
         if (profile != null) {

--- a/Sources/ImagePlayground/Image.Icon.cs
+++ b/Sources/ImagePlayground/Image.Icon.cs
@@ -8,6 +8,11 @@ using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
 public partial class Image {
+    /// <summary>
+    /// Saves the image in ICO format using multiple resolutions.
+    /// </summary>
+    /// <param name="filePath">Destination ICO file path.</param>
+    /// <param name="sizes">Optional list of icon sizes.</param>
     public void SaveAsIcon(string filePath, params int[] sizes) {
         string fullPath = Helpers.ResolvePath(filePath);
         if (sizes == null || sizes.Length == 0) {

--- a/Sources/ImagePlayground/Image.Image.cs
+++ b/Sources/ImagePlayground/Image.Image.cs
@@ -5,6 +5,13 @@ using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
 public partial class Image : IDisposable {
+    /// <summary>
+    /// Draws another image onto the current image from a file path.
+    /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <param name="x">X coordinate where the image will be placed.</param>
+    /// <param name="y">Y coordinate where the image will be placed.</param>
+    /// <param name="opacity">Opacity of the drawn image.</param>
     public void AddImage(string filePath, int x, int y, float opacity) {
         string fullPath = Helpers.ResolvePath(filePath);
 
@@ -13,11 +20,24 @@ public partial class Image : IDisposable {
             _image.Mutate(mx => mx.DrawImage(image, location, opacity));
         }
     }
+    /// <summary>
+    /// Draws another image onto the current image.
+    /// </summary>
+    /// <param name="image">Image to draw.</param>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="opacity">Opacity of the drawn image.</param>
     public void AddImage(SixLabors.ImageSharp.Image image, int x, int y, float opacity) {
         var location = new Point(x, y);
         _image.Mutate(mx => mx.DrawImage(image, location, opacity));
     }
 
+    /// <summary>
+    /// Draws another image onto the current image at the given location.
+    /// </summary>
+    /// <param name="image">Image to draw.</param>
+    /// <param name="location">Target location.</param>
+    /// <param name="opacity">Opacity of the drawn image.</param>
     public void AddImage(SixLabors.ImageSharp.Image image, Point location, float opacity) {
         _image.Mutate(mx => mx.DrawImage(image, location, opacity));
     }

--- a/Sources/ImagePlayground/Image.Text.cs
+++ b/Sources/ImagePlayground/Image.Text.cs
@@ -8,6 +8,13 @@ using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
 public partial class Image : IDisposable {
+    /// <summary>
+    /// Calculates the dimensions required to render <paramref name="text"/> using the specified font.
+    /// </summary>
+    /// <param name="text">The text to measure.</param>
+    /// <param name="fontSize">Font size in points.</param>
+    /// <param name="fontFamilyName">Name of the font family to use.</param>
+    /// <returns>The measured text rectangle.</returns>
     public FontRectangle GetTextSize(string text, float fontSize, string fontFamilyName) {
         if (!SixLabors.Fonts.SystemFonts.TryGet(fontFamilyName, out var fontFamily)) {
             if (!SixLabors.Fonts.SystemFonts.TryGet("DejaVu Sans", out fontFamily)) {
@@ -20,6 +27,20 @@ public partial class Image : IDisposable {
         return textSize;
     }
 
+    /// <summary>
+    /// Draws a text string at the specified location.
+    /// </summary>
+    /// <param name="x">The x-coordinate of the text origin.</param>
+    /// <param name="y">The y-coordinate of the text origin.</param>
+    /// <param name="text">The text to render.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size in points.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Horizontal shadow offset.</param>
+    /// <param name="shadowOffsetY">Vertical shadow offset.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline thickness.</param>
     public void AddText(float x, float y, string text, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.ImageSharp.Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, SixLabors.ImageSharp.Color? outlineColor = null, float outlineWidth = 0f) {
         if (!SixLabors.Fonts.SystemFonts.TryGet(fontFamilyName, out var fontFamily)) {
             if (!SixLabors.Fonts.SystemFonts.TryGet("DejaVu Sans", out fontFamily)) {
@@ -40,9 +61,44 @@ public partial class Image : IDisposable {
         });
     }
 
+    /// <summary>
+    /// Draws text confined to a bounding box.
+    /// </summary>
+    /// <param name="x">X coordinate of the bounding box origin.</param>
+    /// <param name="y">Y coordinate of the bounding box origin.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="boxWidth">Width of the text box.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size in points.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="horizontalAlignment">Horizontal alignment within the box.</param>
+    /// <param name="verticalAlignment">Vertical alignment within the box.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Horizontal shadow offset.</param>
+    /// <param name="shadowOffsetY">Vertical shadow offset.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline thickness.</param>
     public void AddTextBox(float x, float y, string text, float boxWidth, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, SixLabors.ImageSharp.Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, SixLabors.ImageSharp.Color? outlineColor = null, float outlineWidth = 0f) =>
         AddTextBox(x, y, text, boxWidth, 0f, color, fontSize, fontFamilyName, horizontalAlignment, verticalAlignment, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
 
+    /// <summary>
+    /// Draws text confined to a bounding box with explicit height.
+    /// </summary>
+    /// <param name="x">X coordinate of the box.</param>
+    /// <param name="y">Y coordinate of the box.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="boxWidth">Box width.</param>
+    /// <param name="boxHeight">Box height.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size in points.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="horizontalAlignment">Horizontal alignment inside the box.</param>
+    /// <param name="verticalAlignment">Vertical alignment inside the box.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Horizontal shadow offset.</param>
+    /// <param name="shadowOffsetY">Vertical shadow offset.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline thickness.</param>
     public void AddTextBox(float x, float y, string text, float boxWidth, float boxHeight, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, SixLabors.ImageSharp.Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, SixLabors.ImageSharp.Color? outlineColor = null, float outlineWidth = 0f) {
         if (!SixLabors.Fonts.SystemFonts.TryGet(fontFamilyName, out var fontFamily)) {
             if (!SixLabors.Fonts.SystemFonts.TryGet("DejaVu Sans", out fontFamily)) {

--- a/Sources/ImagePlayground/Image.Watermark.cs
+++ b/Sources/ImagePlayground/Image.Watermark.cs
@@ -17,6 +17,16 @@ public partial class Image : IDisposable {
         Middle,
     }
 
+    /// <summary>
+    /// Draws a text watermark at the specified coordinates.
+    /// </summary>
+    /// <param name="text">Watermark text.</param>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="color">Watermark color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="padding">Optional padding around the watermark.</param>
     public void Watermark(string text, float x, float y, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", float padding = 18f) {
         if (!SystemFonts.TryGet(fontFamilyName, out var fontFamily)) {
             throw new Exception($"Couldn't find font {fontFamilyName}");
@@ -31,6 +41,15 @@ public partial class Image : IDisposable {
 
     }
 
+    /// <summary>
+    /// Places a text watermark using a predefined placement.
+    /// </summary>
+    /// <param name="text">Watermark text.</param>
+    /// <param name="placement">Placement of the watermark.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family.</param>
+    /// <param name="padding">Padding around the text.</param>
     public void Watermark(string text, WatermarkPlacement placement, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", float padding = 18f) {
         var textSize = GetTextSize(text, fontSize, fontFamilyName);
 
@@ -140,6 +159,15 @@ public partial class Image : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Adds a tiled watermark image over the entire picture.
+    /// </summary>
+    /// <param name="filePath">Path to the watermark image.</param>
+    /// <param name="spacing">Spacing between tiles.</param>
+    /// <param name="opacity">Opacity of each tile.</param>
+    /// <param name="rotate">Rotation angle applied to the watermark.</param>
+    /// <param name="flipMode">Flip mode for the watermark.</param>
+    /// <param name="watermarkPercentage">Size of the watermark in percent (1-100).</param>
     public void WatermarkImageTiled(string filePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         if (watermarkPercentage < 1 || watermarkPercentage > 100) {

--- a/Sources/ImagePlayground/ImageHelper.AddText.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddText.cs
@@ -3,6 +3,22 @@ using SixLabors.ImageSharp;
 
 namespace ImagePlayground;
 public partial class ImageHelper {
+    /// <summary>
+    /// Adds text to an image file and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Shadow offset X.</param>
+    /// <param name="shadowOffsetY">Shadow offset Y.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline width.</param>
     public static void AddText(string filePath, string outFilePath, float x, float y, string text, Color color, float fontSize = 16f, string fontFamilyName = "Arial", Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
@@ -12,9 +28,48 @@ public partial class ImageHelper {
         img.Save(outFullPath);
     }
 
+    /// <summary>
+    /// Adds text within a bounding box to an image file and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="x">X coordinate of the box.</param>
+    /// <param name="y">Y coordinate of the box.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="boxWidth">Width of the box.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="horizontalAlignment">Horizontal alignment.</param>
+    /// <param name="verticalAlignment">Vertical alignment.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Shadow offset X.</param>
+    /// <param name="shadowOffsetY">Shadow offset Y.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline width.</param>
     public static void AddTextBox(string filePath, string outFilePath, float x, float y, string text, float boxWidth, Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) =>
         AddTextBox(filePath, outFilePath, x, y, text, boxWidth, 0f, color, fontSize, fontFamilyName, horizontalAlignment, verticalAlignment, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
 
+    /// <summary>
+    /// Adds text within a bounding box to an image file and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="x">X coordinate of the box.</param>
+    /// <param name="y">Y coordinate of the box.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="boxWidth">Width of the box.</param>
+    /// <param name="boxHeight">Height of the box.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="horizontalAlignment">Horizontal alignment.</param>
+    /// <param name="verticalAlignment">Vertical alignment.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Shadow offset X.</param>
+    /// <param name="shadowOffsetY">Shadow offset Y.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline width.</param>
     public static void AddTextBox(string filePath, string outFilePath, float x, float y, string text, float boxWidth, float boxHeight, Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);

--- a/Sources/ImagePlayground/ImageHelper.Crop.cs
+++ b/Sources/ImagePlayground/ImageHelper.Crop.cs
@@ -3,6 +3,12 @@ using SixLabors.ImageSharp;
 
 namespace ImagePlayground;
 public partial class ImageHelper {
+    /// <summary>
+    /// Crops an image to the specified rectangle and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="rectangle">Rectangle to crop.</param>
     public static void Crop(string filePath, string outFilePath, Rectangle rectangle) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
@@ -12,6 +18,14 @@ public partial class ImageHelper {
         img.Save(outFullPath);
     }
 
+    /// <summary>
+    /// Crops an image to a circle and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="centerX">Circle center X.</param>
+    /// <param name="centerY">Circle center Y.</param>
+    /// <param name="radius">Circle radius.</param>
     public static void CropCircle(string filePath, string outFilePath, float centerX, float centerY, float radius) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
@@ -21,6 +35,12 @@ public partial class ImageHelper {
         img.Save(outFullPath);
     }
 
+    /// <summary>
+    /// Crops an image using a polygon and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="points">Polygon points.</param>
     public static void CropPolygon(string filePath, string outFilePath, params PointF[] points) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);


### PR DESCRIPTION
## Summary
- document image text rendering helpers
- document avatar helpers
- document crop helpers
- document EXIF, icon, and watermark helpers
- run `dotnet build` with documentation generation

## Testing
- `dotnet build Sources/ImagePlayground.sln -p:GenerateDocumentationFile=true`

------
https://chatgpt.com/codex/tasks/task_e_6857b54a73d4832e94e2e4deb8fa49e0