### PR TITLE
Add ValidateRange attributes and test negative size

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
@@ -62,7 +62,7 @@ public sealed class AddImageWatermarkCmdlet : PSCmdlet {
 
     /// <summary>Tile watermark across the image with given spacing.</summary>
     [Parameter]
-    [ValidateRange(0, int.MaxValue)]
+    [ValidateRange(1, 10000)]
     public int? Spacing { get; set; }
 
     /// <summary>Use asynchronous processing.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
@@ -29,10 +29,12 @@ public sealed class NewImageAvatarCmdlet : PSCmdlet {
 
     /// <summary>Width of the avatar.</summary>
     [Parameter]
+    [ValidateRange(1, 10000)]
     public int Width { get; set; } = 200;
 
     /// <summary>Height of the avatar.</summary>
     [Parameter]
+    [ValidateRange(1, 10000)]
     public int Height { get; set; } = 200;
 
     /// <summary>Corner radius for rounding.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -29,10 +29,12 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
 
     /// <summary>Width of the chart.</summary>
     [Parameter]
+    [ValidateRange(1, 10000)]
     public int Width { get; set; } = 600;
 
     /// <summary>Height of the chart.</summary>
     [Parameter]
+    [ValidateRange(1, 10000)]
     public int Height { get; set; } = 400;
 
     /// <summary>X axis title.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
@@ -24,6 +24,7 @@ public sealed class NewImageIconCmdlet : PSCmdlet {
     /// <summary>Icon sizes to include.</summary>
     /// <para>Defaults to common icon sizes when empty.</para>
     [Parameter]
+    [ValidateRange(1, 10000)]
     public int[] Size { get; set; } = Array.Empty<int>();
 
     /// <summary>Open the icon after saving.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
@@ -21,10 +21,12 @@ public sealed class NewImageThumbnailCmdlet : PSCmdlet {
 
     /// <summary>Thumbnail width.</summary>
     [Parameter]
+    [ValidateRange(1, 10000)]
     public int Width { get; set; } = 100;
 
     /// <summary>Thumbnail height.</summary>
     [Parameter]
+    [ValidateRange(1, 10000)]
     public int Height { get; set; } = 100;
 
     /// <summary>Ignore aspect ratio.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
@@ -31,16 +31,19 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
         /// <summary>New width of the image.</summary>
         /// <para>Used with <see cref="Height"/> when not using <see cref="Percentage"/>.</para>
         [Parameter(ParameterSetName = ParameterSetHeightWidth)]
+        [ValidateRange(1, 10000)]
         public int Width { get; set; }
 
         /// <summary>New height of the image.</summary>
         /// <para>Used with <see cref="Width"/> when not using <see cref="Percentage"/>.</para>
         [Parameter(ParameterSetName = ParameterSetHeightWidth)]
+        [ValidateRange(1, 10000)]
         public int Height { get; set; }
 
         /// <summary>Percentage based resize.</summary>
         /// <para>Applies uniform scaling relative to the original size.</para>
         [Parameter(ParameterSetName = ParameterSetPercentage)]
+        [ValidateRange(1, 10000)]
         public int Percentage { get; set; }
 
         /// <summary>Ignore aspect ratio.</summary>

--- a/Tests/Resize-Image.Tests.ps1
+++ b/Tests/Resize-Image.Tests.ps1
@@ -74,6 +74,13 @@ Describe 'Resize-Image' {
         { Resize-Image -FilePath $src -OutputPath $dest -Percentage -5 } | Should -Throw
     }
 
+    It 'throws for negative dimensions' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dest = Join-Path $TestDir 'logo-invalid-dim.png'
+        { Resize-Image -FilePath $src -OutputPath $dest -Width -5 -Height 10 } | Should -Throw
+        { Resize-Image -FilePath $src -OutputPath $dest -Width 10 -Height -5 } | Should -Throw
+    }
+
 
 }
 


### PR DESCRIPTION
## Summary
- apply `ValidateRange` to several cmdlets for width/height options
- add validation for watermark spacing
- test that `Resize-Image` throws on negative dimensions

## Testing
- `dotnet build Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6859154bdbf0832e80fb35743b73b0c4