### PR TITLE
Document Compare overloads

### DIFF
--- a/Sources/ImagePlayground/ImageHelper.Compare.cs
+++ b/Sources/ImagePlayground/ImageHelper.Compare.cs
@@ -4,6 +4,12 @@ using Codeuctivity.ImageSharpCompare;
 namespace ImagePlayground;
 public partial class ImageHelper {
 
+    /// <summary>
+    /// Compares two images and returns the difference result.
+    /// </summary>
+    /// <param name="filePath">Path to the first image.</param>
+    /// <param name="filePathToCompare">Path to the image to compare against.</param>
+    /// <returns>Comparison result.</returns>
     public static ICompareResult Compare(string filePath, string filePathToCompare) {
         string fullPath = Helpers.ResolvePath(filePath);
         string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);
@@ -11,6 +17,12 @@ public partial class ImageHelper {
         return ImageSharpCompare.CalcDiff(fullPath, fullPathToCompare);
     }
 
+    /// <summary>
+    /// Compares two images and saves the difference mask.
+    /// </summary>
+    /// <param name="filePath">Path to the first image.</param>
+    /// <param name="filePathToCompare">Path to the image to compare against.</param>
+    /// <param name="filePathToSave">Destination path for the difference mask.</param>
     public static void Compare(string filePath, string filePathToCompare, string filePathToSave) {
         string fullPath = Helpers.ResolvePath(filePath);
         string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);


### PR DESCRIPTION
## Summary
- add XML docs for both `ImageHelper.Compare` overloads

## Testing
- `dotnet restore Sources/ImagePlayground.sln`
- `dotnet build Sources/ImagePlayground.sln --configuration Release --no-restore`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --configuration Release --framework net8.0 --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_685ba9c38de4832e87b55eb747b77b19