### PR TITLE
Add avatar helper docs

### DIFF
--- a/Sources/ImagePlayground/ImageHelper.Avatar.cs
+++ b/Sources/ImagePlayground/ImageHelper.Avatar.cs
@@ -3,6 +3,14 @@ using SixLabors.ImageSharp;
 
 namespace ImagePlayground;
 public partial class ImageHelper {
+    /// <summary>
+    /// Converts an image file to an avatar and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination file path.</param>
+    /// <param name="width">Width of the avatar.</param>
+    /// <param name="height">Height of the avatar.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
     public static void Avatar(string filePath, string outFilePath, int width, int height, float cornerRadius) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
@@ -11,6 +19,14 @@ public partial class ImageHelper {
         img.SaveAsAvatar(outFullPath, width, height, cornerRadius);
     }
 
+    /// <summary>
+    /// Converts an image file to an avatar and writes it to a stream.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outStream">Destination stream.</param>
+    /// <param name="width">Width of the avatar.</param>
+    /// <param name="height">Height of the avatar.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
     public static void Avatar(string filePath, Stream outStream, int width, int height, float cornerRadius) {
         string fullPath = Helpers.ResolvePath(filePath);
 
@@ -18,6 +34,12 @@ public partial class ImageHelper {
         img.SaveAsAvatar(outStream, width, height, cornerRadius);
     }
 
+    /// <summary>
+    /// Converts an image file to a circular avatar and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination file path.</param>
+    /// <param name="size">Diameter of the avatar.</param>
     public static void AvatarCircular(string filePath, string outFilePath, int size) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
@@ -26,6 +48,12 @@ public partial class ImageHelper {
         img.SaveAsCircularAvatar(outFullPath, size);
     }
 
+    /// <summary>
+    /// Converts an image file to a circular avatar and writes it to a stream.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outStream">Destination stream.</param>
+    /// <param name="size">Diameter of the avatar.</param>
     public static void AvatarCircular(string filePath, Stream outStream, int size) {
         string fullPath = Helpers.ResolvePath(filePath);
 


### PR DESCRIPTION
## Summary
- add missing XML docs for Avatar helper methods

## Testing
- `dotnet build Sources/ImagePlayground/ImagePlayground.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685ba9d5847c832eac5bfcdf4e5f5b93