### PR TITLE
Add XML documentation comments

### DIFF
--- a/Sources/ImagePlayground/Helpers.Encoder.cs
+++ b/Sources/ImagePlayground/Helpers.Encoder.cs
@@ -12,6 +12,13 @@ using SixLabors.ImageSharp.Formats.Webp;
 
 namespace ImagePlayground;
 public static partial class Helpers {
+    /// <summary>
+    /// Returns an image encoder instance appropriate for the given file extension.
+    /// </summary>
+    /// <param name="extension">File extension including the leading dot.</param>
+    /// <param name="quality">Optional quality value for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
+    /// <returns>Configured image encoder.</returns>
     public static IImageEncoder GetEncoder(string extension, int? quality, int? compressionLevel) {
         extension = extension.ToLowerInvariant();
         return extension switch {

--- a/Sources/ImagePlayground/Helpers.Resampler.cs
+++ b/Sources/ImagePlayground/Helpers.Resampler.cs
@@ -3,6 +3,11 @@ using SixLabors.ImageSharp.Processing.Processors.Transforms;
 
 namespace ImagePlayground;
 public static partial class Helpers {
+    /// <summary>
+    /// Maps the <see cref="Image.Sampler"/> enumeration to a concrete resampler implementation.
+    /// </summary>
+    /// <param name="sampler">Sampler option.</param>
+    /// <returns>Corresponding image resampler.</returns>
     public static IResampler GetResampler(Image.Sampler sampler) =>
         sampler switch {
             Image.Sampler.NearestNeighbor => KnownResamplers.NearestNeighbor,

--- a/Sources/ImagePlayground/Helpers.cs
+++ b/Sources/ImagePlayground/Helpers.cs
@@ -26,6 +26,11 @@ public static partial class Helpers {
         }
     }
 
+    /// <summary>
+    /// Checks whether the specified file is locked by another process.
+    /// </summary>
+    /// <param name="file">File to test.</param>
+    /// <returns><c>true</c> if the file cannot be opened exclusively.</returns>
     public static bool IsFileLocked(this FileInfo file) {
         try {
             using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {
@@ -43,6 +48,11 @@ public static partial class Helpers {
         return false;
     }
 
+    /// <summary>
+    /// Determines if the file specified by path is locked by another process.
+    /// </summary>
+    /// <param name="fileName">Path to the file.</param>
+    /// <returns><c>true</c> if the file cannot be opened exclusively.</returns>
     public static bool IsFileLocked(this string fileName) {
         try {
             var file = new FileInfo(fileName);

--- a/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
@@ -4,6 +4,18 @@ using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
 public partial class ImageHelper {
+    /// <summary>
+    /// Adds an image watermark at one of the predefined placements.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination path.</param>
+    /// <param name="watermarkFilePath">Watermark image path.</param>
+    /// <param name="placement">Placement of the watermark.</param>
+    /// <param name="opacity">Opacity of the watermark.</param>
+    /// <param name="padding">Padding around the watermark.</param>
+    /// <param name="rotate">Rotation in degrees.</param>
+    /// <param name="flipMode">Flip mode applied to watermark.</param>
+    /// <param name="watermarkPercentage">Size of the watermark relative to the base image.</param>
     public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, Image.WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
@@ -12,6 +24,18 @@ public partial class ImageHelper {
         img.Save(outFullPath);
     }
 
+    /// <summary>
+    /// Adds an image watermark at exact coordinates.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination path.</param>
+    /// <param name="watermarkFilePath">Watermark image path.</param>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="opacity">Opacity of the watermark.</param>
+    /// <param name="rotate">Rotation in degrees.</param>
+    /// <param name="flipMode">Flip mode applied to watermark.</param>
+    /// <param name="watermarkPercentage">Size of the watermark relative to the base image.</param>
     public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
@@ -20,6 +44,17 @@ public partial class ImageHelper {
         img.Save(outFullPath);
     }
 
+    /// <summary>
+    /// Tiles the watermark image across the target image.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination path.</param>
+    /// <param name="watermarkFilePath">Watermark image path.</param>
+    /// <param name="spacing">Spacing between watermark tiles.</param>
+    /// <param name="opacity">Opacity of the watermark.</param>
+    /// <param name="rotate">Rotation in degrees.</param>
+    /// <param name="flipMode">Flip mode applied to watermark.</param>
+    /// <param name="watermarkPercentage">Size of each watermark relative to the base image.</param>
     public static void WatermarkImageTiled(string filePath, string outFilePath, string watermarkFilePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);

--- a/Sources/ImagePlayground/ImageHelper.Base64.cs
+++ b/Sources/ImagePlayground/ImageHelper.Base64.cs
@@ -3,6 +3,11 @@ using System.IO;
 
 namespace ImagePlayground;
 public partial class ImageHelper {
+    /// <summary>
+    /// Reads an image file and returns its Base64 representation.
+    /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <returns>Base64 encoded string.</returns>
     public static string ConvertToBase64(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
         using var stream = File.OpenRead(fullPath);
@@ -11,6 +16,11 @@ public partial class ImageHelper {
         return Convert.ToBase64String(ms.ToArray());
     }
 
+    /// <summary>
+    /// Writes a Base64 encoded image to disk.
+    /// </summary>
+    /// <param name="base64">Base64 encoded image content.</param>
+    /// <param name="outFilePath">Destination file path.</param>
     public static void ConvertFromBase64(string base64, string outFilePath) {
         string outFullPath = Helpers.ResolvePath(outFilePath);
         var bytes = Convert.FromBase64String(base64);

--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -54,6 +54,15 @@ public partial class ImageHelper {
         }
     }
 
+    /// <summary>
+    /// Resizes the provided <paramref name="image"/> to the specified dimensions.
+    /// </summary>
+    /// <param name="image">Image instance to resize.</param>
+    /// <param name="width">Desired width or <c>null</c> to auto calculate.</param>
+    /// <param name="height">Desired height or <c>null</c> to auto calculate.</param>
+    /// <param name="keepAspectRatio">Preserve the original aspect ratio.</param>
+    /// <param name="sampler">Optional resampler algorithm.</param>
+    /// <returns>Resized image instance.</returns>
     public static SixLabors.ImageSharp.Image Resize(SixLabors.ImageSharp.Image image, int? width, int? height, bool keepAspectRatio = true, Image.Sampler? sampler = null) {
         if (width == null && height == null) {
             return image;
@@ -107,6 +116,14 @@ public partial class ImageHelper {
         }
     }
 
+    /// <summary>
+    /// Combines two images either horizontally or vertically.
+    /// </summary>
+    /// <param name="filePath">Path to the first image.</param>
+    /// <param name="filePath2">Path to the second image.</param>
+    /// <param name="outFilePath">Destination path of the combined image.</param>
+    /// <param name="resizeToFit">Resize images so they fit next to each other.</param>
+    /// <param name="imagePlacement">Determines placement of <paramref name="filePath2"/>.</param>
     public static void Combine(string filePath, string filePath2, string outFilePath, bool resizeToFit = false, ImagePlacement imagePlacement = ImagePlacement.Bottom) {
         string fullPath = Helpers.ResolvePath(filePath);
         string fullPath2 = Helpers.ResolvePath(filePath2);
@@ -184,6 +201,14 @@ public partial class ImageHelper {
 
     }
 
+    /// <summary>
+    /// Generates a patterned image and saves it to disk.
+    /// </summary>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="width">Image width.</param>
+    /// <param name="height">Image height.</param>
+    /// <param name="color">Background color.</param>
+    /// <param name="open">Open the image after saving.</param>
     public static void Create(string filePath, int width, int height, Color color, bool open = false) {
         string fullPath = Helpers.ResolvePath(filePath);
 


### PR DESCRIPTION
## Summary
- add XML docs for public helpers and image utilities
- run `dotnet build` with docs enabled to verify

## Testing
- `dotnet build -c Release Sources/ImagePlayground/ImagePlayground.csproj /p:GenerateDocumentationFile=true`

------
https://chatgpt.com/codex/tasks/task_e_6857b71b7f84832eb77e021f0f7f9a21