### PR TITLE
Add thumbnail cache with clearing cmdlet

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,9 @@
 - Fix signing
 - Small fixes
 
+### 0.0.9 - 2024.06.05
+- Added thumbnail caching and `Clear-ImageThumbnailCache` cmdlet
+
 ### 0.0.7 - 2024.06.05
 - Add another method `$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png",50,100, 0.5, 0.5)`
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,9 +3,6 @@
 - Fix signing
 - Small fixes
 
-### 0.0.9 - 2024.06.05
-- Added thumbnail caching and `Clear-ImageThumbnailCache` cmdlet
-
 ### 0.0.7 - 2024.06.05
 - Add another method `$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png",50,100, 0.5, 0.5)`
 

--- a/ImagePlayground.psd1
+++ b/ImagePlayground.psd1
@@ -45,6 +45,7 @@
         'New-ImageQRCodeSwiss',
         'New-ImageGif',
         'New-ImageThumbnail',
+        'Clear-ImageThumbnailCache',
         'Remove-ImageExif',
         'Resize-Image',
         'Save-Image',

--- a/README.MD
+++ b/README.MD
@@ -91,6 +91,7 @@ It works fine when running in PowerShell 5.1 console, or ISE (shrug!).
 - `New-ImageQRCodeWiFi` - Creates a WiFi QR code image.
 - `New-ImageQRContact` - Generates a QR code image containing the provided contact details.
 - `New-ImageThumbnail` - Creates thumbnails for all images in a directory.
+- `Clear-ImageThumbnailCache` - Removes cached thumbnails.
 - `Remove-ImageExif` - Removes EXIF metadata from an image.
 - `Resize-Image` - Resizes an image.
 - `Save-Image` - Saves an image to disk.

--- a/Sources/ImagePlayground.PowerShell/CmdletClearImageThumbnailCache.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletClearImageThumbnailCache.cs
@@ -1,0 +1,12 @@
+using System.Management.Automation;
+
+namespace ImagePlayground.PowerShell;
+
+/// <summary>Clears cached thumbnails.</summary>
+[Cmdlet(VerbsCommon.Clear, "ImageThumbnailCache")]
+public sealed class ClearImageThumbnailCacheCmdlet : PSCmdlet {
+    /// <inheritdoc />
+    protected override void ProcessRecord() {
+        ImagePlayground.ImageHelper.ClearThumbnailCache();
+    }
+}

--- a/Sources/ImagePlayground/ImageHelper.GetImageThumbnail.cs
+++ b/Sources/ImagePlayground/ImageHelper.GetImageThumbnail.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground;
+public partial class ImageHelper {
+    private static string GetThumbnailCacheDirectory() {
+        string dir = Path.Combine(Path.GetTempPath(), "ImagePlayground", "thumbnails");
+        if (!Directory.Exists(dir)) {
+            Directory.CreateDirectory(dir);
+        }
+        return dir;
+    }
+
+    private static string ComputeFileHash(string path) {
+        using var stream = File.OpenRead(path);
+        using var sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(stream);
+        return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Gets a thumbnail for the specified image. The thumbnail is cached based on the image hash.
+    /// </summary>
+    /// <param name="filePath">Path to the image file.</param>
+    /// <param name="width">Thumbnail width.</param>
+    /// <param name="height">Thumbnail height.</param>
+    /// <param name="keepAspectRatio">Whether to maintain aspect ratio.</param>
+    /// <param name="sampler">Optional sampler algorithm.</param>
+    /// <returns>Thumbnail image.</returns>
+    public static Image GetImageThumbnail(string filePath, int width, int height, bool keepAspectRatio = true, Image.Sampler? sampler = null) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string hash = ComputeFileHash(fullPath);
+        string cacheDir = GetThumbnailCacheDirectory();
+        string thumbPath = Path.Combine(cacheDir, $"{hash}_{width}x{height}.png");
+
+        if (!File.Exists(thumbPath)) {
+            Resize(fullPath, thumbPath, width, height, keepAspectRatio, sampler);
+        }
+
+        return Image.Load(thumbPath);
+    }
+
+    /// <summary>
+    /// Removes all cached thumbnails.
+    /// </summary>
+    public static void ClearThumbnailCache() {
+        string cacheDir = Path.Combine(Path.GetTempPath(), "ImagePlayground", "thumbnails");
+        if (Directory.Exists(cacheDir)) {
+            Directory.Delete(cacheDir, true);
+        }
+    }
+}

--- a/Tests/Clear-ImageThumbnailCache.Tests.ps1
+++ b/Tests/Clear-ImageThumbnailCache.Tests.ps1
@@ -1,0 +1,18 @@
+Describe 'Clear-ImageThumbnailCache' {
+
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
+        $TestDir = Join-Path $PSScriptRoot 'Artifacts'
+        if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
+    }
+
+    It 'clears cached thumbnails' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $img = [ImagePlayground.ImageHelper]::GetImageThumbnail($src, 20, 20)
+        $cache = $img.FilePath
+        $img.Dispose()
+        Test-Path $cache | Should -BeTrue
+        Clear-ImageThumbnailCache
+        Test-Path $cache | Should -BeFalse
+    }
+}


### PR DESCRIPTION
## Summary
- cache thumbnails generated by `GetImageThumbnail`
- expose `Clear-ImageThumbnailCache` PowerShell cmdlet
- document new command and feature
- test clearing thumbnail cache

## Testing
- `dotnet test Sources/ImagePlayground.sln`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6859157733ec832e9d786679b315d93b