### PR TITLE
Add XML docs for image helpers

### DIFF
--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -123,14 +123,28 @@ public partial class Image : IDisposable {
         _image.Mutate(x => x.BoxBlur());
     }
 
+    /// <summary>
+    /// Adjusts contrast by the specified <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Contrast adjustment factor.</param>
     public void Contrast(float amount) {
         _image.Mutate(x => x.Contrast(amount));
     }
 
+    /// <summary>
+    /// Compares the current image with <paramref name="imageToCompare"/>.
+    /// </summary>
+    /// <param name="imageToCompare">Image to compare with.</param>
+    /// <returns>Comparison result.</returns>
     public ICompareResult Compare(Image imageToCompare) {
         return ImageSharpCompare.CalcDiff(_image, imageToCompare._image);
     }
 
+    /// <summary>
+    /// Compares the current image with the file at <paramref name="filePathToCompare"/>.
+    /// </summary>
+    /// <param name="filePathToCompare">Path to the image to compare with.</param>
+    /// <returns>Comparison result.</returns>
     public ICompareResult Compare(string filePathToCompare) {
         string fullPath = Helpers.ResolvePath(filePathToCompare);
 
@@ -139,6 +153,11 @@ public partial class Image : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Creates a difference mask between this image and <paramref name="imageToCompare"/> and saves it.
+    /// </summary>
+    /// <param name="imageToCompare">Image to compare with.</param>
+    /// <param name="filePathToSave">Output path for the mask image.</param>
     public void Compare(Image imageToCompare, string filePathToSave) {
         string outFullPath = Helpers.ResolvePath(filePathToSave);
         using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
@@ -148,6 +167,11 @@ public partial class Image : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Creates a difference mask between this image and the file at <paramref name="filePathToCompare"/> and saves it.
+    /// </summary>
+    /// <param name="filePathToCompare">Path to the image to compare with.</param>
+    /// <param name="filePathToSave">Output path for the mask image.</param>
     public void Compare(string filePathToCompare, string filePathToSave) {
         string fullPath = Helpers.ResolvePath(filePathToCompare);
         string outFullPath = Helpers.ResolvePath(filePathToSave);
@@ -161,37 +185,78 @@ public partial class Image : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Crops the image to the specified <paramref name="rectangle"/>.
+    /// </summary>
+    /// <param name="rectangle">Crop rectangle.</param>
     public void Crop(Rectangle rectangle) {
         _image.Mutate(x => x.Crop(rectangle));
     }
+
+    /// <summary>
+    /// Applies a dithering effect.
+    /// </summary>
     public void Dither() {
         _image.Mutate(x => x.Dither());
     }
 
+    /// <summary>
+    /// Draws a line ending at <paramref name="pointF"/> using the specified <paramref name="color"/> and <paramref name="thickness"/>.
+    /// </summary>
+    /// <param name="color">Line color.</param>
+    /// <param name="thickness">Line thickness.</param>
+    /// <param name="pointF">End point of the line.</param>
     public void DrawLines(Color color, float thickness, PointF pointF) {
         _image.Mutate(x => x.DrawLine(color, thickness, pointF));
     }
 
+    /// <summary>
+    /// Draws a polygon with the specified parameters.
+    /// </summary>
+    /// <param name="color">Polygon color.</param>
+    /// <param name="thickness">Outline thickness.</param>
+    /// <param name="pointF">Polygon vertex.</param>
     public void DrawPolygon(Color color, float thickness, PointF pointF) {
         _image.Mutate(x => x.DrawPolygon(color, thickness, pointF));
     }
 
+    /// <summary>
+    /// Applies a color <paramref name="colorMatrix"/> filter.
+    /// </summary>
+    /// <param name="colorMatrix">Color matrix to apply.</param>
     public void Filter(ColorMatrix colorMatrix) {
         _image.Mutate(x => x.Filter(colorMatrix));
     }
 
+    /// <summary>
+    /// Fills the image with <paramref name="color"/>.
+    /// </summary>
+    /// <param name="color">Fill color.</param>
     public void Fill(Color color) {
         _image.Mutate(x => x.Fill(color));
     }
 
+    /// <summary>
+    /// Fills the specified <paramref name="rectangle"/> with <paramref name="color"/>.
+    /// </summary>
+    /// <param name="color">Fill color.</param>
+    /// <param name="rectangle">Target rectangle.</param>
     public void Fill(Color color, Rectangle rectangle) {
         _image.Mutate(x => x.Fill(color, rectangle));
     }
 
+    /// <summary>
+    /// Flips the image using the provided <paramref name="flipMode"/>.
+    /// </summary>
+    /// <param name="flipMode">Flip mode.</param>
     public void Flip(FlipMode flipMode) {
         _image.Mutate(x => x.Flip(flipMode));
     }
 
+    /// <summary>
+    /// Applies a Gaussian blur using the optional <paramref name="sigma"/> value.
+    /// </summary>
+    /// <param name="sigma">Blur radius.</param>
     public void GaussianBlur(float? sigma) {
         if (sigma != null) {
             _image.Mutate(x => x.GaussianBlur(sigma.Value));
@@ -200,6 +265,10 @@ public partial class Image : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Sharpens the image using a Gaussian algorithm.
+    /// </summary>
+    /// <param name="sigma">Sharpen strength.</param>
     public void GaussianSharpen(float? sigma) {
         if (sigma != null) {
             _image.Mutate(x => x.GaussianSharpen(sigma.Value));
@@ -207,69 +276,136 @@ public partial class Image : IDisposable {
             _image.Mutate(x => x.GaussianSharpen());
         }
     }
+
+    /// <summary>
+    /// Performs histogram equalization on the image.
+    /// </summary>
     public void HistogramEqualization() {
         _image.Mutate(x => x.HistogramEqualization());
     }
 
+    /// <summary>
+    /// Shifts hue by the specified <paramref name="degrees"/>.
+    /// </summary>
+    /// <param name="degrees">Hue rotation in degrees.</param>
     public void Hue(float degrees) {
         _image.Mutate(x => x.Hue(degrees));
     }
 
+    /// <summary>
+    /// Converts the image to grayscale using the specified <paramref name="grayscaleMode"/>.
+    /// </summary>
+    /// <param name="grayscaleMode">Grayscale conversion mode.</param>
     public void Grayscale(GrayscaleMode grayscaleMode = GrayscaleMode.Bt709) {
         _image.Mutate(x => x.Grayscale(grayscaleMode));
     }
 
+    /// <summary>
+    /// Applies a Kodachrome color filter.
+    /// </summary>
     public void Kodachrome() {
         _image.Mutate(x => x.Kodachrome());
     }
 
+    /// <summary>
+    /// Adjusts lightness by <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Lightness factor.</param>
     public void Lightness(float amount) {
         _image.Mutate(x => x.Lightness(amount));
     }
+
+    /// <summary>
+    /// Applies a lomograph effect.
+    /// </summary>
     public void Lomograph() {
         _image.Mutate(x => x.Lomograph());
     }
 
+    /// <summary>
+    /// Inverts the colors of the image.
+    /// </summary>
     public void Invert() {
         _image.Mutate(x => x.Invert());
     }
 
+    /// <summary>
+    /// Changes opacity by the given <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Opacity factor.</param>
     public void Opacity(float amount) {
         _image.Mutate(x => x.Opacity(amount));
     }
 
+    /// <summary>
+    /// Applies a Polaroid style filter.
+    /// </summary>
     public void Polaroid() {
         _image.Mutate(x => x.Polaroid());
     }
 
+    /// <summary>
+    /// Pixelates the image with a default size.
+    /// </summary>
     public void Pixelate() {
         _image.Mutate(x => x.Pixelate());
     }
 
+    /// <summary>
+    /// Pixelates the image using the specified <paramref name="size"/>.
+    /// </summary>
+    /// <param name="size">Pixel block size.</param>
     public void Pixelate(int size) {
         _image.Mutate(x => x.Pixelate(size));
     }
 
+    /// <summary>
+    /// Applies an oil paint effect using default options.
+    /// </summary>
     public void OilPaint() {
         _image.Mutate(x => x.OilPaint());
     }
 
+    /// <summary>
+    /// Applies an oil paint effect with the given parameters.
+    /// </summary>
+    /// <param name="levels">Number of intensity levels.</param>
+    /// <param name="brushSize">Brush size.</param>
     public void OilPaint(int levels, int brushSize) {
         _image.Mutate(x => x.OilPaint(levels, brushSize));
     }
 
+    /// <summary>
+    /// Rotates the image using the specified <paramref name="rotateMode"/>.
+    /// </summary>
+    /// <param name="rotateMode">Rotation mode.</param>
     public void Rotate(RotateMode rotateMode) {
         _image.Mutate(x => x.Rotate(rotateMode));
     }
 
+    /// <summary>
+    /// Rotates the image by an arbitrary number of <paramref name="degrees"/>.
+    /// </summary>
+    /// <param name="degrees">Angle in degrees.</param>
     public void Rotate(float degrees) {
         _image.Mutate(x => x.Rotate(degrees: degrees));
     }
 
+    /// <summary>
+    /// Rotates and flips the image in a single operation.
+    /// </summary>
+    /// <param name="rotateMode">Rotation mode.</param>
+    /// <param name="flipMode">Flip mode.</param>
     public void RotateFlip(RotateMode rotateMode, FlipMode flipMode) {
         _image.Mutate(x => x.RotateFlip(rotateMode, flipMode));
     }
 
+    /// <summary>
+    /// Resizes the image to the specified dimensions.
+    /// </summary>
+    /// <param name="width">New width.</param>
+    /// <param name="height">New height.</param>
+    /// <param name="keepAspectRatio">Maintain aspect ratio if possible.</param>
     public void Resize(int? width, int? height, bool keepAspectRatio = true) {
         if (width == null && height == null) {
             return;
@@ -290,6 +426,10 @@ public partial class Image : IDisposable {
         _image.Mutate(x => x.Resize(options));
     }
 
+    /// <summary>
+    /// Resizes the image by a <paramref name="percentage"/> of the current size.
+    /// </summary>
+    /// <param name="percentage">Scale percentage.</param>
     public void Resize(int percentage) {
         if (percentage <= 0) {
             throw new ArgumentOutOfRangeException(nameof(percentage));
@@ -304,30 +444,58 @@ public partial class Image : IDisposable {
         _image.Mutate(x => x.Resize(options));
     }
 
+    /// <summary>
+    /// Changes saturation by the specified <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Saturation factor.</param>
     public void Saturate(float amount) {
         _image.Mutate(x => x.Saturate(amount));
     }
 
+    /// <summary>
+    /// Applies a sepia tone effect.
+    /// </summary>
     public void Sepia() {
         _image.Mutate(x => x.Sepia());
     }
 
+    /// <summary>
+    /// Applies a sepia tone effect with the given <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Sepia intensity.</param>
     public void Sepia(float amount) {
         _image.Mutate(x => x.Sepia(amount));
     }
 
+    /// <summary>
+    /// Skews the image by the specified angles.
+    /// </summary>
+    /// <param name="degreesX">Skew angle on the X axis.</param>
+    /// <param name="degreesY">Skew angle on the Y axis.</param>
     public void Skew(float degreesX, float degreesY) {
         _image.Mutate(x => x.Skew(degreesX, degreesY));
     }
 
+    /// <summary>
+    /// Adds a vignette effect using default options.
+    /// </summary>
     public void Vignette() {
         _image.Mutate(x => x.Vignette());
     }
 
+    /// <summary>
+    /// Adds a vignette effect using the specified <paramref name="color"/>.
+    /// </summary>
+    /// <param name="color">Vignette color.</param>
     public void Vignette(Color color) {
         _image.Mutate(x => x.Vignette(color));
     }
 
+    /// <summary>
+    /// Loads an <see cref="SixLabors.ImageSharp.Image"/> from disk.
+    /// </summary>
+    /// <param name="filePath">Path to the image file.</param>
+    /// <returns>The loaded image.</returns>
     public static SixLabors.ImageSharp.Image GetImage(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
         using (var inStream = System.IO.File.OpenRead(fullPath)) {
@@ -335,11 +503,22 @@ public partial class Image : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Creates a new blank image and assigns the provided <paramref name="filePath"/>.
+    /// </summary>
+    /// <param name="filePath">Path where the image will be saved.</param>
+    /// <param name="width">Image width.</param>
+    /// <param name="height">Image height.</param>
     public void Create(string filePath, int width, int height) {
         _filePath = filePath;
         _image = new Image<Rgba32>(width, height);
     }
 
+    /// <summary>
+    /// Loads an image from the specified path.
+    /// </summary>
+    /// <param name="filePath">Path to the image file.</param>
+    /// <returns>Loaded <see cref="Image"/> instance.</returns>
     public static Image Load(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
 
@@ -369,10 +548,20 @@ public partial class Image : IDisposable {
         Helpers.Open(filePath, openImage);
     }
 
+    /// <summary>
+    /// Saves the image overwriting the original file and optionally opens it.
+    /// </summary>
+    /// <param name="openImage">Whether to open the saved file.</param>
     public void Save(bool openImage) {
         Save("", openImage, null, null);
     }
 
+    /// <summary>
+    /// Saves the image to the provided <paramref name="stream"/>.
+    /// </summary>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="quality">Optional quality for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
     public void Save(Stream stream, int? quality = null, int? compressionLevel = null) {
         string extension = System.IO.Path.GetExtension(_filePath)?.ToLowerInvariant();
         var encoder = Helpers.GetEncoder(extension, quality, compressionLevel);
@@ -380,12 +569,21 @@ public partial class Image : IDisposable {
         stream.Seek(0, SeekOrigin.Begin);
     }
 
+    /// <summary>
+    /// Converts the image to a memory stream.
+    /// </summary>
+    /// <param name="quality">Optional quality for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
+    /// <returns>Stream containing the image data.</returns>
     public MemoryStream ToStream(int? quality = null, int? compressionLevel = null) {
         var ms = new MemoryStream();
         Save(ms, quality, compressionLevel);
         return ms;
     }
 
+    /// <summary>
+    /// Disposes the underlying image resources.
+    /// </summary>
     public void Dispose() {
         if (_image != null) {
             _image.Dispose();


### PR DESCRIPTION
## Summary
- document public methods in `Image.cs`

## Testing
- `dotnet restore Sources/ImagePlayground.sln`
- `dotnet build Sources/ImagePlayground.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685ba9c8ad54832e8e2c5064d7fd6ed2