### PR TITLE
Add metadata export/import

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletExportImageMetadata.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletExportImageMetadata.cs
@@ -1,0 +1,43 @@
+using ImagePlayground;
+using System.IO;
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+/// <summary>Exports metadata from an image.</summary>
+/// <example>
+///   <summary>Get metadata JSON string</summary>
+///   <code>Export-ImageMetadata -FilePath in.jpg</code>
+/// </example>
+/// <example>
+///   <summary>Save metadata to a file</summary>
+///   <code>Export-ImageMetadata -FilePath in.jpg -OutputPath meta.json</code>
+/// </example>
+[Cmdlet(VerbsData.Export, "ImageMetadata")]
+[OutputType(typeof(string))]
+public sealed class ExportImageMetadataCmdlet : PSCmdlet {
+    /// <summary>Source image file.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>Optional path to write metadata JSON.</summary>
+    [Parameter(Position = 1)]
+    public string? OutputPath { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
+            WriteWarning($"Export-ImageMetadata - File {FilePath} not found. Please check the path.");
+            return;
+        }
+
+        string json = ImageHelper.ExportMetadata(filePath);
+        if (string.IsNullOrWhiteSpace(OutputPath)) {
+            WriteObject(json);
+        } else {
+            var output = Helpers.ResolvePath(OutputPath!);
+            File.WriteAllText(output, json);
+        }
+    }
+}

--- a/Sources/ImagePlayground.PowerShell/CmdletImportImageMetadata.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletImportImageMetadata.cs
@@ -1,0 +1,47 @@
+using ImagePlayground;
+using System.IO;
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+/// <summary>Imports metadata into an image.</summary>
+/// <example>
+///   <summary>Apply metadata from file</summary>
+///   <code>Import-ImageMetadata -FilePath img.jpg -MetadataPath meta.json</code>
+/// </example>
+/// <example>
+///   <summary>Save to new file</summary>
+///   <code>Import-ImageMetadata -FilePath img.jpg -MetadataPath meta.json -OutputPath out.jpg</code>
+/// </example>
+[Cmdlet(VerbsData.Import, "ImageMetadata")]
+public sealed class ImportImageMetadataCmdlet : PSCmdlet {
+    /// <summary>Image to update.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>JSON metadata file.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string MetadataPath { get; set; } = string.Empty;
+
+    /// <summary>Destination image path. Defaults to FilePath.</summary>
+    [Parameter(Position = 2)]
+    public string? OutputPath { get; set; }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        var filePath = Helpers.ResolvePath(FilePath);
+        if (!File.Exists(filePath)) {
+            WriteWarning($"Import-ImageMetadata - File {FilePath} not found. Please check the path.");
+            return;
+        }
+
+        var metaPath = Helpers.ResolvePath(MetadataPath);
+        if (!File.Exists(metaPath)) {
+            WriteWarning($"Import-ImageMetadata - Metadata file {MetadataPath} not found. Please check the path.");
+            return;
+        }
+
+        var output = string.IsNullOrWhiteSpace(OutputPath) ? filePath : Helpers.ResolvePath(OutputPath!);
+        ImageHelper.ImportMetadata(filePath, metaPath, output);
+    }
+}

--- a/Sources/ImagePlayground.Tests/Metadata.cs
+++ b/Sources/ImagePlayground.Tests/Metadata.cs
@@ -1,0 +1,39 @@
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using System.IO;
+using Xunit;
+using PlaygroundImage = ImagePlayground.Image;
+
+namespace ImagePlayground.Tests;
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_Metadata_RoundTrip() {
+        string imgPath = Path.Combine(_directoryWithTests, "metadata.jpg");
+        string metaPath = Path.Combine(_directoryWithTests, "metadata.json");
+        if (File.Exists(imgPath)) File.Delete(imgPath);
+        if (File.Exists(metaPath)) File.Delete(metaPath);
+
+        using (var img = new PlaygroundImage()) {
+            img.Create(imgPath, 10, 10);
+            img.Metadata.HorizontalResolution = 300;
+            img.Metadata.VerticalResolution = 300;
+            img.SetExifValue(ExifTag.Software, "ImagePlayground");
+            img.Save();
+        }
+
+        ImageHelper.ExportMetadata(imgPath, metaPath);
+
+        using (var img = PlaygroundImage.Load(imgPath)) {
+            img.Metadata.HorizontalResolution = 72;
+            img.Metadata.VerticalResolution = 72;
+            img.ClearExifValues();
+            img.Save();
+        }
+
+        ImageHelper.ImportMetadata(imgPath, metaPath, imgPath);
+
+        using var check = PlaygroundImage.Load(imgPath);
+        Assert.Equal(300, check.Metadata.HorizontalResolution);
+        Assert.Equal(300, check.Metadata.VerticalResolution);
+        Assert.Contains(check.GetExifValues(), v => v.Tag == ExifTag.Software && v.GetValue()?.ToString() == "ImagePlayground");
+    }
+}

