### PR TITLE
Fix docs for partial classes

### DIFF
--- a/Sources/ImagePlayground/Image.Avatar.cs
+++ b/Sources/ImagePlayground/Image.Avatar.cs
@@ -6,6 +6,9 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
 public partial class Image : IDisposable {
     /// <summary>
     /// Converts the image into an avatar with the specified size and corner radius.

--- a/Sources/ImagePlayground/Image.Crop.cs
+++ b/Sources/ImagePlayground/Image.Crop.cs
@@ -5,6 +5,9 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
 public partial class Image : System.IDisposable {
     /// <summary>
     /// Crops the image to a circular region.

--- a/Sources/ImagePlayground/Image.Exif.cs
+++ b/Sources/ImagePlayground/Image.Exif.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
 public partial class Image {
     /// <summary>
     /// Gets all EXIF values from the image.

--- a/Sources/ImagePlayground/Image.Icon.cs
+++ b/Sources/ImagePlayground/Image.Icon.cs
@@ -7,6 +7,9 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
 public partial class Image {
     /// <summary>
     /// Saves the image in ICO format using multiple resolutions.

--- a/Sources/ImagePlayground/Image.Image.cs
+++ b/Sources/ImagePlayground/Image.Image.cs
@@ -4,6 +4,9 @@ using SixLabors.ImageSharp.Processing;
 
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
 public partial class Image : IDisposable {
     /// <summary>
     /// Draws another image onto the current image from a file path.

--- a/Sources/ImagePlayground/Image.Text.cs
+++ b/Sources/ImagePlayground/Image.Text.cs
@@ -7,6 +7,9 @@ using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
 public partial class Image : IDisposable {
     /// <summary>
     /// Calculates the dimensions required to render <paramref name="text"/> using the specified font.

--- a/Sources/ImagePlayground/Image.Watermark.cs
+++ b/Sources/ImagePlayground/Image.Watermark.cs
@@ -7,6 +7,9 @@ using FontStyle = SixLabors.Fonts.FontStyle;
 using PointF = SixLabors.ImageSharp.PointF;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
 public partial class Image : IDisposable {
 
     public enum WatermarkPlacement {

--- a/Sources/ImagePlayground/ImageHelper.AddText.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddText.cs
@@ -2,6 +2,9 @@ using System.IO;
 using SixLabors.ImageSharp;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
     /// <summary>
     /// Adds text to an image file and saves the result.

--- a/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
@@ -4,6 +4,9 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
     /// <summary>
     /// Adds an image watermark at one of the predefined placements.

--- a/Sources/ImagePlayground/ImageHelper.Avatar.cs
+++ b/Sources/ImagePlayground/ImageHelper.Avatar.cs
@@ -2,6 +2,9 @@ using System.IO;
 using SixLabors.ImageSharp;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
     /// <summary>
     /// Converts an image file to an avatar and saves the result.

--- a/Sources/ImagePlayground/ImageHelper.Base64.cs
+++ b/Sources/ImagePlayground/ImageHelper.Base64.cs
@@ -2,6 +2,9 @@ using System;
 using System.IO;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
     /// <summary>
     /// Reads an image file and returns its Base64 representation.

--- a/Sources/ImagePlayground/ImageHelper.Compare.cs
+++ b/Sources/ImagePlayground/ImageHelper.Compare.cs
@@ -2,6 +2,9 @@
 using Codeuctivity.ImageSharpCompare;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
 
     /// <summary>

--- a/Sources/ImagePlayground/ImageHelper.Crop.cs
+++ b/Sources/ImagePlayground/ImageHelper.Crop.cs
@@ -2,6 +2,9 @@ using System.IO;
 using SixLabors.ImageSharp;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
     /// <summary>
     /// Crops an image to the specified rectangle and saves the result.

--- a/Sources/ImagePlayground/ImageHelper.GetImageThumbnail.cs
+++ b/Sources/ImagePlayground/ImageHelper.GetImageThumbnail.cs
@@ -4,6 +4,9 @@ using System.Security.Cryptography;
 using SixLabors.ImageSharp;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
     private static string GetThumbnailCacheDirectory() {
         string dir = Path.Combine(Path.GetTempPath(), "ImagePlayground", "thumbnails");

--- a/Sources/ImagePlayground/ImageHelper.Metadata.cs
+++ b/Sources/ImagePlayground/ImageHelper.Metadata.cs
@@ -8,14 +8,33 @@ using SixLabors.ImageSharp.Metadata.Profiles.Iptc;
 using SixLabors.ImageSharp.Metadata.Profiles.Xmp;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
+    /// <summary>
+    /// Serialization model for image metadata.
+    /// </summary>
     private sealed class SerializedImageMetadata {
+        /// <summary>Horizontal resolution.</summary>
         public double HorizontalResolution { get; set; }
+
+        /// <summary>Vertical resolution.</summary>
         public double VerticalResolution { get; set; }
+
+        /// <summary>Resolution measurement units.</summary>
         public PixelResolutionUnit ResolutionUnits { get; set; }
+
+        /// <summary>Serialized Exif profile.</summary>
         public byte[]? ExifProfile { get; set; }
+
+        /// <summary>Serialized XMP profile.</summary>
         public byte[]? XmpProfile { get; set; }
+
+        /// <summary>Serialized ICC profile.</summary>
         public byte[]? IccProfile { get; set; }
+
+        /// <summary>Serialized IPTC profile.</summary>
         public byte[]? IptcProfile { get; set; }
     }
     /// <summary>

--- a/Sources/ImagePlayground/ImageHelper.Thumbnails.cs
+++ b/Sources/ImagePlayground/ImageHelper.Thumbnails.cs
@@ -3,6 +3,9 @@ using System.IO;
 using SixLabors.ImageSharp;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
     /// <summary>
     /// Generates resized copies for all images found in <paramref name="directoryPath"/>.

--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -11,6 +11,9 @@ using SixLabors.ImageSharp.Processing.Processors.Transforms;
 using Color = SixLabors.ImageSharp.Color;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
 public partial class ImageHelper {
     /// <summary>
     /// Converts an image from one format to another.


### PR DESCRIPTION
## Summary
- add summary comments to partial classes
- document metadata helper model

## Testing
- `dotnet test Sources/ImagePlayground.sln` *(fails: Could not find 'mono' host)*
- `Invoke-Pester` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b803b9ee0832ea784357b0b25588d