### PR TITLE
Remove stray DotSettings file

### DIFF
--- a/Sources/ImagePlayground.sln.DotSettings.user
+++ b/Sources/ImagePlayground.sln.DotSettings.user
@@ -1,6 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=86bcc673_002Df4cf_002D47f9_002D9f0d_002D6ebeda422ccf/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Test_ResizeImage" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;xUnit::66240CFB-6319-4B1D-8DB3-C4CB16803E27::.NETFramework,Version=v4.7.2::ImagePlayground.Tests.ImagePlayground.Test_ResizeImage&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
-&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
## Summary
- remove user-specific `.DotSettings` from repo

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release`
- `dotnet test Sources/ImagePlayground.sln -c Release` *(fails: could not find `mono`)*

------
https://chatgpt.com/codex/tasks/task_e_6857f8b735c0832eb536eb5a8f5b3107