### PR TITLE
Add width validation

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
@@ -16,10 +16,12 @@ public sealed class NewImageGridCmdlet : PSCmdlet {
 
     /// <summary>Width of the new image.</summary>
     [Parameter(Mandatory = true, Position = 1)]
+    [ValidateRange(1, 10000)]
     public int Width { get; set; }
 
     /// <summary>Height of the new image.</summary>
     [Parameter(Mandatory = true, Position = 2)]
+    [ValidateRange(1, 10000)]
     public int Height { get; set; }
 
     /// <summary>Background color.</summary>

--- a/Tests/New-ImageGrid.Tests.ps1
+++ b/Tests/New-ImageGrid.Tests.ps1
@@ -24,5 +24,14 @@ Describe 'New-ImageGrid' {
 
     }
 
+    It 'throws for negative dimensions' {
+
+        $dest = Join-Path $TestDir 'grid.png'
+
+        { New-ImageGrid -FilePath $dest -Width -5 -Height 10 } | Should -Throw
+        { New-ImageGrid -FilePath $dest -Width 10 -Height -5 } | Should -Throw
+
+    }
+
 }
 


### PR DESCRIPTION
## Summary
- restrict grid cmdlet dimensions to be between 1 and 10000
- test negative grid sizes

## Testing
- `dotnet build Sources/ImagePlayground.sln --configuration Debug`
- `pwsh -NoLogo -NoProfile -Command "& ./ImagePlayground.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_6857f8bcc17c832eb249de9b1f36a3e1