### PR TITLE
Improve XML docs for core helpers

### DIFF
--- a/Sources/ImagePlayground/Helpers.cs
+++ b/Sources/ImagePlayground/Helpers.cs
@@ -4,19 +4,19 @@ using System.IO;
 namespace ImagePlayground;
 public static partial class Helpers {
     /// <summary>
-    /// Converts Color to Hex Color
+    /// Converts a <see cref="SixLabors.ImageSharp.Color"/> to a 6 character hex string.
     /// </summary>
-    /// <param name="c"></param>
-    /// <returns></returns>
+    /// <param name="c">Color value to convert.</param>
+    /// <returns>Hex string without alpha component.</returns>
     public static string ToHexColor(this SixLabors.ImageSharp.Color c) {
         return c.ToHex().Remove(6);
     }
 
     /// <summary>
-    /// Opens up any file using assigned Application
+    /// Opens the specified file using the OS default application if <paramref name="open"/> is <c>true</c>.
     /// </summary>
-    /// <param name="filePath"></param>
-    /// <param name="open"></param>
+    /// <param name="filePath">Path to the file.</param>
+    /// <param name="open">Whether to open the file.</param>
     public static void Open(string filePath, bool open) {
         if (open) {
             ProcessStartInfo startInfo = new ProcessStartInfo(filePath) {

--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -12,57 +12,113 @@ using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Extensions.Transforms;
 
 namespace ImagePlayground;
+
+/// <summary>
+/// Represents an image loaded using ImageSharp and exposes basic manipulation helpers.
+/// </summary>
 public partial class Image : IDisposable {
     private SixLabors.ImageSharp.Image _image;
     private string _filePath;
+
+    /// <summary>Gets the width of the image.</summary>
     public int Width => _image.Width;
+
+    /// <summary>Gets the height of the image.</summary>
     public int Height => _image.Height;
+
+    /// <summary>Gets the path the image was loaded from.</summary>
     public string FilePath => _filePath;
+
+    /// <summary>Gets the metadata associated with the image.</summary>
     public ImageMetadata Metadata => _image.Metadata;
+
+    /// <summary>Gets information about the underlying pixel type.</summary>
     public PixelTypeInfo PixelType => _image.PixelType;
+
+    /// <summary>Gets the frame collection for multi-frame images.</summary>
     public ImageFrameCollection Frames => _image.Frames;
 
+    /// <summary>
+    /// Resampling algorithms used when resizing images.
+    /// </summary>
     public enum Sampler {
+        /// <summary>Nearest neighbour sampling.</summary>
         NearestNeighbor,
+        /// <summary>Box resampling.</summary>
         Box,
+        /// <summary>Triangle resampling.</summary>
         Triangle,
+        /// <summary>Hermite resampling.</summary>
         Hermite,
+        /// <summary>Lanczos with a radius of 2.</summary>
         Lanczos2,
+        /// <summary>Lanczos with a radius of 3.</summary>
         Lanczos3,
+        /// <summary>Lanczos with a radius of 5.</summary>
         Lanczos5,
+        /// <summary>Lanczos with a radius of 8.</summary>
         Lanczos8,
+        /// <summary>Mitchell–Netravali filter.</summary>
         MitchellNetravali,
+        /// <summary>Catmull–Rom spline.</summary>
         CatmullRom,
+        /// <summary>Robidoux filter.</summary>
         Robidoux,
+        /// <summary>Sharper variant of Robidoux filter.</summary>
         RobidouxSharp,
+        /// <summary>B-Spline resampling.</summary>
         Spline,
+        /// <summary>Welch resampling.</summary>
         Welch,
     }
 
+    /// <summary>
+    /// Applies an adaptive threshold filter to the current image.
+    /// </summary>
     public void AdaptiveThreshold() {
         _image.Mutate(x => x.AdaptiveThreshold());
     }
 
+    /// <summary>
+    /// Automatically rotates the image according to EXIF orientation data.
+    /// </summary>
     public void AutoOrient() {
         _image.Mutate(x => x.AutoOrient());
     }
 
+    /// <summary>
+    /// Fills the background with the specified <paramref name="color"/>.
+    /// </summary>
+    /// <param name="color">Fill color.</param>
     public void BackgroundColor(Color color) {
         _image.Mutate(x => x.BackgroundColor(color));
     }
 
+    /// <summary>
+    /// Converts the image to black and white.
+    /// </summary>
     public void BlackWhite() {
         _image.Mutate(x => x.BlackWhite());
     }
 
+    /// <summary>
+    /// Adjusts brightness by the specified <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Brightness adjustment factor.</param>
     public void Brightness(float amount) {
         _image.Mutate(x => x.Brightness(amount));
     }
 
+    /// <summary>
+    /// Applies a bokeh blur effect.
+    /// </summary>
     public void BokehBlur() {
         _image.Mutate(x => x.BokehBlur());
     }
 
+    /// <summary>
+    /// Applies a simple box blur.
+    /// </summary>
     public void BoxBlur() {
         _image.Mutate(x => x.BoxBlur());
     }
@@ -295,6 +351,13 @@ public partial class Image : IDisposable {
         return image;
     }
 
+    /// <summary>
+    /// Saves the image to disk.
+    /// </summary>
+    /// <param name="filePath">Target path or empty to overwrite the original file.</param>
+    /// <param name="openImage">Whether to open the saved file.</param>
+    /// <param name="quality">Optional quality for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
     public void Save(string filePath = "", bool openImage = false, int? quality = null, int? compressionLevel = null) {
         if (filePath == "") {
             filePath = _filePath;

--- a/Sources/ImagePlayground/ImageHelper.Thumbnails.cs
+++ b/Sources/ImagePlayground/ImageHelper.Thumbnails.cs
@@ -4,6 +4,15 @@ using SixLabors.ImageSharp;
 
 namespace ImagePlayground;
 public partial class ImageHelper {
+    /// <summary>
+    /// Generates resized copies for all images found in <paramref name="directoryPath"/>.
+    /// </summary>
+    /// <param name="directoryPath">Folder containing the source images.</param>
+    /// <param name="outputDirectory">Destination folder for the thumbnails.</param>
+    /// <param name="width">Thumbnail width.</param>
+    /// <param name="height">Thumbnail height.</param>
+    /// <param name="keepAspectRatio">Whether to maintain aspect ratio.</param>
+    /// <param name="sampler">Optional sampler algorithm.</param>
     public static void GenerateThumbnails(string directoryPath, string outputDirectory, int width, int height, bool keepAspectRatio = true, Image.Sampler? sampler = null) {
         string inputDir = Helpers.ResolvePath(directoryPath);
         string outDir = Helpers.ResolvePath(outputDirectory);

--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -16,8 +16,10 @@ public partial class ImageHelper {
     /// Converts an image from one format to another.
     /// Following image formats are supported: bmp, gif, jpeg, pbm, png, tga, tiff, webp
     /// </summary>
-    /// <param name="filePath"></param>
-    /// <param name="outFilePath"></param>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="quality">Optional quality value for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
     /// <exception cref="UnknownImageFormatException"></exception>
     public static void ConvertTo(string filePath, string outFilePath, int? quality = null, int? compressionLevel = null) {
         string fullPath = Helpers.ResolvePath(filePath);

--- a/Sources/ImagePlayground/Types.cs
+++ b/Sources/ImagePlayground/Types.cs
@@ -3,20 +3,39 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace ImagePlayground;
+
+/// <summary>
+/// Supported image container formats.
+/// </summary>
 public enum ImageTypes {
+    /// <summary>Bitmap image format.</summary>
     Bmp,
+    /// <summary>GIF image format.</summary>
     Gif,
+    /// <summary>JPEG image format.</summary>
     Jpeg,
+    /// <summary>Portable bitmap format.</summary>
     Pbm,
+    /// <summary>PNG image format.</summary>
     Png,
+    /// <summary>TGA image format.</summary>
     Tga,
+    /// <summary>TIFF image format.</summary>
     Tiff,
+    /// <summary>WebP image format.</summary>
     WebP
 }
 
+/// <summary>
+/// Describes a relative placement for combining images.
+/// </summary>
 public enum ImagePlacement {
+    /// <summary>Place image at the bottom of the canvas.</summary>
     Bottom,
+    /// <summary>Place image on the right side.</summary>
     Right,
+    /// <summary>Place image at the top of the canvas.</summary>
     Top,
+    /// <summary>Place image on the left side.</summary>
     Left
 }


### PR DESCRIPTION
## Summary
- document image helper utilities
- document thumbnail generator and Types enums
- document key members in `Image`
- clean up helper docs

## Testing
- `dotnet build Sources/ImagePlayground/ImagePlayground.csproj -c Release -p:GenerateDocumentationFile=true`
- `dotnet build Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj -c Release -p:GenerateDocumentationFile=true`


------
https://chatgpt.com/codex/tasks/task_e_6858359c2f90832e9d151ce44ddb8925