### PR TITLE
Fix small typo in changelog

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,7 +1,7 @@
 ﻿### 0.0.8 - 2024.06.05
 - Bump dependencies
 - Fix signing
-- Smnal fixes
+- Small fixes
 
 ### 0.0.7 - 2024.06.05
 - Add another method `$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png",50,100, 0.5, 0.5)`


### PR DESCRIPTION
## Summary
- fix a typo in CHANGELOG

## Testing
- `pwsh -File ImagePlayground.Tests.ps1`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --no-restore --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6857e4e74ebc832ebf94739e8e64ac36