### PR TITLE
Add inheritdoc to QR code cmdlets

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
@@ -48,6 +48,7 @@ public sealed class NewImageQrCodeBezahlCodeCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
@@ -40,6 +40,7 @@ public sealed class NewImageQrCodeBitcoinCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
@@ -40,6 +40,7 @@ public sealed class NewImageQrCodeGirocodeCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
@@ -40,6 +40,7 @@ public sealed class NewImageQrCodeMoneroCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
@@ -24,6 +24,7 @@ public sealed class NewImageQrCodeOtpCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
@@ -24,6 +24,7 @@ public sealed class NewImageQrCodePhoneNumberCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
@@ -40,6 +40,7 @@ public sealed class NewImageQrCodeShadowSocksCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
@@ -24,6 +24,7 @@ public sealed class NewImageQrCodeSkypeCallCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
@@ -24,6 +24,7 @@ public sealed class NewImageQrCodeSlovenianUpnQrCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
@@ -24,6 +24,7 @@ public sealed class NewImageQrCodeSwissCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");


### PR DESCRIPTION
## Summary
- fix XML documentation warnings by adding `<inheritdoc/>` comments to QR code cmdlets

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685feb45e218832eacf7748d114b79b5