### PR TITLE
Add URL support to ResolvePath

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,4 @@
-﻿### 0.0.8 - 2024.06.05
+### 0.0.8 - 2024.06.05
 - Bump dependencies
 - Fix signing
 - Small fixes

--- a/Examples/Helpers.ResolvePath.ps1
+++ b/Examples/Helpers.ResolvePath.ps1
@@ -1,0 +1,10 @@
+Import-Module .\ImagePlayground.psd1 -Force
+
+# Resolve a remote file path. The temporary file is removed after processing.
+$url = 'https://example.com/image.png'
+$path = [ImagePlayground.Helpers]::ResolvePath($url)
+Write-Host "Downloaded to $path"
+
+# Do something with the file...
+
+[ImagePlayground.Helpers]::CleanupTempFiles()


### PR DESCRIPTION
## Summary
- enhance `Helpers.ResolvePath` to download http(s) URLs and keep track of temp files
- add method to clean temp files
- document remote path resolving with a standalone example
- test new URL resolving behavior using a dynamic port

## Testing
- `dotnet restore Sources/ImagePlayground.sln`
- `dotnet build Sources/ImagePlayground.sln --configuration Release --no-restore`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --configuration Release --framework net8.0 --no-build`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1` *(fails: Get-Image not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6859154745a0832ea13290e58fa33069