--- a/Sources/ImagePlayground/ImageHelper.Metadata.cs
+++ b/Sources/ImagePlayground/ImageHelper.Metadata.cs
@@ -1,0 +1,80 @@
+using System.IO;
+using System.Text.Json;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Iptc;
+using SixLabors.ImageSharp.Metadata.Profiles.Xmp;
+
+namespace ImagePlayground;
+public partial class ImageHelper {
+    private sealed class SerializedImageMetadata {
+        public double HorizontalResolution { get; set; }
+        public double VerticalResolution { get; set; }
+        public PixelResolutionUnit ResolutionUnits { get; set; }
+        public byte[]? ExifProfile { get; set; }
+        public byte[]? XmpProfile { get; set; }
+        public byte[]? IccProfile { get; set; }
+        public byte[]? IptcProfile { get; set; }
+    }
+    /// <summary>
+    /// Exports metadata from an image to a JSON string.
+    /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <returns>Serialized metadata.</returns>
+    public static string ExportMetadata(string filePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        using var img = Image.Load(fullPath);
+        var meta = img.Metadata;
+        var data = new SerializedImageMetadata {
+            HorizontalResolution = meta.HorizontalResolution,
+            VerticalResolution = meta.VerticalResolution,
+            ResolutionUnits = meta.ResolutionUnits,
+            ExifProfile = meta.ExifProfile?.ToByteArray(),
+            XmpProfile = meta.XmpProfile?.ToByteArray(),
+            IccProfile = meta.IccProfile?.ToByteArray(),
+            IptcProfile = meta.IptcProfile?.Data
+        };
+        return JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    /// <summary>
+    /// Exports metadata from an image and writes it to a file.
+    /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <param name="outFilePath">Destination file for metadata.</param>
+    public static void ExportMetadata(string filePath, string outFilePath) {
+        string json = ExportMetadata(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        File.WriteAllText(outFullPath, json);
+    }
+
+    /// <summary>
+    /// Imports metadata from a JSON file and saves the updated image.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="metadataFilePath">Path to JSON metadata file.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    public static void ImportMetadata(string filePath, string metadataFilePath, string outFilePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string metaFullPath = Helpers.ResolvePath(metadataFilePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        string json = File.ReadAllText(metaFullPath);
+        SerializedImageMetadata? data = JsonSerializer.Deserialize<SerializedImageMetadata>(json);
+        if (data is null) {
+            throw new InvalidDataException("Metadata file is invalid");
+        }
+
+        using var img = Image.Load(fullPath);
+        img.Metadata.HorizontalResolution = data.HorizontalResolution;
+        img.Metadata.VerticalResolution = data.VerticalResolution;
+        img.Metadata.ResolutionUnits = data.ResolutionUnits;
+        img.Metadata.ExifProfile = data.ExifProfile != null ? new ExifProfile(data.ExifProfile) : null;
+        img.Metadata.XmpProfile = data.XmpProfile != null ? new XmpProfile(data.XmpProfile) : null;
+        img.Metadata.IccProfile = data.IccProfile != null ? new IccProfile(data.IccProfile) : null;
+        img.Metadata.IptcProfile = data.IptcProfile != null ? new IptcProfile(data.IptcProfile) : null;
+        img.Save(outFullPath);
+    }
+}

--- a/Sources/ImagePlayground/ImagePlayground.csproj
+++ b/Sources/ImagePlayground/ImagePlayground.csproj
@@ -28,6 +28,7 @@
         <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
         <PackageReference Include="System.Memory" Version="4.5.5" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageReference Include="System.Text.Json" Version="8.0.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- add metadata serialization helpers
- create new Export-ImageMetadata/Import-ImageMetadata cmdlets
- test metadata round-trip

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0 --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6859157efe9c832eb063b1086e177df8