### PR TITLE
Add asynchronous image helpers

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
@@ -65,6 +65,10 @@ public sealed class AddImageWatermarkCmdlet : PSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int? Spacing { get; set; }
 
+    /// <summary>Use asynchronous processing.</summary>
+    [Parameter]
+    public SwitchParameter Async { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var filePath = Helpers.ResolvePath(FilePath);
@@ -80,11 +84,23 @@ public sealed class AddImageWatermarkCmdlet : PSCmdlet {
         var output = Helpers.ResolvePath(OutputPath);
 
         if (Spacing != null) {
-            ImagePlayground.ImageHelper.WatermarkImageTiled(filePath, output, watermark, Spacing.Value, Opacity, Rotate, FlipMode, WatermarkPercentage);
+            if (Async.IsPresent) {
+                ImagePlayground.ImageHelper.WatermarkImageTiledAsync(filePath, output, watermark, Spacing.Value, Opacity, Rotate, FlipMode, WatermarkPercentage).GetAwaiter().GetResult();
+            } else {
+                ImagePlayground.ImageHelper.WatermarkImageTiled(filePath, output, watermark, Spacing.Value, Opacity, Rotate, FlipMode, WatermarkPercentage);
+            }
         } else if (ParameterSetName == ParameterSetCoordinates) {
-            ImagePlayground.ImageHelper.WatermarkImage(filePath, output, watermark, X, Y, Opacity, Rotate, FlipMode, WatermarkPercentage);
+            if (Async.IsPresent) {
+                ImagePlayground.ImageHelper.WatermarkImageAsync(filePath, output, watermark, X, Y, Opacity, Rotate, FlipMode, WatermarkPercentage).GetAwaiter().GetResult();
+            } else {
+                ImagePlayground.ImageHelper.WatermarkImage(filePath, output, watermark, X, Y, Opacity, Rotate, FlipMode, WatermarkPercentage);
+            }
         } else {
-            ImagePlayground.ImageHelper.WatermarkImage(filePath, output, watermark, Placement, Opacity, Padding, Rotate, FlipMode, WatermarkPercentage);
+            if (Async.IsPresent) {
+                ImagePlayground.ImageHelper.WatermarkImageAsync(filePath, output, watermark, Placement, Opacity, Padding, Rotate, FlipMode, WatermarkPercentage).GetAwaiter().GetResult();
+            } else {
+                ImagePlayground.ImageHelper.WatermarkImage(filePath, output, watermark, Placement, Opacity, Padding, Rotate, FlipMode, WatermarkPercentage);
+            }
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
@@ -48,6 +48,10 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
         [Parameter(ParameterSetName = ParameterSetHeightWidth)]
         public SwitchParameter DontRespectAspectRatio { get; set; }
 
+        /// <summary>Use asynchronous processing.</summary>
+        [Parameter]
+        public SwitchParameter Async { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var filePath = Helpers.ResolvePath(FilePath);
@@ -58,7 +62,11 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
         var output = Helpers.ResolvePath(OutputPath);
 
         if (ParameterSetName == ParameterSetPercentage) {
-            ImagePlayground.ImageHelper.Resize(filePath, output, Percentage);
+            if (Async.IsPresent) {
+                ImagePlayground.ImageHelper.ResizeAsync(filePath, output, Percentage).GetAwaiter().GetResult();
+            } else {
+                ImagePlayground.ImageHelper.Resize(filePath, output, Percentage);
+            }
             return;
         }
 
@@ -74,6 +82,10 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
         int? height = heightBound ? Height : (int?)null;
         bool keepAspect = !DontRespectAspectRatio.IsPresent;
 
-        ImagePlayground.ImageHelper.Resize(filePath, output, width, height, keepAspect);
+        if (Async.IsPresent) {
+            ImagePlayground.ImageHelper.ResizeAsync(filePath, output, width, height, keepAspect).GetAwaiter().GetResult();
+        } else {
+            ImagePlayground.ImageHelper.Resize(filePath, output, width, height, keepAspect);
+        }
     }
 }

--- a/Sources/ImagePlayground.Tests/AsyncMethods.cs
+++ b/Sources/ImagePlayground.Tests/AsyncMethods.cs
@@ -1,0 +1,34 @@
+using SixLabors.ImageSharp;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+public partial class ImagePlayground {
+    [Fact]
+    public async Task Test_ResizeAsync() {
+        string src = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+        string dest = Path.Combine(_directoryWithTests, "logo_async.png");
+        if (File.Exists(dest)) File.Delete(dest);
+
+        await ImageHelper.ResizeAsync(src, dest, 40, 40);
+        using var img = Image.Load(dest);
+        Assert.Equal(40, img.Width);
+        Assert.Equal(40, img.Height);
+    }
+
+    [Fact]
+    public async Task Test_WatermarkImageAsync() {
+        string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+        string wmk = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+        string dest = Path.Combine(_directoryWithTests, "wm_async.png");
+        if (File.Exists(dest)) File.Delete(dest);
+
+        await ImageHelper.WatermarkImageAsync(src, dest, wmk, Image.WatermarkPlacement.Middle, watermarkPercentage: 100);
+        Assert.True(File.Exists(dest));
+        using var orig = Image.Load(src);
+        using var res = Image.Load(dest);
+        Assert.Equal(orig.Width, res.Width);
+        Assert.Equal(orig.Height, res.Height);
+    }
+}

--- a/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading.Tasks;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
 
@@ -25,6 +26,19 @@ public partial class ImageHelper {
     }
 
     /// <summary>
+    /// Asynchronously adds an image watermark at one of the predefined placements.
+    /// </summary>
+    public static async Task WatermarkImageAsync(string filePath, string outFilePath, string watermarkFilePath, Image.WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        await Task.Run(() => {
+            using var img = Image.Load(fullPath);
+            img.WatermarkImage(watermarkFilePath, placement, opacity, padding, rotate, flipMode, watermarkPercentage);
+            img.Save(outFullPath);
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Adds an image watermark at exact coordinates.
     /// </summary>
     /// <param name="filePath">Source image path.</param>
@@ -45,6 +59,19 @@ public partial class ImageHelper {
     }
 
     /// <summary>
+    /// Asynchronously adds an image watermark at exact coordinates.
+    /// </summary>
+    public static async Task WatermarkImageAsync(string filePath, string outFilePath, string watermarkFilePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        await Task.Run(() => {
+            using var img = Image.Load(fullPath);
+            img.WatermarkImage(watermarkFilePath, x, y, opacity, rotate, flipMode, watermarkPercentage);
+            img.Save(outFullPath);
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Tiles the watermark image across the target image.
     /// </summary>
     /// <param name="filePath">Source image path.</param>
@@ -61,5 +88,18 @@ public partial class ImageHelper {
         using var img = Image.Load(fullPath);
         img.WatermarkImageTiled(watermarkFilePath, spacing, opacity, rotate, flipMode, watermarkPercentage);
         img.Save(outFullPath);
+    }
+
+    /// <summary>
+    /// Asynchronously tiles the watermark image across the target image.
+    /// </summary>
+    public static async Task WatermarkImageTiledAsync(string filePath, string outFilePath, string watermarkFilePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        await Task.Run(() => {
+            using var img = Image.Load(fullPath);
+            img.WatermarkImageTiled(watermarkFilePath, spacing, opacity, rotate, flipMode, watermarkPercentage);
+            img.Save(outFullPath);
+        }).ConfigureAwait(false);
     }
 }

--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using ScottPlot;
+using System.Threading.Tasks;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.Drawing.Processing;
@@ -52,6 +53,21 @@ public partial class ImageHelper {
             Resize(image, width, height, keepAspectRatio, sampler);
             image.Save(outFullPath);
         }
+    }
+
+    /// <summary>
+    /// Asynchronously resizes an image to the specified width and height.
+    /// </summary>
+    public static async Task ResizeAsync(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Image.Sampler? sampler = null) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        await Task.Run(() => {
+            using var inStream = System.IO.File.OpenRead(fullPath);
+            using SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream);
+            Resize(image, width, height, keepAspectRatio, sampler);
+            image.Save(outFullPath);
+        }).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -114,6 +130,27 @@ public partial class ImageHelper {
             Resize(image, width, height, false);
             image.Save(outFullPath);
         }
+    }
+
+    /// <summary>
+    /// Asynchronously resizes an image to the specified percentage.
+    /// </summary>
+    public static async Task ResizeAsync(string filePath, string outFilePath, int percentage) {
+        if (percentage <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(percentage));
+        }
+
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        await Task.Run(() => {
+            using var inStream = System.IO.File.OpenRead(fullPath);
+            using SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream);
+            int width = image.Width * percentage / 100;
+            int height = image.Height * percentage / 100;
+            Resize(image, width, height, false);
+            image.Save(outFullPath);
+        }).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Tests/Add-ImageWatermark.Tests.ps1
+++ b/Tests/Add-ImageWatermark.Tests.ps1
@@ -21,4 +21,20 @@ Describe 'Add-ImageWatermark' {
         $out.Dispose()
         $orig.Dispose()
     }
+
+    It 'adds watermark asynchronously' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'watermark-async.png'
+        $wmk = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        if (Test-Path $dest) { Remove-Item $dest }
+
+        Add-ImageWatermark -FilePath $src -OutputPath $dest -WatermarkPath $wmk -WatermarkPercentage 100 -Async
+        Test-Path $dest | Should -BeTrue
+        $out = [ImagePlayground.Image]::Load($dest)
+        $orig = [ImagePlayground.Image]::Load($src)
+        $out.Width | Should -Be $orig.Width
+        $out.Height | Should -Be $orig.Height
+        $out.Dispose()
+        $orig.Dispose()
+    }
 }

--- a/Tests/Resize-Image.Tests.ps1
+++ b/Tests/Resize-Image.Tests.ps1
@@ -30,6 +30,18 @@ Describe 'Resize-Image' {
 
     }
 
+    It 'resizes an image asynchronously' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dest = Join-Path $TestDir 'logo-small-async.png'
+
+        Resize-Image -FilePath $src -OutputPath $dest -Width 40 -Height 40 -Async
+
+        $img = [ImagePlayground.Image]::Load($dest)
+        $img.Width | Should -Be 40
+        $img.Height | Should -Be 40
+        $img.Dispose()
+    }
+
     It 'resizes an image by percentage' {
 
         $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'


### PR DESCRIPTION
## Summary
- implement `ResizeAsync` and watermark async helpers
- expose `-Async` switch for Resize-Image and Add-ImageWatermark cmdlets
- add async tests for library and cmdlets

## Testing
- `dotnet test Sources/ImagePlayground.sln --no-build --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6857fd40c930832e9774141ffbba5f01