### PR TITLE
Improve XML documentation across core library

### DIFF
--- a/Sources/ImagePlayground/BarCode.cs
+++ b/Sources/ImagePlayground/BarCode.cs
@@ -21,6 +21,10 @@ namespace ImagePlayground;
 /// <summary>
 /// Helper methods for generating and reading barcodes.
 /// </summary>
+/// <remarks>
+/// The methods in this class use the Barcoder library to create barcode images
+/// and ImageSharp for rendering.
+/// </remarks>
 public class BarCode {
     /// <summary>Supported barcode formats.</summary>
     public enum BarcodeTypes {

--- a/Sources/ImagePlayground/Charts.cs
+++ b/Sources/ImagePlayground/Charts.cs
@@ -8,6 +8,9 @@ using ImageColor = SixLabors.ImageSharp.Color;
 namespace ImagePlayground;
 
 /// <summary>Chart generation helpers.</summary>
+/// <remarks>
+/// Uses ScottPlot under the hood to render chart images.
+/// </remarks>
 public static class Charts {
     /// <summary>Type of chart definition.</summary>
     public enum ChartDefinitionType {

--- a/Sources/ImagePlayground/GIF.cs
+++ b/Sources/ImagePlayground/GIF.cs
@@ -9,6 +9,9 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace ImagePlayground;
 /// <summary>Helper methods for creating animated GIFs.</summary>
+/// <remarks>
+/// Each frame is loaded using ImageSharp and combined into a single GIF image.
+/// </remarks>
 public static class Gif {
     /// <summary>
     /// Generates an animated GIF from a set of images.

--- a/Sources/ImagePlayground/Helpers.Encoder.cs
+++ b/Sources/ImagePlayground/Helpers.Encoder.cs
@@ -11,6 +11,9 @@ using SixLabors.ImageSharp.Formats.Tiff;
 using SixLabors.ImageSharp.Formats.Webp;
 
 namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for selecting the right image encoder.
+/// </summary>
 public static partial class Helpers {
     /// <summary>
     /// Returns an image encoder instance appropriate for the given file extension.

--- a/Sources/ImagePlayground/Helpers.Resampler.cs
+++ b/Sources/ImagePlayground/Helpers.Resampler.cs
@@ -2,6 +2,9 @@ using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
 
 namespace ImagePlayground;
+/// <summary>
+/// Resolves sampler options to ImageSharp resampler instances.
+/// </summary>
 public static partial class Helpers {
     /// <summary>
     /// Maps the <see cref="Image.Sampler"/> enumeration to a concrete resampler implementation.

--- a/Sources/ImagePlayground/Helpers.cs
+++ b/Sources/ImagePlayground/Helpers.cs
@@ -2,6 +2,9 @@
 using System.IO;
 
 namespace ImagePlayground;
+/// <summary>
+/// General helper utilities for file access and process handling.
+/// </summary>
 public static partial class Helpers {
     /// <summary>
     /// Converts a <see cref="SixLabors.ImageSharp.Color"/> to a 6 character hex string.

--- a/Sources/ImagePlayground/Image.Icon.cs
+++ b/Sources/ImagePlayground/Image.Icon.cs
@@ -10,6 +10,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides image manipulation operations.
 /// </summary>
+/// <remarks>
+/// Icon files can contain multiple resolutions which are generated automatically.
+/// </remarks>
 public partial class Image {
     /// <summary>
     /// Saves the image in ICO format using multiple resolutions.

--- a/Sources/ImagePlayground/Image.Text.cs
+++ b/Sources/ImagePlayground/Image.Text.cs
@@ -10,6 +10,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides image manipulation operations.
 /// </summary>
+/// <remarks>
+/// Text rendering relies on the fonts available in the operating system.
+/// </remarks>
 public partial class Image : IDisposable {
     /// <summary>
     /// Calculates the dimensions required to render <paramref name="text"/> using the specified font.

--- a/Sources/ImagePlayground/Image.Watermark.cs
+++ b/Sources/ImagePlayground/Image.Watermark.cs
@@ -10,6 +10,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides image manipulation operations.
 /// </summary>
+/// <remarks>
+/// Watermarks can be applied as text or images with configurable placement.
+/// </remarks>
 public partial class Image : IDisposable {
 
     public enum WatermarkPlacement {

--- a/Sources/ImagePlayground/Image.cs
+++ b/Sources/ImagePlayground/Image.cs
@@ -16,6 +16,10 @@ namespace ImagePlayground;
 /// <summary>
 /// Represents an image loaded using ImageSharp and exposes basic manipulation helpers.
 /// </summary>
+/// <remarks>
+/// The class wraps <see cref="SixLabors.ImageSharp.Image"/> and ensures resources
+/// are properly disposed.
+/// </remarks>
 public partial class Image : IDisposable {
     private SixLabors.ImageSharp.Image _image;
     private string _filePath;

--- a/Sources/ImagePlayground/ImageHelper.AddText.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddText.cs
@@ -5,6 +5,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// These methods operate on file paths and delegate actual drawing to the <see cref="Image"/> class.
+/// </remarks>
 public partial class ImageHelper {
     /// <summary>
     /// Adds text to an image file and saves the result.

--- a/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
+++ b/Sources/ImagePlayground/ImageHelper.AddWatermark.cs
@@ -7,6 +7,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// Useful for quickly applying watermarks without manually loading images.
+/// </remarks>
 public partial class ImageHelper {
     /// <summary>
     /// Adds an image watermark at one of the predefined placements.

--- a/Sources/ImagePlayground/ImageHelper.Avatar.cs
+++ b/Sources/ImagePlayground/ImageHelper.Avatar.cs
@@ -5,6 +5,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// Avatar helpers simplify creating square cropped images with rounded corners.
+/// </remarks>
 public partial class ImageHelper {
     /// <summary>
     /// Converts an image file to an avatar and saves the result.

--- a/Sources/ImagePlayground/ImageHelper.Base64.cs
+++ b/Sources/ImagePlayground/ImageHelper.Base64.cs
@@ -5,6 +5,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// Converting images to and from Base64 strings allows easy transport via text formats.
+/// </remarks>
 public partial class ImageHelper {
     /// <summary>
     /// Reads an image file and returns its Base64 representation.

--- a/Sources/ImagePlayground/ImageHelper.Compare.cs
+++ b/Sources/ImagePlayground/ImageHelper.Compare.cs
@@ -5,6 +5,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// Comparison helpers rely on ImageSharpCompare to detect visual differences between files.
+/// </remarks>
 public partial class ImageHelper {
 
     /// <summary>

--- a/Sources/ImagePlayground/ImageHelper.Crop.cs
+++ b/Sources/ImagePlayground/ImageHelper.Crop.cs
@@ -5,6 +5,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// Useful for quickly cropping or clipping images without manual steps.
+/// </remarks>
 public partial class ImageHelper {
     /// <summary>
     /// Crops an image to the specified rectangle and saves the result.

--- a/Sources/ImagePlayground/ImageHelper.GetImageThumbnail.cs
+++ b/Sources/ImagePlayground/ImageHelper.GetImageThumbnail.cs
@@ -7,6 +7,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// Thumbnails are cached in the user's temporary directory for quick retrieval.
+/// </remarks>
 public partial class ImageHelper {
     private static string GetThumbnailCacheDirectory() {
         string dir = Path.Combine(Path.GetTempPath(), "ImagePlayground", "thumbnails");

--- a/Sources/ImagePlayground/ImageHelper.Metadata.cs
+++ b/Sources/ImagePlayground/ImageHelper.Metadata.cs
@@ -11,6 +11,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// Metadata operations allow import and export of EXIF, ICC and other profiles.
+/// </remarks>
 public partial class ImageHelper {
     /// <summary>
     /// Serialization model for image metadata.

--- a/Sources/ImagePlayground/ImageHelper.Thumbnails.cs
+++ b/Sources/ImagePlayground/ImageHelper.Thumbnails.cs
@@ -6,6 +6,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// Thumbnail generation can speed up gallery loading by creating small preview images.
+/// </remarks>
 public partial class ImageHelper {
     /// <summary>
     /// Generates resized copies for all images found in <paramref name="directoryPath"/>.

--- a/Sources/ImagePlayground/ImageHelper.cs
+++ b/Sources/ImagePlayground/ImageHelper.cs
@@ -14,6 +14,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for image manipulation.
 /// </summary>
+/// <remarks>
+/// This class exposes high-level convenience methods built on top of the <see cref="Image"/> type.
+/// </remarks>
 public partial class ImageHelper {
     /// <summary>
     /// Converts an image from one format to another.

--- a/Sources/ImagePlayground/QRCode.cs
+++ b/Sources/ImagePlayground/QRCode.cs
@@ -12,6 +12,9 @@ namespace ImagePlayground;
 /// <summary>
 /// Provides helper methods for generating various QR code payloads and reading QR codes.
 /// </summary>
+/// <remarks>
+/// Methods in this class use QRCoder to generate the underlying QR code data.
+/// </remarks>
 public class QrCode {
     /// <summary>
     /// Creates a QR code image from a raw string value.


### PR DESCRIPTION
## Summary
- document `Helpers` partial classes
- add remarks to image helper classes and barcode/QR code helpers
- expand summaries for GIF and chart helpers
- ensure all major public types have XML docs

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_687351bddb64832eb6db47542653b361