### PR TITLE
Split library into modular projects

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -1,0 +1,184 @@
+﻿using System.IO;
+using Barcoder;
+using Barcoder.Code128;
+using Barcoder.Code39;
+using Barcoder.Code93;
+using Barcoder.Ean;
+using Barcoder.Kix;
+using Barcoder.Qr;
+using Barcoder.Renderer.Image;
+using Barcoder.DataMatrix;
+using Barcoder.UpcA;
+using Barcoder.UpcE;
+using BarcodeReader.ImageSharp;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using ZXing;
+using ZXing.Common;
+using Encoding = Barcoder.Qr.Encoding;
+
+namespace ImagePlayground;
+/// <summary>
+/// Helper methods for generating and reading barcodes.
+/// </summary>
+public class BarCode {
+    /// <summary>
+    /// Saves the generated barcode image to disk.
+    /// </summary>
+    /// <param name="barcode">Barcode to render.</param>
+    /// <param name="filePath">Destination file path.</param>
+    private static void SaveToFile(IBarcode barcode, string filePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+
+        ImageFormat imageFormatDetected;
+        FileInfo fileInfo = new FileInfo(fullPath);
+
+        if (fileInfo.Extension == ".png") {
+            imageFormatDetected = ImageFormat.Png;
+        } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+            imageFormatDetected = ImageFormat.Jpeg;
+        } else if (fileInfo.Extension == ".bmp") {
+            imageFormatDetected = ImageFormat.Bmp;
+        } else {
+            throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+        }
+
+        var options = new ImageRendererOptions();
+        options.ImageFormat = imageFormatDetected;
+        var renderer = new ImageRenderer(options);
+        //var renderer = new ImageRenderer(imageFormat: imageFormatDetected);
+
+        using (var stream = new FileStream(fullPath, FileMode.Create)) {
+            renderer.Render(barcode, stream);
+        }
+    }
+
+    private static void SaveToFile(Image<Rgba32> image, string filePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        FileInfo fileInfo = new FileInfo(fullPath);
+
+        if (fileInfo.Extension == ".png") {
+            image.SaveAsPng(fullPath);
+        } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+            image.SaveAsJpeg(fullPath);
+        } else if (fileInfo.Extension == ".bmp") {
+            image.SaveAsBmp(fullPath);
+        } else {
+            throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+        }
+    }
+
+    /// <summary>Generates a QR code.</summary>
+    /// <param name="content">Value encoded in the QR code.</param>
+    /// <param name="filePath">Destination file path.</param>
+    /// <param name="errorCorrectionLevel">Error correction level.</param>
+    /// <param name="encoding">Text encoding.</param>
+    public static void GenerateQr(string content, string filePath, ErrorCorrectionLevel errorCorrectionLevel = ErrorCorrectionLevel.H, Encoding encoding = Encoding.Auto) {
+        var barcode = QrEncoder.Encode(content, errorCorrectionLevel, encoding);
+        SaveToFile(barcode, filePath);
+    }
+
+    /// <summary>Generates an EAN barcode.</summary>
+    /// <param name="content">Value encoded in the barcode.</param>
+    /// <param name="filePath">Destination file path.</param>
+    public static void GenerateEan(string content, string filePath) {
+        var barcode = EanEncoder.Encode(content);
+        SaveToFile(barcode, filePath);
+    }
+
+    /// <summary>Generates a Code 128 barcode.</summary>
+    public static void GenerateCode128(string content, string filePath, bool includeChecksum = true) {
+        var barcode = Code128Encoder.Encode(content, includeChecksum);
+        SaveToFile(barcode, filePath);
+    }
+
+    /// <summary>Generates a Code 93 barcode.</summary>
+    public static void GenerateCode93(string content, string filePath, bool includeChecksum = true, bool fullAsciiMode = false) {
+        var barcode = Code93Encoder.Encode(content, includeChecksum, fullAsciiMode);
+        SaveToFile(barcode, filePath);
+    }
+
+    /// <summary>Generates a Code 39 barcode.</summary>
+    public static void GenerateCode39(string content, string filePath, bool includeChecksum = true, bool fullAsciiMode = false) {
+        var barcode = Code39Encoder.Encode(content, includeChecksum, fullAsciiMode);
+        SaveToFile(barcode, filePath);
+    }
+
+    /// <summary>Generates a UPC-E barcode.</summary>
+    public static void GenerateUpcE(string content, string filePath, UpcENumberSystem upcNumberSystem = UpcENumberSystem.Zero) {
+        var barcode = UpcEEncoder.Encode(content, upcNumberSystem);
+        SaveToFile(barcode, filePath);
+    }
+
+    /// <summary>Generates a UPC-A barcode.</summary>
+    public static void GenerateUpcA(string content, string filePath) {
+        var barcode = UpcAEncoder.Encode(content);
+        SaveToFile(barcode, filePath);
+    }
+
+    /// <summary>Generates a KIX barcode.</summary>
+    public static void GenerateKix(string content, string filePath) {
+        var barcode = KixEncoder.Encode(content);
+        SaveToFile(barcode, filePath);
+    }
+
+    /// <summary>Generates a Data Matrix barcode.</summary>
+    public static void GenerateDataMatrix(string content, string filePath) {
+        var barcode = DataMatrixEncoder.Encode(content);
+        SaveToFile(barcode, filePath);
+    }
+
+    /// <summary>Generates a PDF417 barcode.</summary>
+    public static void GeneratePdf417(string content, string filePath) {
+        var writer = new ZXing.ImageSharp.BarcodeWriter<Rgba32> {
+            Format = BarcodeFormat.PDF_417,
+            Options = new EncodingOptions {
+                Width = 300,
+                Height = 150,
+                Margin = 1
+            }
+        };
+        using Image<Rgba32> image = writer.Write(content);
+        SaveToFile(image, filePath);
+    }
+
+    /// <summary>
+    /// Dispatches barcode generation based on <paramref name="barcodeType"/>.
+    /// </summary>
+    public static void Generate(BarcodeType barcodeType, string content, string filePath) {
+        if (barcodeType == BarcodeType.Code128) {
+            GenerateCode128(content, filePath);
+        } else if (barcodeType == BarcodeType.Code93) {
+            GenerateCode93(content, filePath);
+        } else if (barcodeType == BarcodeType.Code39) {
+            GenerateCode39(content, filePath);
+        } else if (barcodeType == BarcodeType.KixCode) {
+            GenerateKix(content, filePath);
+        } else if (barcodeType == BarcodeType.UPCA) {
+            GenerateUpcA(content, filePath);
+        } else if (barcodeType == BarcodeType.UPCE) {
+            GenerateUpcE(content, filePath);
+        } else if (barcodeType == BarcodeType.EAN) {
+            GenerateEan(content, filePath);
+        } else if (barcodeType == BarcodeType.DataMatrix) {
+            GenerateDataMatrix(content, filePath);
+        } else if (barcodeType == BarcodeType.PDF417) {
+            GeneratePdf417(content, filePath);
+        }
+    }
+
+    /// <summary>
+    /// Reads and decodes a barcode from an image.
+    /// </summary>
+    /// <param name="filePath">Path to the barcode image.</param>
+    /// <returns>Decoded barcode result.</returns>
+    public static BarcodeResult<Rgba32> Read(string filePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+
+        using (Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath)) {
+            BarcodeReader.ImageSharp.BarcodeReader<Rgba32> reader = new(types: new[] { ZXing.BarcodeFormat.All_1D, ZXing.BarcodeFormat.DATA_MATRIX, ZXing.BarcodeFormat.PDF_417 });
+            var response = reader.Decode(barcodeImage);
+            return response;
+        }
+    }
+}

--- a/Sources/ImagePlayground.BarCode/BarcodeType.cs
+++ b/Sources/ImagePlayground.BarCode/BarcodeType.cs
@@ -1,0 +1,26 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Supported barcode formats.
+/// </summary>
+public enum BarcodeType
+{
+    /// <summary>Code 128 barcode.</summary>
+    Code128,
+    /// <summary>Code 93 barcode.</summary>
+    Code93,
+    /// <summary>Code 39 barcode.</summary>
+    Code39,
+    /// <summary>KIX code used by Dutch Post.</summary>
+    KixCode,
+    /// <summary>UPC-E barcode.</summary>
+    UPCE,
+    /// <summary>UPC-A barcode.</summary>
+    UPCA,
+    /// <summary>EAN-8/EAN-13 barcode.</summary>
+    EAN,
+    /// <summary>Data Matrix 2D barcode.</summary>
+    DataMatrix,
+    /// <summary>PDF417 2D barcode.</summary>
+    PDF417
+}

--- a/Sources/ImagePlayground.BarCode/ImagePlayground.BarCode.csproj
+++ b/Sources/ImagePlayground.BarCode/ImagePlayground.BarCode.csproj
@@ -1,0 +1,40 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
+    <AssemblyName>ImagePlayground.BarCode</AssemblyName>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ImagePlayground.Core\ImagePlayground.Core.csproj" />
+    <PackageReference Include="Barcoder" Version="2.0.0" />
+    <PackageReference Include="Barcoder.Renderer.Image" Version="2.0.0" />
+    <PackageReference Include="BarcodeReader.ImageSharp" Version="2.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Collections" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Threading" />
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.IO" />
+    <Using Include="System.Net" />
+    <Using Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+</Project>

--- a/Sources/ImagePlayground.Chart/ChartDefinitionType.cs
+++ b/Sources/ImagePlayground.Chart/ChartDefinitionType.cs
@@ -1,0 +1,24 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Type of chart definition.
+/// </summary>
+public enum ChartDefinitionType
+{
+    /// <summary>Bar chart.</summary>
+    Bar,
+    /// <summary>Line chart.</summary>
+    Line,
+    /// <summary>Scatter chart.</summary>
+    Scatter,
+    /// <summary>Polar plot.</summary>
+    Polar,
+    /// <summary>Pie chart.</summary>
+    Pie,
+    /// <summary>Radial gauge chart.</summary>
+    Radial,
+    /// <summary>Heatmap chart.</summary>
+    Heatmap,
+    /// <summary>Histogram chart.</summary>
+    Histogram
+}

--- a/Sources/ImagePlayground.Chart/ChartTheme.cs
+++ b/Sources/ImagePlayground.Chart/ChartTheme.cs
@@ -1,0 +1,14 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Available chart themes.
+/// </summary>
+public enum ChartTheme
+{
+    /// <summary>Use the default ScottPlot style.</summary>
+    Default,
+    /// <summary>Apply the dark theme.</summary>
+    Dark,
+    /// <summary>Apply the light theme.</summary>
+    Light
+}

--- a/Sources/ImagePlayground.Chart/Charts.cs
+++ b/Sources/ImagePlayground.Chart/Charts.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ScottPlot;
+using SixLabors.ImageSharp.PixelFormats;
+using ImageColor = SixLabors.ImageSharp.Color;
+
+namespace ImagePlayground;
+
+/// <summary>Chart generation helpers.</summary>
+public static class Charts {
+
+    /// <summary>Base class for chart definitions.</summary>
+    public abstract class ChartDefinition {
+        /// <summary>Chart type.</summary>
+        public ChartDefinitionType Type { get; }
+        /// <summary>Chart name.</summary>
+        public string Name { get; }
+
+        protected ChartDefinition(ChartDefinitionType type, string name) {
+            Type = type;
+            Name = name;
+        }
+    }
+
+    /// <summary>Bar chart definition.</summary>
+    public sealed class ChartBar : ChartDefinition {
+        /// <summary>Bar values.</summary>
+        public IList<double> Value { get; }
+
+        /// <summary>Bar color.</summary>
+        public ImageColor? Color { get; }
+
+        /// <summary>Create a bar chart definition.</summary>
+        /// <param name="name">Series name.</param>
+        /// <param name="value">Bar values.</param>
+        /// <param name="color">Optional bar color.</param>
+        public ChartBar(string name, IList<double> value, ImageColor? color = null) : base(ChartDefinitionType.Bar, name) {
+            Value = value;
+            Color = color;
+        }
+    }
+
+    /// <summary>Line chart definition.</summary>
+    public sealed class ChartLine : ChartDefinition {
+        /// <summary>Line values.</summary>
+        public IList<double> Value { get; }
+
+        /// <summary>Line color.</summary>
+        public ImageColor? Color { get; }
+
+        /// <summary>Shape of markers used for data points.</summary>
+        public MarkerShape MarkerShape { get; }
+
+        /// <summary>Optional size of the markers.</summary>
+        public float? MarkerSize { get; }
+
+        /// <summary>Render the line using a smooth curve.</summary>
+        public bool Smooth { get; }
+
+        /// <summary>Create a line chart definition.</summary>
+        /// <param name="name">Series name.</param>
+        /// <param name="value">Line values.</param>
+        /// <param name="color">Optional line color.</param>
+        /// <param name="markerShape">Marker shape.</param>
+        /// <param name="markerSize">Optional marker size.</param>
+        /// <param name="smooth">Render as a smooth curve.</param>
+        public ChartLine(
+            string name,
+            IList<double> value,
+            ImageColor? color = null,
+            MarkerShape markerShape = MarkerShape.None,
+            float? markerSize = null,
+            bool smooth = false) : base(ChartDefinitionType.Line, name) {
+            Value = value;
+            Color = color;
+            MarkerShape = markerShape;
+            MarkerSize = markerSize;
+            Smooth = smooth;
+        }
+    }
+
+    /// <summary>Scatter chart definition.</summary>
+    public sealed class ChartScatter : ChartDefinition {
+        /// <summary>X values.</summary>
+        public IList<double> X { get; }
+
+        /// <summary>Y values.</summary>
+        public IList<double> Y { get; }
+
+        /// <summary>Point color.</summary>
+        public ImageColor? Color { get; }
+
+        /// <summary>Create a scatter chart definition.</summary>
+        /// <param name="name">Series name.</param>
+        /// <param name="x">X data points.</param>
+        /// <param name="y">Y data points.</param>
+        /// <param name="color">Optional point color.</param>
+        public ChartScatter(string name, IList<double> x, IList<double> y, ImageColor? color = null) : base(ChartDefinitionType.Scatter, name) {
+            X = x;
+            Y = y;
+            Color = color;
+        }
+    }
+
+    /// <summary>Polar plot definition.</summary>
+    public sealed class ChartPolar : ChartDefinition {
+        /// <summary>Angle values.</summary>
+        public IList<double> Angle { get; }
+
+        /// <summary>Radius values.</summary>
+        public IList<double> Value { get; }
+
+        /// <summary>Line color.</summary>
+        public ImageColor? Color { get; }
+
+        /// <summary>Create a polar chart definition.</summary>
+        /// <param name="name">Series name.</param>
+        /// <param name="angle">Angle values.</param>
+        /// <param name="value">Radius values.</param>
+        /// <param name="color">Optional line color.</param>
+        public ChartPolar(string name, IList<double> angle, IList<double> value, ImageColor? color = null) : base(ChartDefinitionType.Polar, name) {
+            Angle = angle;
+            Value = value;
+            Color = color;
+        }
+    }
+
+    /// <summary>Pie chart definition.</summary>
+    public sealed class ChartPie : ChartDefinition {
+        /// <summary>Slice value.</summary>
+        public double Value { get; }
+
+        /// <summary>Slice color.</summary>
+        public ImageColor? Color { get; }
+
+        /// <summary>Create a pie slice definition.</summary>
+        /// <param name="name">Slice label.</param>
+        /// <param name="value">Slice value.</param>
+        /// <param name="color">Optional slice color.</param>
+        public ChartPie(string name, double value, ImageColor? color = null) : base(ChartDefinitionType.Pie, name) {
+            Value = value;
+            Color = color;
+        }
+    }
+
+    /// <summary>Radial gauge chart definition.</summary>
+    public sealed class ChartRadial : ChartDefinition {
+        /// <summary>Gauge value.</summary>
+        public double Value { get; }
+
+        /// <summary>Gauge color.</summary>
+        public ImageColor? Color { get; }
+
+        /// <summary>Create a radial gauge definition.</summary>
+        /// <param name="name">Gauge label.</param>
+        /// <param name="value">Gauge value.</param>
+        /// <param name="color">Optional gauge color.</param>
+        public ChartRadial(string name, double value, ImageColor? color = null) : base(ChartDefinitionType.Radial, name) {
+            Value = value;
+            Color = color;
+        }
+    }
+
+    /// <summary>Heatmap chart definition.</summary>
+    public sealed class ChartHeatmap : ChartDefinition {
+        /// <summary>Values of the heatmap.</summary>
+        public double[,] Data { get; }
+
+        /// <summary>Create a heatmap definition.</summary>
+        /// <param name="name">Series name.</param>
+        /// <param name="data">Heatmap values.</param>
+        public ChartHeatmap(string name, double[,] data) : base(ChartDefinitionType.Heatmap, name) {
+            Data = data;
+        }
+    }
+
+    /// <summary>Histogram chart definition.</summary>
+    public sealed class ChartHistogram : ChartDefinition {
+        /// <summary>Values for the histogram.</summary>
+        public double[] Values { get; }
+
+        /// <summary>Size of each bin.</summary>
+        public int? BinSize { get; }
+
+        /// <summary>Create a histogram definition.</summary>
+        /// <param name="name">Series name.</param>
+        /// <param name="values">Input values.</param>
+        /// <param name="binSize">Optional bin size.</param>
+        public ChartHistogram(string name, double[] values, int? binSize = null) : base(ChartDefinitionType.Histogram, name) {
+            Values = values;
+            BinSize = binSize;
+        }
+    }
+
+    /// <summary>Options for bar charts.</summary>
+    public sealed class ChartBarOptions {
+        /// <summary>Whether to show values above bars.</summary>
+        public bool ShowValuesAboveBars { get; }
+
+        /// <summary>Initialize options for bar charts.</summary>
+        /// <param name="showValuesAboveBars">Show value labels.</param>
+        public ChartBarOptions(bool showValuesAboveBars) {
+            ShowValuesAboveBars = showValuesAboveBars;
+        }
+    }
+
+
+    /// <summary>Chart annotation definition.</summary>
+    public sealed class ChartAnnotation {
+        /// <summary>X coordinate of the annotation.</summary>
+        public double X { get; }
+        /// <summary>Y coordinate of the annotation.</summary>
+        public double Y { get; }
+        /// <summary>Annotation text.</summary>
+        public string Text { get; }
+        /// <summary>Display arrow.</summary>
+        public bool Arrow { get; }
+
+        /// <summary>Create an annotation.</summary>
+        /// <param name="x">X coordinate.</param>
+        /// <param name="y">Y coordinate.</param>
+        /// <param name="text">Annotation text.</param>
+        /// <param name="arrow">Display arrow.</param>
+        public ChartAnnotation(double x, double y, string text, bool arrow = false) {
+            X = x;
+            Y = y;
+            Text = text;
+            Arrow = arrow;
+        }
+    }
+
+    /// <summary>Generate a chart based on provided definitions.</summary>
+    public static void Generate(
+        IEnumerable<ChartDefinition> definitions,
+        string filePath,
+        int width = 600,
+        int height = 400,
+        ChartBarOptions? barOptions = null,
+        string? xTitle = null,
+        string? yTitle = null,
+        bool showGrid = false,
+        ChartTheme theme = ChartTheme.Default,
+        IEnumerable<ChartAnnotation>? annotations = null) {
+        if (definitions is null) throw new ArgumentNullException(nameof(definitions));
+        var list = definitions.ToList();
+        if (list.Count == 0) throw new ArgumentException("No chart definitions provided", nameof(definitions));
+
+        var plot = new Plot();
+        switch (theme) {
+            case ChartTheme.Dark:
+                new ScottPlot.PlotStyles.Dark().Apply(plot);
+                break;
+            case ChartTheme.Light:
+                new ScottPlot.PlotStyles.Light().Apply(plot);
+                break;
+        }
+        var type = list[0].Type;
+        if (list.Any(d => d.Type != type))
+            throw new ArgumentException("Mixed chart definition types provided. All chart definitions must have the same ChartDefinitionType.", nameof(definitions));
+
+        switch (type) {
+            case ChartDefinitionType.Bar:
+                var positions = new List<int>();
+                var labels = new List<string>();
+                var dict = new Dictionary<int, List<double>>();
+                int pos = 0;
+                foreach (var bar in list.Cast<ChartBar>()) {
+                    for (int i = 0; i < bar.Value.Count; i++) {
+                        if (!dict.TryGetValue(i, out var vals)) {
+                            vals = new List<double>();
+                            dict[i] = vals;
+                        }
+                        vals.Add(bar.Value[i]);
+                    }
+                    labels.Add(bar.Name);
+                    positions.Add(pos++);
+                }
+                foreach (var kv in dict.OrderBy(k => k.Key)) {
+                    var plottable = plot.Add.Bars(kv.Value.ToArray());
+                    plottable.ValueLabelStyle.IsVisible = barOptions?.ShowValuesAboveBars == true;
+                    if (barOptions?.ShowValuesAboveBars == true) {
+                        for (int i = 0; i < plottable.Bars.Count; i++) {
+                            plottable.Bars[i].ValueLabel = plottable.Bars[i].Value.ToString();
+                        }
+                    }
+                    for (int i = 0; i < plottable.Bars.Count && i < list.Count; i++) {
+                        var c = ((ChartBar)list[i]).Color;
+                        if (c.HasValue) {
+                            var px = c.Value.ToPixel<Rgba32>();
+                            plottable.Bars[i].FillColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                        }
+                    }
+                }
+                plot.Axes.Bottom.SetTicks(positions.Select(x => (double)x).ToArray(), labels.ToArray());
+                break;
+            case ChartDefinitionType.Line:
+                foreach (var line in list.Cast<ChartLine>()) {
+                    var sig = plot.Add.Signal(line.Value.ToArray());
+                    if (line.Smooth) {
+                        var prop = sig.GetType().GetProperty("SignalLineStyle");
+                        if (prop is not null) {
+                            var enumType = prop.PropertyType;
+                            var spline = Enum.Parse(enumType, "Spline");
+                            prop.SetValue(sig, spline);
+                        }
+                    }
+                    sig.LegendText = line.Name;
+                    sig.MarkerShape = line.MarkerShape;
+                    if (line.MarkerSize.HasValue)
+                        sig.MarkerSize = line.MarkerSize.Value;
+                    if (line.Color.HasValue) {
+                        var px = line.Color.Value.ToPixel<Rgba32>();
+                        sig.LineColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                    }
+                }
+                plot.ShowLegend();
+                break;
+            case ChartDefinitionType.Scatter:
+                foreach (var scatter in list.Cast<ChartScatter>()) {
+                    var sc = plot.Add.Scatter(scatter.X.ToArray(), scatter.Y.ToArray());
+                    sc.LegendText = scatter.Name;
+                    if (scatter.Color.HasValue) {
+                        var px = scatter.Color.Value.ToPixel<Rgba32>();
+                        sc.Color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                    }
+                }
+                plot.ShowLegend();
+                break;
+            case ChartDefinitionType.Polar:
+                foreach (var polar in list.Cast<ChartPolar>()) {
+                    var pp = plot.Add.Polar(polar.Angle.ToArray(), polar.Value.ToArray());
+                    pp.LegendText = polar.Name;
+                    if (polar.Color.HasValue) {
+                        var px = polar.Color.Value.ToPixel<Rgba32>();
+                        pp.Color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                    }
+                }
+                plot.ShowLegend();
+                break;
+            case ChartDefinitionType.Pie:
+                var pieValues = list.Cast<ChartPie>().Select(p => p.Value).ToArray();
+                var pieLabels = list.Cast<ChartPie>().Select(p => p.Name).ToArray();
+                var pie = plot.Add.Pie(pieValues);
+                for (int i = 0; i < pie.Slices.Count && i < pieLabels.Length; i++) {
+                    pie.Slices[i].Label = pieLabels[i];
+                    var c = ((ChartPie)list[i]).Color;
+                    if (c.HasValue) {
+                        var px = c.Value.ToPixel<Rgba32>();
+                        pie.Slices[i].FillColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                    }
+                }
+                break;
+            case ChartDefinitionType.Radial:
+                var rValues = list.Cast<ChartRadial>().Select(r => r.Value).ToArray();
+                var rLabels = list.Cast<ChartRadial>().Select(r => r.Name).ToArray();
+                var radial = plot.Add.RadialGaugePlot(rValues);
+                radial.Labels = rLabels;
+                var rColors = list.Cast<ChartRadial>().Select(r => r.Color).ToArray();
+                if (rColors.Any(c => c.HasValue)) {
+                    radial.Colors = rColors.Select(c => {
+                        if (c.HasValue) {
+                            var px = c.Value.ToPixel<Rgba32>();
+                            return new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                        }
+                        return new ScottPlot.Color();
+                    }).ToArray();
+                }
+                plot.ShowLegend();
+                break;
+            case ChartDefinitionType.Heatmap:
+                foreach (var map in list.Cast<ChartHeatmap>()) {
+                    plot.Add.Heatmap(map.Data);
+                }
+                break;
+            case ChartDefinitionType.Histogram:
+                foreach (var hist in list.Cast<ChartHistogram>()) {
+                    var histogram = hist.BinSize.HasValue
+                        ? ScottPlot.Statistics.Histogram.WithBinSize(hist.BinSize.Value, hist.Values)
+                        : ScottPlot.Statistics.Histogram.WithBinCount(10, hist.Values);
+                    var bp = plot.Add.Bars(histogram.Bins, histogram.Counts);
+                    bp.LegendText = hist.Name;
+                    foreach (var bar in bp.Bars) {
+                        bar.Size = histogram.FirstBinSize * 0.8;
+                    }
+                }
+                plot.ShowLegend();
+                break;
+        }
+
+        if (!string.IsNullOrEmpty(xTitle)) {
+            plot.Axes.Bottom.Label.Text = xTitle;
+        }
+
+        if (!string.IsNullOrEmpty(yTitle)) {
+            plot.Axes.Left.Label.Text = yTitle;
+        }
+
+        if (showGrid) {
+            plot.ShowGrid();
+        } else {
+            plot.HideGrid();
+        }
+
+        if (annotations is not null) {
+            foreach (var ann in annotations) {
+                var callout = plot.Add.Callout(ann.Text, new Coordinates(ann.X, ann.Y), new Coordinates(ann.X, ann.Y));
+                if (!ann.Arrow) {
+                    callout.ArrowLineWidth = 0;
+                }
+            }
+        }
+
+        filePath = Helpers.ResolvePath(filePath);
+        plot.SavePng(filePath, width, height);
+    }
+}

--- a/Sources/ImagePlayground.Chart/Helpers.PlotExtensions.cs
+++ b/Sources/ImagePlayground.Chart/Helpers.PlotExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using ScottPlot;
+
+namespace ImagePlayground;
+/// <summary>Extension methods for ScottPlot.</summary>
+public static class PlotExtensions {
+    /// <summary>Add a polar scatter plot.</summary>
+    /// <param name="add">Plottable adder.</param>
+    /// <param name="angles">Angle values in radians.</param>
+    /// <param name="values">Radius values.</param>
+    public static ScottPlot.Plottables.Scatter Polar(this PlottableAdder add, double[] angles, double[] values) {
+        if (angles is null) throw new ArgumentNullException(nameof(angles));
+        if (values is null) throw new ArgumentNullException(nameof(values));
+        if (angles.Length != values.Length) throw new ArgumentException("Angles and values must have the same length.");
+        var xs = new double[angles.Length];
+        var ys = new double[angles.Length];
+        for (int i = 0; i < angles.Length; i++) {
+            xs[i] = values[i] * Math.Cos(angles[i]);
+            ys[i] = values[i] * Math.Sin(angles[i]);
+        }
+        return add.Scatter(xs, ys);
+    }
+}

--- a/Sources/ImagePlayground.Chart/ImagePlayground.Chart.csproj
+++ b/Sources/ImagePlayground.Chart/ImagePlayground.Chart.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
+    <AssemblyName>ImagePlayground.Chart</AssemblyName>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ImagePlayground.Core\ImagePlayground.Core.csproj" />
+    <PackageReference Include="ScottPlot" Version="5.0.55" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Collections" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Threading" />
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.IO" />
+    <Using Include="System.Net" />
+    <Using Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+</Project>

--- a/Sources/ImagePlayground.Core/GIF.cs
+++ b/Sources/ImagePlayground.Core/GIF.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using SixLabors.ImageSharp;
+using ImageSharpImage = SixLabors.ImageSharp.Image;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace ImagePlayground;
+/// <summary>Helper methods for creating animated GIFs.</summary>
+public static class Gif {
+    /// <summary>
+    /// Generates an animated GIF from a set of images.
+    /// </summary>
+    /// <param name="sourceImages">Paths to images used as frames.</param>
+    /// <param name="filePath">Destination GIF file path.</param>
+    /// <param name="frameDelay">Delay between frames in milliseconds.</param>
+    public static void Generate(IEnumerable<string> sourceImages, string filePath, int frameDelay = 100) {
+        if (sourceImages is null) {
+            throw new ArgumentNullException(nameof(sourceImages));
+        }
+
+        var frames = sourceImages.Select(Helpers.ResolvePath).ToList();
+        if (frames.Count == 0) {
+            throw new ArgumentException("No frames specified", nameof(sourceImages));
+        }
+
+        foreach (var frame in frames) {
+            if (!File.Exists(frame)) {
+                throw new FileNotFoundException($"Frame not found: {frame}", frame);
+            }
+        }
+
+        string output = Helpers.ResolvePath(filePath);
+
+        using var gif = ImageSharpImage.Load(frames[0]);
+        gif.Metadata.GetGifMetadata().RepeatCount = 0;
+        gif.Frames.RootFrame.Metadata.GetGifMetadata().FrameDelay = Math.Max(1, frameDelay / 10);
+
+        for (int i = 1; i < frames.Count; i++) {
+            using var image = ImageSharpImage.Load(frames[i]);
+            image.Frames.RootFrame.Metadata.GetGifMetadata().FrameDelay = Math.Max(1, frameDelay / 10);
+            gif.Frames.AddFrame(image.Frames.RootFrame);
+        }
+
+        SixLabors.ImageSharp.ImageExtensions.SaveAsGif(gif, output, new GifEncoder());
+    }
+}

--- a/Sources/ImagePlayground.Core/Helpers.Encoder.cs
+++ b/Sources/ImagePlayground.Core/Helpers.Encoder.cs
@@ -1,0 +1,53 @@
+using System;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Pbm;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Tga;
+using SixLabors.ImageSharp.Formats.Tiff;
+using SixLabors.ImageSharp.Formats.Webp;
+
+namespace ImagePlayground;
+public static partial class Helpers {
+    /// <summary>
+    /// Returns an image encoder instance appropriate for the given file extension.
+    /// </summary>
+    /// <param name="extension">File extension including the leading dot.</param>
+    /// <param name="quality">Optional quality value for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
+    /// <returns>Configured image encoder.</returns>
+    public static IImageEncoder GetEncoder(string extension, int? quality, int? compressionLevel) {
+        extension = extension.ToLowerInvariant();
+        return extension switch {
+            ".png" => new PngEncoder {
+                CompressionLevel = compressionLevel.HasValue
+                    ? (PngCompressionLevel)Math.Max(0, Math.Min(9, compressionLevel.Value))
+                    : PngCompressionLevel.DefaultCompression
+            },
+            ".jpg" => new JpegEncoder {
+                Quality = quality.HasValue
+                    ? Math.Max(0, Math.Min(100, quality.Value))
+                    : 75
+            },
+            ".jpeg" => new JpegEncoder {
+                Quality = quality.HasValue
+                    ? Math.Max(0, Math.Min(100, quality.Value))
+                    : 75
+            },
+            ".bmp" => new BmpEncoder(),
+            ".gif" => new GifEncoder(),
+            ".pbm" => new PbmEncoder(),
+            ".tga" => new TgaEncoder(),
+            ".tiff" => new TiffEncoder(),
+            ".webp" => new WebpEncoder {
+                Quality = quality.HasValue
+                    ? Math.Max(0, Math.Min(100, quality.Value))
+                    : 75
+            },
+            _ => throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it."),
+        };
+    }
+}

--- a/Sources/ImagePlayground.Core/Helpers.Path.cs
+++ b/Sources/ImagePlayground.Core/Helpers.Path.cs
@@ -1,0 +1,140 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Helper methods for working with file paths.
+/// </summary>
+public static partial class Helpers {
+    private static readonly System.Collections.Concurrent.ConcurrentBag<string> _tempFiles = new();
+
+    static Helpers() {
+        System.AppDomain.CurrentDomain.ProcessExit += (_, _) => CleanupTempFiles();
+    }
+    /// <summary>
+    /// Resolves the provided path to an absolute file system path.
+    /// Environment variables are expanded and relative paths are
+    /// converted to full paths.
+    /// </summary>
+    /// <param name="path">File system path to resolve.</param>
+    /// <returns>Absolute file path.</returns>
+    /// <exception cref="System.ArgumentException">Thrown when path is null or empty.</exception>
+    public static string ResolvePath(string path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new System.ArgumentException("Path cannot be null or empty", nameof(path));
+        }
+
+        string expanded = System.Environment.ExpandEnvironmentVariables(path);
+
+        if (expanded.StartsWith("http://", System.StringComparison.OrdinalIgnoreCase) ||
+            expanded.StartsWith("https://", System.StringComparison.OrdinalIgnoreCase)) {
+            string tempFile = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+            using (var client = new System.Net.Http.HttpClient()) {
+                var bytes = client.GetByteArrayAsync(expanded).GetAwaiter().GetResult();
+                System.IO.File.WriteAllBytes(tempFile, bytes);
+            }
+            _tempFiles.Add(tempFile);
+            return tempFile;
+        }
+
+        return System.IO.Path.GetFullPath(expanded);
+    }
+
+    /// <summary>
+    /// Reads the contents of a file after verifying that it exists.
+    /// </summary>
+    /// <param name="path">Path to the file.</param>
+    /// <returns>File contents.</returns>
+    /// <exception cref="System.IO.FileNotFoundException">Thrown when the file does not exist.</exception>
+    public static string ReadFileChecked(string path) {
+        string fullPath = ResolvePath(path);
+        if (!System.IO.File.Exists(fullPath)) {
+            throw new System.IO.FileNotFoundException($"File not found: {path}", fullPath);
+        }
+
+        return System.IO.File.ReadAllText(fullPath);
+    }
+
+    /// <summary>
+    /// Asynchronously reads the contents of a file after verifying that it exists.
+    /// </summary>
+    /// <param name="path">Path to the file.</param>
+    /// <returns>File contents.</returns>
+    /// <exception cref="System.IO.FileNotFoundException">Thrown when the file does not exist.</exception>
+    public static async System.Threading.Tasks.Task<string> ReadFileCheckedAsync(string path) {
+        string fullPath = ResolvePath(path);
+        if (!System.IO.File.Exists(fullPath)) {
+            throw new System.IO.FileNotFoundException($"File not found: {path}", fullPath);
+        }
+
+#if NETSTANDARD2_0 || NETFRAMEWORK
+        return await System.Threading.Tasks.Task.Run(() => System.IO.File.ReadAllText(fullPath)).ConfigureAwait(false);
+#else
+        return await System.IO.File.ReadAllTextAsync(fullPath).ConfigureAwait(false);
+#endif
+}
+
+
+    /// <summary>
+    /// Downloads content from a URL with proper encoding detection.
+    /// </summary>
+    /// <param name="client">HttpClient to use for the request.</param>
+    /// <param name="url">URL to download from.</param>
+    /// <returns>Content as a string with proper encoding.</returns>
+    public static async System.Threading.Tasks.Task<string> GetStringWithProperEncodingAsync(System.Net.Http.HttpClient client, string url) {
+        using var response = await client.GetAsync(url).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+        var contentType = response.Content.Headers.ContentType;
+        if (contentType?.CharSet != null) {
+            try {
+                var encoding = System.Text.Encoding.GetEncoding(contentType.CharSet);
+                return encoding.GetString(bytes);
+            } catch {
+            }
+        }
+
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
+            return System.Text.Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+        }
+        if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE) {
+            return System.Text.Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+        }
+        if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF) {
+            return System.Text.Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+        }
+
+        var asciiContent = System.Text.Encoding.ASCII.GetString(bytes);
+        var metaMatch = System.Text.RegularExpressions.Regex.Match(
+            asciiContent,
+            @"<meta[^>]+charset\s*=\s*[""']?([^""'>\s]+)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        if (metaMatch.Success) {
+            try {
+                var encoding = System.Text.Encoding.GetEncoding(metaMatch.Groups[1].Value);
+                return encoding.GetString(bytes);
+            } catch {
+            }
+        }
+
+        return System.Text.Encoding.UTF8.GetString(bytes);
+    }
+
+    /// <summary>
+    /// Removes any temporary files created when resolving URLs.
+    /// </summary>
+    public static void CleanupTempFiles() {
+        foreach (string file in _tempFiles) {
+            try {
+                if (System.IO.File.Exists(file)) {
+                    System.IO.File.Delete(file);
+                }
+            } catch {
+            }
+        }
+        while (!_tempFiles.IsEmpty) {
+            _tempFiles.TryTake(out _);
+        }
+    }
+}

--- a/Sources/ImagePlayground.Core/Helpers.Resampler.cs
+++ b/Sources/ImagePlayground.Core/Helpers.Resampler.cs
@@ -1,0 +1,29 @@
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Processors.Transforms;
+
+namespace ImagePlayground;
+public static partial class Helpers {
+    /// <summary>
+    /// Maps the <see cref="Sampler"/> enumeration to a concrete resampler implementation.
+    /// </summary>
+    /// <param name="sampler">Sampler option.</param>
+    /// <returns>Corresponding image resampler.</returns>
+    public static IResampler GetResampler(Sampler sampler) =>
+        sampler switch {
+            Sampler.NearestNeighbor => KnownResamplers.NearestNeighbor,
+            Sampler.Box => KnownResamplers.Box,
+            Sampler.Triangle => KnownResamplers.Triangle,
+            Sampler.Hermite => KnownResamplers.Hermite,
+            Sampler.Lanczos2 => KnownResamplers.Lanczos2,
+            Sampler.Lanczos3 => KnownResamplers.Lanczos3,
+            Sampler.Lanczos5 => KnownResamplers.Lanczos5,
+            Sampler.Lanczos8 => KnownResamplers.Lanczos8,
+            Sampler.MitchellNetravali => KnownResamplers.MitchellNetravali,
+            Sampler.CatmullRom => KnownResamplers.CatmullRom,
+            Sampler.Robidoux => KnownResamplers.Robidoux,
+            Sampler.RobidouxSharp => KnownResamplers.RobidouxSharp,
+            Sampler.Spline => KnownResamplers.Spline,
+            Sampler.Welch => KnownResamplers.Welch,
+            _ => KnownResamplers.Bicubic,
+        };
+}

--- a/Sources/ImagePlayground.Core/Helpers.cs
+++ b/Sources/ImagePlayground.Core/Helpers.cs
@@ -1,0 +1,73 @@
+﻿using System.Diagnostics;
+using System.IO;
+
+namespace ImagePlayground;
+public static partial class Helpers {
+    /// <summary>
+    /// Converts a <see cref="SixLabors.ImageSharp.Color"/> to a 6 character hex string.
+    /// </summary>
+    /// <param name="c">Color value to convert.</param>
+    /// <returns>Hex string without alpha component.</returns>
+    public static string ToHexColor(this SixLabors.ImageSharp.Color c) {
+        return c.ToHex().Remove(6);
+    }
+
+    /// <summary>
+    /// Opens the specified file using the OS default application if <paramref name="open"/> is <c>true</c>.
+    /// </summary>
+    /// <param name="filePath">Path to the file.</param>
+    /// <param name="open">Whether to open the file.</param>
+    public static void Open(string filePath, bool open) {
+        if (open) {
+            ProcessStartInfo startInfo = new ProcessStartInfo(filePath) {
+                UseShellExecute = true
+            };
+            Process.Start(startInfo);
+        }
+    }
+
+    /// <summary>
+    /// Checks whether the specified file is locked by another process.
+    /// </summary>
+    /// <param name="file">File to test.</param>
+    /// <returns><c>true</c> if the file cannot be opened exclusively.</returns>
+    public static bool IsFileLocked(this FileInfo file) {
+        try {
+            using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {
+                stream.Close();
+            }
+        } catch (IOException) {
+            //the file is unavailable because it is:
+            //still being written to
+            //or being processed by another thread
+            //or does not exist (has already been processed)
+            return true;
+        }
+
+        //file is not locked
+        return false;
+    }
+
+    /// <summary>
+    /// Determines if the file specified by path is locked by another process.
+    /// </summary>
+    /// <param name="fileName">Path to the file.</param>
+    /// <returns><c>true</c> if the file cannot be opened exclusively.</returns>
+    public static bool IsFileLocked(this string fileName) {
+        try {
+            var file = new FileInfo(fileName);
+            using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {
+                stream.Close();
+            }
+        } catch (IOException) {
+            //the file is unavailable because it is:
+            //still being written to
+            //or being processed by another thread
+            //or does not exist (has already been processed)
+            return true;
+        }
+
+        //file is not locked
+        return false;
+    }
+}

--- a/Sources/ImagePlayground.Core/Image.Avatar.cs
+++ b/Sources/ImagePlayground.Core/Image.Avatar.cs
@@ -1,0 +1,103 @@
+using System;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
+public partial class Image : IDisposable {
+    /// <summary>
+    /// Converts the image into an avatar with the specified size and corner radius.
+    /// </summary>
+    /// <param name="width">Desired avatar width.</param>
+    /// <param name="height">Desired avatar height.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
+    public void Avatar(int width, int height, float cornerRadius) {
+        _image.Mutate(x => ConvertToAvatar(x, new Size(width, height), cornerRadius));
+    }
+
+    /// <summary>
+    /// Saves the image as an avatar file.
+    /// </summary>
+    /// <param name="filePath">Destination file path.</param>
+    /// <param name="width">Width of the avatar.</param>
+    /// <param name="height">Height of the avatar.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
+    public void SaveAsAvatar(string filePath, int width, int height, float cornerRadius) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        using var clone = _image.Clone(x => ConvertToAvatar(x, new Size(width, height), cornerRadius));
+        clone.Save(fullPath);
+    }
+
+    /// <summary>
+    /// Writes the avatar image to a stream.
+    /// </summary>
+    /// <param name="stream">Stream to write the avatar to.</param>
+    /// <param name="width">Width of the avatar.</param>
+    /// <param name="height">Height of the avatar.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
+    public void SaveAsAvatar(Stream stream, int width, int height, float cornerRadius) {
+        using var clone = _image.Clone(x => ConvertToAvatar(x, new Size(width, height), cornerRadius));
+        clone.SaveAsPng(stream);
+        stream.Seek(0, SeekOrigin.Begin);
+    }
+
+    /// <summary>
+    /// Saves the image as a circular avatar file.
+    /// </summary>
+    /// <param name="filePath">Destination file path.</param>
+    /// <param name="size">Diameter of the avatar.</param>
+    public void SaveAsCircularAvatar(string filePath, int size) {
+        SaveAsAvatar(filePath, size, size, size / 2f);
+    }
+
+    /// <summary>
+    /// Writes a circular avatar to a stream.
+    /// </summary>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="size">Diameter of the avatar.</param>
+    public void SaveAsCircularAvatar(Stream stream, int size) {
+        SaveAsAvatar(stream, size, size, size / 2f);
+    }
+
+    private static IImageProcessingContext ConvertToAvatar(IImageProcessingContext context, Size size, float cornerRadius) {
+        return ApplyRoundedCorners(context.Resize(new ResizeOptions {
+            Size = size,
+            Mode = ResizeMode.Crop
+        }), cornerRadius);
+    }
+
+    private static IImageProcessingContext ApplyRoundedCorners(IImageProcessingContext context, float cornerRadius) {
+        Size size = context.GetCurrentSize();
+        IPathCollection corners = BuildCorners(size.Width, size.Height, cornerRadius);
+
+        context.SetGraphicsOptions(new GraphicsOptions {
+            Antialias = true,
+            AlphaCompositionMode = PixelAlphaCompositionMode.DestOut
+        });
+
+        foreach (IPath path in corners) {
+            context = context.Fill(Color.Red, path);
+        }
+
+        return context;
+    }
+
+    private static PathCollection BuildCorners(int imageWidth, int imageHeight, float cornerRadius) {
+        var rect = new RectangularPolygon(-0.5f, -0.5f, cornerRadius, cornerRadius);
+        IPath cornerTopLeft = rect.Clip(new EllipsePolygon(cornerRadius - 0.5f, cornerRadius - 0.5f, cornerRadius));
+
+        float rightPos = imageWidth - cornerTopLeft.Bounds.Width + 1;
+        float bottomPos = imageHeight - cornerTopLeft.Bounds.Height + 1;
+
+        IPath cornerTopRight = cornerTopLeft.RotateDegree(90).Translate(rightPos, 0);
+        IPath cornerBottomLeft = cornerTopLeft.RotateDegree(-90).Translate(0, bottomPos);
+        IPath cornerBottomRight = cornerTopLeft.RotateDegree(180).Translate(rightPos, bottomPos);
+
+        return new PathCollection(cornerTopLeft, cornerBottomLeft, cornerTopRight, cornerBottomRight);
+    }
+}

--- a/Sources/ImagePlayground.Core/Image.Crop.cs
+++ b/Sources/ImagePlayground.Core/Image.Crop.cs
@@ -1,0 +1,39 @@
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
+public partial class Image : System.IDisposable {
+    /// <summary>
+    /// Crops the image to a circular region.
+    /// </summary>
+    /// <param name="centerX">Center X coordinate.</param>
+    /// <param name="centerY">Center Y coordinate.</param>
+    /// <param name="radius">Radius of the circle.</param>
+    public void CropCircle(float centerX, float centerY, float radius) {
+        var circle = new EllipsePolygon(centerX, centerY, radius);
+        ApplyClip(circle);
+    }
+
+    /// <summary>
+    /// Crops the image to the specified polygon.
+    /// </summary>
+    /// <param name="points">Polygon vertices.</param>
+    public void CropPolygon(params PointF[] points) {
+        var polygon = new Polygon(new LinearLineSegment(points));
+        ApplyClip(polygon);
+    }
+
+    private void ApplyClip(IPath shape) {
+        using var clone = _image.Clone(ctx => { });
+        _image.Mutate(x => {
+            x.Clear(Color.Transparent);
+            x.Clip(shape, ctx => ctx.DrawImage(clone, 1f));
+        });
+    }
+}

--- a/Sources/ImagePlayground.Core/Image.Exif.cs
+++ b/Sources/ImagePlayground.Core/Image.Exif.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
+public partial class Image {
+    /// <summary>
+    /// Gets all EXIF values from the image.
+    /// </summary>
+    /// <returns>List of EXIF values.</returns>
+    public IReadOnlyList<IExifValue> GetExifValues() =>
+        _image.Metadata.ExifProfile?.Values ?? new List<IExifValue>();
+
+    /// <summary>
+    /// Sets an EXIF value on the image.
+    /// </summary>
+    /// <param name="tag">Tag to set.</param>
+    /// <param name="value">Value for the tag.</param>
+    public void SetExifValue(ExifTag tag, object value) {
+        _image.Metadata.ExifProfile ??= new ExifProfile();
+        var method = typeof(ExifProfile).GetMethod("SetValue")!;
+        var generic = method.MakeGenericMethod(tag.GetType().GenericTypeArguments[0]);
+        generic.Invoke(_image.Metadata.ExifProfile, new[] { tag, value });
+    }
+
+    /// <summary>
+    /// Removes specific EXIF values from the image.
+    /// </summary>
+    /// <param name="tags">Tags to remove.</param>
+    public void RemoveExifValues(params ExifTag[] tags) {
+        var profile = _image.Metadata.ExifProfile;
+        if (profile is null) { return; }
+        foreach (var t in tags) {
+            profile.RemoveValue(t);
+        }
+    }
+
+    /// <summary>
+    /// Clears all EXIF values from the image.
+    /// </summary>
+    public void ClearExifValues() {
+        var profile = _image.Metadata.ExifProfile;
+        if (profile != null) {
+            if (profile.Values is List<IExifValue> list) {
+                list.Clear();
+            }
+        }
+    }
+}

--- a/Sources/ImagePlayground.Core/Image.Icon.cs
+++ b/Sources/ImagePlayground.Core/Image.Icon.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
+public partial class Image {
+    /// <summary>
+    /// Saves the image in ICO format using multiple resolutions.
+    /// </summary>
+    /// <param name="filePath">Destination ICO file path.</param>
+    /// <param name="sizes">Optional list of icon sizes.</param>
+    public void SaveAsIcon(string filePath, params int[] sizes) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        if (sizes == null || sizes.Length == 0) {
+            sizes = new[] { 16, 32, 48, 64, 128, 256 };
+        }
+
+        List<byte[]> frames = new();
+        List<(int Width, int Height)> dims = new();
+
+        foreach (int size in sizes.Distinct().OrderBy(s => s)) {
+            using Image<Rgba32> clone = _image.CloneAs<Rgba32>();
+            clone.Mutate(ctx => ctx.Resize(new ResizeOptions {
+                Mode = ResizeMode.Stretch,
+                Size = new Size(size, size)
+            }));
+            using MemoryStream ms = new();
+            clone.SaveAsPng(ms);
+            frames.Add(ms.ToArray());
+            dims.Add((size, size));
+        }
+
+        using FileStream fs = File.Create(fullPath);
+        using BinaryWriter bw = new(fs);
+        bw.Write((ushort)0); // reserved
+        bw.Write((ushort)1); // type icon
+        bw.Write((ushort)frames.Count);
+
+        int offset = 6 + 16 * frames.Count;
+        for (int i = 0; i < frames.Count; i++) {
+            var (w, h) = dims[i];
+            bw.Write((byte)(w >= 256 ? 0 : w));
+            bw.Write((byte)(h >= 256 ? 0 : h));
+            bw.Write((byte)0);
+            bw.Write((byte)0);
+            bw.Write((ushort)1);
+            bw.Write((ushort)32);
+            bw.Write(frames[i].Length);
+            bw.Write(offset);
+            offset += frames[i].Length;
+        }
+
+        foreach (byte[] data in frames) {
+            bw.Write(data);
+        }
+
+        bw.Flush();
+    }
+}

--- a/Sources/ImagePlayground.Core/Image.Image.cs
+++ b/Sources/ImagePlayground.Core/Image.Image.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
+public partial class Image : IDisposable {
+    /// <summary>
+    /// Draws another image onto the current image from a file path.
+    /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <param name="x">X coordinate where the image will be placed.</param>
+    /// <param name="y">Y coordinate where the image will be placed.</param>
+    /// <param name="opacity">Opacity of the drawn image.</param>
+    public void AddImage(string filePath, int x, int y, float opacity) {
+        string fullPath = Helpers.ResolvePath(filePath);
+
+        var location = new Point(x, y);
+        using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {
+            _image.Mutate(mx => mx.DrawImage(image, location, opacity));
+        }
+    }
+    /// <summary>
+    /// Draws another image onto the current image.
+    /// </summary>
+    /// <param name="image">Image to draw.</param>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="opacity">Opacity of the drawn image.</param>
+    public void AddImage(SixLabors.ImageSharp.Image image, int x, int y, float opacity) {
+        var location = new Point(x, y);
+        _image.Mutate(mx => mx.DrawImage(image, location, opacity));
+    }
+
+    /// <summary>
+    /// Draws another image onto the current image at the given location.
+    /// </summary>
+    /// <param name="image">Image to draw.</param>
+    /// <param name="location">Target location.</param>
+    /// <param name="opacity">Opacity of the drawn image.</param>
+    public void AddImage(SixLabors.ImageSharp.Image image, Point location, float opacity) {
+        _image.Mutate(mx => mx.DrawImage(image, location, opacity));
+    }
+}

--- a/Sources/ImagePlayground.Core/Image.Text.cs
+++ b/Sources/ImagePlayground.Core/Image.Text.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Linq;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Processing;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
+public partial class Image : IDisposable {
+    /// <summary>
+    /// Calculates the dimensions required to render <paramref name="text"/> using the specified font.
+    /// </summary>
+    /// <param name="text">The text to measure.</param>
+    /// <param name="fontSize">Font size in points.</param>
+    /// <param name="fontFamilyName">Name of the font family to use.</param>
+    /// <returns>The measured text rectangle.</returns>
+    public FontRectangle GetTextSize(string text, float fontSize, string fontFamilyName) {
+        if (!SixLabors.Fonts.SystemFonts.TryGet(fontFamilyName, out var fontFamily)) {
+            if (!SixLabors.Fonts.SystemFonts.TryGet("DejaVu Sans", out fontFamily)) {
+                fontFamily = SixLabors.Fonts.SystemFonts.Collection.Families.First();
+            }
+        }
+        var font = fontFamily.CreateFont(fontSize, FontStyle.Regular);
+        var options = new SixLabors.Fonts.TextOptions(font) { Dpi = 72, KerningMode = KerningMode.Auto };
+        var textSize = TextMeasurer.MeasureSize(text, options);
+        return textSize;
+    }
+
+    /// <summary>
+    /// Draws a text string at the specified location.
+    /// </summary>
+    /// <param name="x">The x-coordinate of the text origin.</param>
+    /// <param name="y">The y-coordinate of the text origin.</param>
+    /// <param name="text">The text to render.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size in points.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Horizontal shadow offset.</param>
+    /// <param name="shadowOffsetY">Vertical shadow offset.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline thickness.</param>
+    public void AddText(float x, float y, string text, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.ImageSharp.Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, SixLabors.ImageSharp.Color? outlineColor = null, float outlineWidth = 0f) {
+        if (!SixLabors.Fonts.SystemFonts.TryGet(fontFamilyName, out var fontFamily)) {
+            if (!SixLabors.Fonts.SystemFonts.TryGet("DejaVu Sans", out fontFamily)) {
+                fontFamily = SixLabors.Fonts.SystemFonts.Collection.Families.First();
+            }
+        }
+        var font = fontFamily.CreateFont(fontSize, FontStyle.Regular);
+        var pointF = new PointF(x, y);
+        _image.Mutate(mx => {
+            if (shadowColor != null) {
+                var shadowPoint = new PointF(x + shadowOffsetX, y + shadowOffsetY);
+                mx.DrawText(text, font, shadowColor.Value, shadowPoint);
+            }
+            if (outlineColor != null && outlineWidth > 0f) {
+                mx.DrawText(text, font, Brushes.Solid(outlineColor.Value), Pens.Solid(outlineColor.Value, outlineWidth), pointF);
+            }
+            mx.DrawText(text, font, color, pointF);
+        });
+    }
+
+    /// <summary>
+    /// Draws text confined to a bounding box.
+    /// </summary>
+    /// <param name="x">X coordinate of the bounding box origin.</param>
+    /// <param name="y">Y coordinate of the bounding box origin.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="boxWidth">Width of the text box.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size in points.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="horizontalAlignment">Horizontal alignment within the box.</param>
+    /// <param name="verticalAlignment">Vertical alignment within the box.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Horizontal shadow offset.</param>
+    /// <param name="shadowOffsetY">Vertical shadow offset.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline thickness.</param>
+    public void AddTextBox(float x, float y, string text, float boxWidth, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, SixLabors.ImageSharp.Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, SixLabors.ImageSharp.Color? outlineColor = null, float outlineWidth = 0f) =>
+        AddTextBox(x, y, text, boxWidth, 0f, color, fontSize, fontFamilyName, horizontalAlignment, verticalAlignment, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
+
+    /// <summary>
+    /// Draws text confined to a bounding box with explicit height.
+    /// </summary>
+    /// <param name="x">X coordinate of the box.</param>
+    /// <param name="y">Y coordinate of the box.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="boxWidth">Box width.</param>
+    /// <param name="boxHeight">Box height.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size in points.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="horizontalAlignment">Horizontal alignment inside the box.</param>
+    /// <param name="verticalAlignment">Vertical alignment inside the box.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Horizontal shadow offset.</param>
+    /// <param name="shadowOffsetY">Vertical shadow offset.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline thickness.</param>
+    public void AddTextBox(float x, float y, string text, float boxWidth, float boxHeight, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, SixLabors.ImageSharp.Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, SixLabors.ImageSharp.Color? outlineColor = null, float outlineWidth = 0f) {
+        if (!SixLabors.Fonts.SystemFonts.TryGet(fontFamilyName, out var fontFamily)) {
+            if (!SixLabors.Fonts.SystemFonts.TryGet("DejaVu Sans", out fontFamily)) {
+                fontFamily = SixLabors.Fonts.SystemFonts.Collection.Families.First();
+            }
+        }
+
+        var font = fontFamily.CreateFont(fontSize, FontStyle.Regular);
+        var options = new SixLabors.ImageSharp.Drawing.Processing.RichTextOptions(font) {
+            Dpi = 72,
+            WrappingLength = boxWidth,
+            HorizontalAlignment = horizontalAlignment,
+            VerticalAlignment = verticalAlignment,
+            Origin = new PointF(x, y),
+        };
+
+        _image.Mutate(mx => {
+            if (boxHeight > 0) {
+                var rect = new RectangularPolygon(x, y, boxWidth, boxHeight);
+                mx.Clip(rect, ctx => DrawTextInternal(ctx, options, text, color, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth));
+            } else {
+                DrawTextInternal(mx, options, text, color, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
+            }
+        });
+    }
+
+    private static void DrawTextInternal(IImageProcessingContext ctx, SixLabors.ImageSharp.Drawing.Processing.RichTextOptions options, string text, SixLabors.ImageSharp.Color color, SixLabors.ImageSharp.Color? shadowColor, float shadowOffsetX, float shadowOffsetY, SixLabors.ImageSharp.Color? outlineColor, float outlineWidth) {
+        if (shadowColor != null) {
+            var shadowOptions = options;
+            shadowOptions.Origin = new PointF(options.Origin.X + shadowOffsetX, options.Origin.Y + shadowOffsetY);
+            ctx.DrawText(shadowOptions, text, shadowColor.Value);
+        }
+        if (outlineColor != null && outlineWidth > 0f) {
+            ctx.DrawText(options, text, Brushes.Solid(outlineColor.Value), Pens.Solid(outlineColor.Value, outlineWidth));
+        }
+        ctx.DrawText(options, text, color);
+    }
+}

--- a/Sources/ImagePlayground.Core/Image.Watermark.cs
+++ b/Sources/ImagePlayground.Core/Image.Watermark.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Processing;
+using FontStyle = SixLabors.Fonts.FontStyle;
+using PointF = SixLabors.ImageSharp.PointF;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides image manipulation operations.
+/// </summary>
+public partial class Image : IDisposable {
+
+
+
+    /// <summary>
+    /// Draws a text watermark at the specified coordinates.
+    /// </summary>
+    /// <param name="text">Watermark text.</param>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="color">Watermark color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="padding">Optional padding around the watermark.</param>
+    public void Watermark(string text, float x, float y, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", float padding = 18f) {
+        if (!SystemFonts.TryGet(fontFamilyName, out var fontFamily)) {
+            throw new Exception($"Couldn't find font {fontFamilyName}");
+        }
+
+        var font = fontFamily.CreateFont(fontSize, FontStyle.Regular);
+        //var styles = fontFamily.GetAvailableStyles();
+        //var families = SystemFonts.Families;
+
+        var pointF = new PointF(x, y);
+        _image.Mutate(mx => mx.DrawText(text, font, color, pointF));
+
+    }
+
+    /// <summary>
+    /// Places a text watermark using a predefined placement.
+    /// </summary>
+    /// <param name="text">Watermark text.</param>
+    /// <param name="placement">Placement of the watermark.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family.</param>
+    /// <param name="padding">Padding around the text.</param>
+    public void Watermark(string text, WatermarkPlacement placement, SixLabors.ImageSharp.Color color, float fontSize = 16f, string fontFamilyName = "Arial", float padding = 18f) {
+        var textSize = GetTextSize(text, fontSize, fontFamilyName);
+
+        if (placement == WatermarkPlacement.TopLeft) {
+            Watermark(text, padding, padding, color, fontSize, fontFamilyName, padding);
+        } else if (placement == WatermarkPlacement.TopRight) {
+            Watermark(text, _image.Width - textSize.Width - padding, padding, color, fontSize, fontFamilyName, padding);
+        } else if (placement == WatermarkPlacement.BottomLeft) {
+            Watermark(text, padding, _image.Height - textSize.Height - padding, color, fontSize, fontFamilyName, padding);
+        } else if (placement == WatermarkPlacement.BottomRight) {
+            Watermark(text, _image.Width - textSize.Width - padding, _image.Height - textSize.Height - padding, color, fontSize, fontFamilyName, padding);
+        } else if (placement == WatermarkPlacement.Middle) {
+            Watermark(text, (_image.Width - textSize.Width) / 2, (_image.Height - textSize.Height) / 2, color, fontSize, fontFamilyName, padding);
+        }
+    }
+
+    /// <summary>
+    /// Adds an image watermark using a predefined placement.
+    /// </summary>
+    /// <param name="filePath">Path to the watermark image.</param>
+    /// <param name="placement">Placement for the watermark.</param>
+    /// <param name="opacity">Opacity of the watermark.</param>
+    /// <param name="padding">Padding around the watermark.</param>
+    /// <param name="rotate">Rotation angle.</param>
+    /// <param name="flipMode">Flip mode for the watermark.</param>
+    /// <param name="watermarkPercentage">Size of the watermark in percent (1-100).</param>
+    public void WatermarkImage(string filePath, WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        if (watermarkPercentage < 1 || watermarkPercentage > 100) {
+            throw new ArgumentOutOfRangeException(nameof(watermarkPercentage), "Watermark percentage must be between 1 and 100.");
+        }
+
+        var location = new Point(0, 0);
+        using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {
+            var watermarkWidth = image.Width * watermarkPercentage / 100;
+            var watermarkHeight = image.Height * watermarkPercentage / 100;
+
+            if (watermarkPercentage != 100 || rotate != 0 || flipMode != FlipMode.None) {
+                image.Mutate(mx => {
+                    if (watermarkPercentage != 100) {
+                        mx.Resize(watermarkWidth, watermarkHeight);
+                    }
+
+                    if (flipMode != FlipMode.None) {
+                        mx.Flip(flipMode);
+                    }
+
+                    if (rotate != 0) {
+                        mx.Rotate(rotate);
+                    }
+                });
+            }
+
+            if (placement == WatermarkPlacement.TopLeft) {
+                location = new Point((int)padding, (int)padding);
+            } else if (placement == WatermarkPlacement.TopRight) {
+                location = new Point((int)(_image.Width - image.Width - padding), (int)padding);
+            } else if (placement == WatermarkPlacement.BottomLeft) {
+                location = new Point((int)padding, (int)(_image.Height - image.Height - padding));
+            } else if (placement == WatermarkPlacement.BottomRight) {
+                location = new Point((int)(_image.Width - image.Width - padding), (int)(_image.Height - image.Height - padding));
+            } else if (placement == WatermarkPlacement.Middle) {
+                location = new Point((int)((_image.Width - image.Width) / 2), (int)((_image.Height - image.Height) / 2));
+            }
+            AddImage(image, location, opacity);
+        }
+    }
+
+    /// <summary>
+    /// Adds an image watermark at the specified coordinates.
+    /// </summary>
+    /// <param name="filePath">Path to the watermark image.</param>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="opacity">Opacity of the watermark.</param>
+    /// <param name="rotate">Rotation angle.</param>
+    /// <param name="flipMode">Flip mode for the watermark.</param>
+    /// <param name="watermarkPercentage">Size of the watermark in percent (1-100).</param>
+    public void WatermarkImage(string filePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        if (watermarkPercentage < 1 || watermarkPercentage > 100) {
+            throw new ArgumentOutOfRangeException(nameof(watermarkPercentage), "Watermark percentage must be between 1 and 100.");
+        }
+
+        var location = new Point(x, y);
+        using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {
+            var watermarkWidth = image.Width * watermarkPercentage / 100;
+            var watermarkHeight = image.Height * watermarkPercentage / 100;
+
+            // apply changes
+            if (watermarkPercentage != 100 || rotate != 0 || flipMode != FlipMode.None) {
+                image.Mutate(mx => {
+                    if (watermarkPercentage != 100) {
+                        mx.Resize(watermarkWidth, watermarkHeight);
+                    }
+
+                    if (flipMode != FlipMode.None) {
+                        mx.Flip(flipMode);
+                    }
+
+                    if (rotate != 0) {
+                        mx.Rotate(rotate);
+                    }
+                });
+            }
+            AddImage(image, location, opacity);
+        }
+    }
+
+    /// <summary>
+    /// Adds a tiled watermark image over the entire picture.
+    /// </summary>
+    /// <param name="filePath">Path to the watermark image.</param>
+    /// <param name="spacing">Spacing between tiles.</param>
+    /// <param name="opacity">Opacity of each tile.</param>
+    /// <param name="rotate">Rotation angle applied to the watermark.</param>
+    /// <param name="flipMode">Flip mode for the watermark.</param>
+    /// <param name="watermarkPercentage">Size of the watermark in percent (1-100).</param>
+    public void WatermarkImageTiled(string filePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        if (watermarkPercentage < 1 || watermarkPercentage > 100) {
+            throw new ArgumentOutOfRangeException(nameof(watermarkPercentage), "Watermark percentage must be between 1 and 100.");
+        }
+
+        using (var image = SixLabors.ImageSharp.Image.Load(fullPath)) {
+            var watermarkWidth = image.Width * watermarkPercentage / 100;
+            var watermarkHeight = image.Height * watermarkPercentage / 100;
+
+            if (watermarkPercentage != 100 || rotate != 0 || flipMode != FlipMode.None) {
+                image.Mutate(mx => {
+                    if (watermarkPercentage != 100) {
+                        mx.Resize(watermarkWidth, watermarkHeight);
+                    }
+
+                    if (flipMode != FlipMode.None) {
+                        mx.Flip(flipMode);
+                    }
+
+                    if (rotate != 0) {
+                        mx.Rotate(rotate);
+                    }
+                });
+            }
+
+            for (int y = spacing; y < _image.Height; y += image.Height + spacing) {
+                for (int x = spacing; x < _image.Width; x += image.Width + spacing) {
+                    AddImage(image, x, y, opacity);
+                }
+            }
+        }
+    }
+}

--- a/Sources/ImagePlayground.Core/Image.cs
+++ b/Sources/ImagePlayground.Core/Image.cs
@@ -1,0 +1,560 @@
+﻿using System;
+using System.IO;
+using System.Numerics;
+using Codeuctivity.ImageSharpCompare;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Extensions.Transforms;
+
+namespace ImagePlayground;
+
+/// <summary>
+/// Represents an image loaded using ImageSharp and exposes basic manipulation helpers.
+/// </summary>
+public partial class Image : IDisposable {
+    private SixLabors.ImageSharp.Image _image;
+    private string _filePath;
+
+    /// <summary>Gets the width of the image.</summary>
+    public int Width => _image.Width;
+
+    /// <summary>Gets the height of the image.</summary>
+    public int Height => _image.Height;
+
+    /// <summary>Gets the path the image was loaded from.</summary>
+    public string FilePath => _filePath;
+
+    /// <summary>Gets the metadata associated with the image.</summary>
+    public ImageMetadata Metadata => _image.Metadata;
+
+    /// <summary>Gets information about the underlying pixel type.</summary>
+    public PixelTypeInfo PixelType => _image.PixelType;
+
+    /// <summary>Gets the frame collection for multi-frame images.</summary>
+    public ImageFrameCollection Frames => _image.Frames;
+
+
+
+    /// <summary>
+    /// Applies an adaptive threshold filter to the current image.
+    /// </summary>
+    public void AdaptiveThreshold() {
+        _image.Mutate(x => x.AdaptiveThreshold());
+    }
+
+    /// <summary>
+    /// Automatically rotates the image according to EXIF orientation data.
+    /// </summary>
+    public void AutoOrient() {
+        _image.Mutate(x => x.AutoOrient());
+    }
+
+    /// <summary>
+    /// Fills the background with the specified <paramref name="color"/>.
+    /// </summary>
+    /// <param name="color">Fill color.</param>
+    public void BackgroundColor(Color color) {
+        _image.Mutate(x => x.BackgroundColor(color));
+    }
+
+    /// <summary>
+    /// Converts the image to black and white.
+    /// </summary>
+    public void BlackWhite() {
+        _image.Mutate(x => x.BlackWhite());
+    }
+
+    /// <summary>
+    /// Adjusts brightness by the specified <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Brightness adjustment factor.</param>
+    public void Brightness(float amount) {
+        _image.Mutate(x => x.Brightness(amount));
+    }
+
+    /// <summary>
+    /// Applies a bokeh blur effect.
+    /// </summary>
+    public void BokehBlur() {
+        _image.Mutate(x => x.BokehBlur());
+    }
+
+    /// <summary>
+    /// Applies a simple box blur.
+    /// </summary>
+    public void BoxBlur() {
+        _image.Mutate(x => x.BoxBlur());
+    }
+
+    /// <summary>
+    /// Adjusts contrast by the specified <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Contrast adjustment factor.</param>
+    public void Contrast(float amount) {
+        _image.Mutate(x => x.Contrast(amount));
+    }
+
+    /// <summary>
+    /// Compares the current image with <paramref name="imageToCompare"/>.
+    /// </summary>
+    /// <param name="imageToCompare">Image to compare with.</param>
+    /// <returns>Comparison result.</returns>
+    public ICompareResult Compare(Image imageToCompare) {
+        return ImageSharpCompare.CalcDiff(_image, imageToCompare._image);
+    }
+
+    /// <summary>
+    /// Compares the current image with the file at <paramref name="filePathToCompare"/>.
+    /// </summary>
+    /// <param name="filePathToCompare">Path to the image to compare with.</param>
+    /// <returns>Comparison result.</returns>
+    public ICompareResult Compare(string filePathToCompare) {
+        string fullPath = Helpers.ResolvePath(filePathToCompare);
+
+        using (var imageToCompare = GetImage(fullPath)) {
+            return ImageSharpCompare.CalcDiff(_image, imageToCompare);
+        }
+    }
+
+    /// <summary>
+    /// Creates a difference mask between this image and <paramref name="imageToCompare"/> and saves it.
+    /// </summary>
+    /// <param name="imageToCompare">Image to compare with.</param>
+    /// <param name="filePathToSave">Output path for the mask image.</param>
+    public void Compare(Image imageToCompare, string filePathToSave) {
+        string outFullPath = Helpers.ResolvePath(filePathToSave);
+        using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
+            using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(_image, imageToCompare._image)) {
+                SixLabors.ImageSharp.ImageExtensions.SaveAsPng(maskImage, fileStreamDifferenceMask);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a difference mask between this image and the file at <paramref name="filePathToCompare"/> and saves it.
+    /// </summary>
+    /// <param name="filePathToCompare">Path to the image to compare with.</param>
+    /// <param name="filePathToSave">Output path for the mask image.</param>
+    public void Compare(string filePathToCompare, string filePathToSave) {
+        string fullPath = Helpers.ResolvePath(filePathToCompare);
+        string outFullPath = Helpers.ResolvePath(filePathToSave);
+
+        using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
+            using (var imageToCompare = GetImage(fullPath)) {
+                using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(_image, imageToCompare)) {
+                    SixLabors.ImageSharp.ImageExtensions.SaveAsPng(maskImage, fileStreamDifferenceMask);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Crops the image to the specified <paramref name="rectangle"/>.
+    /// </summary>
+    /// <param name="rectangle">Crop rectangle.</param>
+    public void Crop(Rectangle rectangle) {
+        _image.Mutate(x => x.Crop(rectangle));
+    }
+
+    /// <summary>
+    /// Applies a dithering effect.
+    /// </summary>
+    public void Dither() {
+        _image.Mutate(x => x.Dither());
+    }
+
+    /// <summary>
+    /// Draws a line ending at <paramref name="pointF"/> using the specified <paramref name="color"/> and <paramref name="thickness"/>.
+    /// </summary>
+    /// <param name="color">Line color.</param>
+    /// <param name="thickness">Line thickness.</param>
+    /// <param name="pointF">End point of the line.</param>
+    public void DrawLines(Color color, float thickness, PointF pointF) {
+        _image.Mutate(x => x.DrawLine(color, thickness, pointF));
+    }
+
+    /// <summary>
+    /// Draws a polygon with the specified parameters.
+    /// </summary>
+    /// <param name="color">Polygon color.</param>
+    /// <param name="thickness">Outline thickness.</param>
+    /// <param name="pointF">Polygon vertex.</param>
+    public void DrawPolygon(Color color, float thickness, PointF pointF) {
+        _image.Mutate(x => x.DrawPolygon(color, thickness, pointF));
+    }
+
+    /// <summary>
+    /// Applies a color <paramref name="colorMatrix"/> filter.
+    /// </summary>
+    /// <param name="colorMatrix">Color matrix to apply.</param>
+    public void Filter(ColorMatrix colorMatrix) {
+        _image.Mutate(x => x.Filter(colorMatrix));
+    }
+
+    /// <summary>
+    /// Fills the image with <paramref name="color"/>.
+    /// </summary>
+    /// <param name="color">Fill color.</param>
+    public void Fill(Color color) {
+        _image.Mutate(x => x.Fill(color));
+    }
+
+    /// <summary>
+    /// Fills the specified <paramref name="rectangle"/> with <paramref name="color"/>.
+    /// </summary>
+    /// <param name="color">Fill color.</param>
+    /// <param name="rectangle">Target rectangle.</param>
+    public void Fill(Color color, Rectangle rectangle) {
+        _image.Mutate(x => x.Fill(color, rectangle));
+    }
+
+    /// <summary>
+    /// Flips the image using the provided <paramref name="flipMode"/>.
+    /// </summary>
+    /// <param name="flipMode">Flip mode.</param>
+    public void Flip(FlipMode flipMode) {
+        _image.Mutate(x => x.Flip(flipMode));
+    }
+
+    /// <summary>
+    /// Applies a Gaussian blur using the optional <paramref name="sigma"/> value.
+    /// </summary>
+    /// <param name="sigma">Blur radius.</param>
+    public void GaussianBlur(float? sigma) {
+        if (sigma != null) {
+            _image.Mutate(x => x.GaussianBlur(sigma.Value));
+        } else {
+            _image.Mutate(x => x.GaussianBlur());
+        }
+    }
+
+    /// <summary>
+    /// Sharpens the image using a Gaussian algorithm.
+    /// </summary>
+    /// <param name="sigma">Sharpen strength.</param>
+    public void GaussianSharpen(float? sigma) {
+        if (sigma != null) {
+            _image.Mutate(x => x.GaussianSharpen(sigma.Value));
+        } else {
+            _image.Mutate(x => x.GaussianSharpen());
+        }
+    }
+
+    /// <summary>
+    /// Performs histogram equalization on the image.
+    /// </summary>
+    public void HistogramEqualization() {
+        _image.Mutate(x => x.HistogramEqualization());
+    }
+
+    /// <summary>
+    /// Shifts hue by the specified <paramref name="degrees"/>.
+    /// </summary>
+    /// <param name="degrees">Hue rotation in degrees.</param>
+    public void Hue(float degrees) {
+        _image.Mutate(x => x.Hue(degrees));
+    }
+
+    /// <summary>
+    /// Converts the image to grayscale using the specified <paramref name="grayscaleMode"/>.
+    /// </summary>
+    /// <param name="grayscaleMode">Grayscale conversion mode.</param>
+    public void Grayscale(GrayscaleMode grayscaleMode = GrayscaleMode.Bt709) {
+        _image.Mutate(x => x.Grayscale(grayscaleMode));
+    }
+
+    /// <summary>
+    /// Applies a Kodachrome color filter.
+    /// </summary>
+    public void Kodachrome() {
+        _image.Mutate(x => x.Kodachrome());
+    }
+
+    /// <summary>
+    /// Adjusts lightness by <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Lightness factor.</param>
+    public void Lightness(float amount) {
+        _image.Mutate(x => x.Lightness(amount));
+    }
+
+    /// <summary>
+    /// Applies a lomograph effect.
+    /// </summary>
+    public void Lomograph() {
+        _image.Mutate(x => x.Lomograph());
+    }
+
+    /// <summary>
+    /// Inverts the colors of the image.
+    /// </summary>
+    public void Invert() {
+        _image.Mutate(x => x.Invert());
+    }
+
+    /// <summary>
+    /// Changes opacity by the given <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Opacity factor.</param>
+    public void Opacity(float amount) {
+        _image.Mutate(x => x.Opacity(amount));
+    }
+
+    /// <summary>
+    /// Applies a Polaroid style filter.
+    /// </summary>
+    public void Polaroid() {
+        _image.Mutate(x => x.Polaroid());
+    }
+
+    /// <summary>
+    /// Pixelates the image with a default size.
+    /// </summary>
+    public void Pixelate() {
+        _image.Mutate(x => x.Pixelate());
+    }
+
+    /// <summary>
+    /// Pixelates the image using the specified <paramref name="size"/>.
+    /// </summary>
+    /// <param name="size">Pixel block size.</param>
+    public void Pixelate(int size) {
+        _image.Mutate(x => x.Pixelate(size));
+    }
+
+    /// <summary>
+    /// Applies an oil paint effect using default options.
+    /// </summary>
+    public void OilPaint() {
+        _image.Mutate(x => x.OilPaint());
+    }
+
+    /// <summary>
+    /// Applies an oil paint effect with the given parameters.
+    /// </summary>
+    /// <param name="levels">Number of intensity levels.</param>
+    /// <param name="brushSize">Brush size.</param>
+    public void OilPaint(int levels, int brushSize) {
+        _image.Mutate(x => x.OilPaint(levels, brushSize));
+    }
+
+    /// <summary>
+    /// Rotates the image using the specified <paramref name="rotateMode"/>.
+    /// </summary>
+    /// <param name="rotateMode">Rotation mode.</param>
+    public void Rotate(RotateMode rotateMode) {
+        _image.Mutate(x => x.Rotate(rotateMode));
+    }
+
+    /// <summary>
+    /// Rotates the image by an arbitrary number of <paramref name="degrees"/>.
+    /// </summary>
+    /// <param name="degrees">Angle in degrees.</param>
+    public void Rotate(float degrees) {
+        _image.Mutate(x => x.Rotate(degrees: degrees));
+    }
+
+    /// <summary>
+    /// Rotates and flips the image in a single operation.
+    /// </summary>
+    /// <param name="rotateMode">Rotation mode.</param>
+    /// <param name="flipMode">Flip mode.</param>
+    public void RotateFlip(RotateMode rotateMode, FlipMode flipMode) {
+        _image.Mutate(x => x.RotateFlip(rotateMode, flipMode));
+    }
+
+    /// <summary>
+    /// Resizes the image to the specified dimensions.
+    /// </summary>
+    /// <param name="width">New width.</param>
+    /// <param name="height">New height.</param>
+    /// <param name="keepAspectRatio">Maintain aspect ratio if possible.</param>
+    public void Resize(int? width, int? height, bool keepAspectRatio = true) {
+        if (width == null && height == null) {
+            return;
+        }
+
+        var options = new ResizeOptions();
+        if (keepAspectRatio && (width == null || height == null)) {
+            options.Mode = ResizeMode.Max;
+            options.Size = new Size(width ?? 0, height ?? 0);
+        } else if (keepAspectRatio) {
+            options.Mode = ResizeMode.Max;
+            options.Size = new Size(width ?? _image.Width, height ?? _image.Height);
+        } else {
+            options.Mode = ResizeMode.Stretch;
+            options.Size = new Size(width ?? _image.Width, height ?? _image.Height);
+        }
+
+        _image.Mutate(x => x.Resize(options));
+    }
+
+    /// <summary>
+    /// Resizes the image by a <paramref name="percentage"/> of the current size.
+    /// </summary>
+    /// <param name="percentage">Scale percentage.</param>
+    public void Resize(int percentage) {
+        if (percentage <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(percentage));
+        }
+
+        int width = _image.Width * percentage / 100;
+        int height = _image.Height * percentage / 100;
+        var options = new ResizeOptions {
+            Mode = ResizeMode.Stretch,
+            Size = new Size(width, height)
+        };
+        _image.Mutate(x => x.Resize(options));
+    }
+
+    /// <summary>
+    /// Changes saturation by the specified <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Saturation factor.</param>
+    public void Saturate(float amount) {
+        _image.Mutate(x => x.Saturate(amount));
+    }
+
+    /// <summary>
+    /// Applies a sepia tone effect.
+    /// </summary>
+    public void Sepia() {
+        _image.Mutate(x => x.Sepia());
+    }
+
+    /// <summary>
+    /// Applies a sepia tone effect with the given <paramref name="amount"/>.
+    /// </summary>
+    /// <param name="amount">Sepia intensity.</param>
+    public void Sepia(float amount) {
+        _image.Mutate(x => x.Sepia(amount));
+    }
+
+    /// <summary>
+    /// Skews the image by the specified angles.
+    /// </summary>
+    /// <param name="degreesX">Skew angle on the X axis.</param>
+    /// <param name="degreesY">Skew angle on the Y axis.</param>
+    public void Skew(float degreesX, float degreesY) {
+        _image.Mutate(x => x.Skew(degreesX, degreesY));
+    }
+
+    /// <summary>
+    /// Adds a vignette effect using default options.
+    /// </summary>
+    public void Vignette() {
+        _image.Mutate(x => x.Vignette());
+    }
+
+    /// <summary>
+    /// Adds a vignette effect using the specified <paramref name="color"/>.
+    /// </summary>
+    /// <param name="color">Vignette color.</param>
+    public void Vignette(Color color) {
+        _image.Mutate(x => x.Vignette(color));
+    }
+
+    /// <summary>
+    /// Loads an <see cref="SixLabors.ImageSharp.Image"/> from disk.
+    /// </summary>
+    /// <param name="filePath">Path to the image file.</param>
+    /// <returns>The loaded image.</returns>
+    public static SixLabors.ImageSharp.Image GetImage(string filePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        using (var inStream = System.IO.File.OpenRead(fullPath)) {
+            return SixLabors.ImageSharp.Image.Load(inStream);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new blank image and assigns the provided <paramref name="filePath"/>.
+    /// </summary>
+    /// <param name="filePath">Path where the image will be saved.</param>
+    /// <param name="width">Image width.</param>
+    /// <param name="height">Image height.</param>
+    public void Create(string filePath, int width, int height) {
+        _filePath = filePath;
+        _image = new Image<Rgba32>(width, height);
+    }
+
+    /// <summary>
+    /// Loads an image from the specified path.
+    /// </summary>
+    /// <param name="filePath">Path to the image file.</param>
+    /// <returns>Loaded <see cref="Image"/> instance.</returns>
+    public static Image Load(string filePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+
+        Image image = new Image {
+            _filePath = fullPath,
+            _image = SixLabors.ImageSharp.Image.Load(fullPath)
+        };
+
+        return image;
+    }
+
+    /// <summary>
+    /// Saves the image to disk.
+    /// </summary>
+    /// <param name="filePath">Target path or empty to overwrite the original file.</param>
+    /// <param name="openImage">Whether to open the saved file.</param>
+    /// <param name="quality">Optional quality for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
+    public void Save(string filePath = "", bool openImage = false, int? quality = null, int? compressionLevel = null) {
+        if (filePath == "") {
+            filePath = _filePath;
+        } else {
+            filePath = Helpers.ResolvePath(filePath);
+        }
+        var encoder = Helpers.GetEncoder(System.IO.Path.GetExtension(filePath), quality, compressionLevel);
+        _image.Save(filePath, encoder);
+        Helpers.Open(filePath, openImage);
+    }
+
+    /// <summary>
+    /// Saves the image overwriting the original file and optionally opens it.
+    /// </summary>
+    /// <param name="openImage">Whether to open the saved file.</param>
+    public void Save(bool openImage) {
+        Save("", openImage, null, null);
+    }
+
+    /// <summary>
+    /// Saves the image to the provided <paramref name="stream"/>.
+    /// </summary>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="quality">Optional quality for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
+    public void Save(Stream stream, int? quality = null, int? compressionLevel = null) {
+        string extension = System.IO.Path.GetExtension(_filePath)?.ToLowerInvariant();
+        var encoder = Helpers.GetEncoder(extension, quality, compressionLevel);
+        _image.Save(stream, encoder);
+        stream.Seek(0, SeekOrigin.Begin);
+    }
+
+    /// <summary>
+    /// Converts the image to a memory stream.
+    /// </summary>
+    /// <param name="quality">Optional quality for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
+    /// <returns>Stream containing the image data.</returns>
+    public MemoryStream ToStream(int? quality = null, int? compressionLevel = null) {
+        var ms = new MemoryStream();
+        Save(ms, quality, compressionLevel);
+        return ms;
+    }
+
+    /// <summary>
+    /// Disposes the underlying image resources.
+    /// </summary>
+    public void Dispose() {
+        if (_image != null) {
+            _image.Dispose();
+        }
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.AddText.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.AddText.cs
@@ -1,0 +1,84 @@
+using System.IO;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+    /// <summary>
+    /// Adds text to an image file and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Shadow offset X.</param>
+    /// <param name="shadowOffsetY">Shadow offset Y.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline width.</param>
+    public static void AddText(string filePath, string outFilePath, float x, float y, string text, Color color, float fontSize = 16f, string fontFamilyName = "Arial", Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using var img = Image.Load(fullPath);
+        img.AddText(x, y, text, color, fontSize, fontFamilyName, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
+        img.Save(outFullPath);
+    }
+
+    /// <summary>
+    /// Adds text within a bounding box to an image file and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="x">X coordinate of the box.</param>
+    /// <param name="y">Y coordinate of the box.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="boxWidth">Width of the box.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="horizontalAlignment">Horizontal alignment.</param>
+    /// <param name="verticalAlignment">Vertical alignment.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Shadow offset X.</param>
+    /// <param name="shadowOffsetY">Shadow offset Y.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline width.</param>
+    public static void AddTextBox(string filePath, string outFilePath, float x, float y, string text, float boxWidth, Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) =>
+        AddTextBox(filePath, outFilePath, x, y, text, boxWidth, 0f, color, fontSize, fontFamilyName, horizontalAlignment, verticalAlignment, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
+
+    /// <summary>
+    /// Adds text within a bounding box to an image file and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="x">X coordinate of the box.</param>
+    /// <param name="y">Y coordinate of the box.</param>
+    /// <param name="text">Text to render.</param>
+    /// <param name="boxWidth">Width of the box.</param>
+    /// <param name="boxHeight">Height of the box.</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontSize">Font size.</param>
+    /// <param name="fontFamilyName">Font family name.</param>
+    /// <param name="horizontalAlignment">Horizontal alignment.</param>
+    /// <param name="verticalAlignment">Vertical alignment.</param>
+    /// <param name="shadowColor">Optional shadow color.</param>
+    /// <param name="shadowOffsetX">Shadow offset X.</param>
+    /// <param name="shadowOffsetY">Shadow offset Y.</param>
+    /// <param name="outlineColor">Optional outline color.</param>
+    /// <param name="outlineWidth">Outline width.</param>
+    public static void AddTextBox(string filePath, string outFilePath, float x, float y, string text, float boxWidth, float boxHeight, Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using var img = Image.Load(fullPath);
+        img.AddTextBox(x, y, text, boxWidth, boxHeight, color, fontSize, fontFamilyName, horizontalAlignment, verticalAlignment, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
+        img.Save(outFullPath);
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.AddWatermark.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.AddWatermark.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+    /// <summary>
+    /// Adds an image watermark at one of the predefined placements.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination path.</param>
+    /// <param name="watermarkFilePath">Watermark image path.</param>
+    /// <param name="placement">Placement of the watermark.</param>
+    /// <param name="opacity">Opacity of the watermark.</param>
+    /// <param name="padding">Padding around the watermark.</param>
+    /// <param name="rotate">Rotation in degrees.</param>
+    /// <param name="flipMode">Flip mode applied to watermark.</param>
+    /// <param name="watermarkPercentage">Size of the watermark relative to the base image.</param>
+    public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        using var img = Image.Load(fullPath);
+        img.WatermarkImage(watermarkFilePath, placement, opacity, padding, rotate, flipMode, watermarkPercentage);
+        img.Save(outFullPath);
+    }
+
+    /// <summary>
+    /// Asynchronously adds an image watermark at one of the predefined placements.
+    /// </summary>
+    public static async Task WatermarkImageAsync(string filePath, string outFilePath, string watermarkFilePath, WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        await Task.Run(() => {
+            using var img = Image.Load(fullPath);
+            img.WatermarkImage(watermarkFilePath, placement, opacity, padding, rotate, flipMode, watermarkPercentage);
+            img.Save(outFullPath);
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Adds an image watermark at exact coordinates.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination path.</param>
+    /// <param name="watermarkFilePath">Watermark image path.</param>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <param name="opacity">Opacity of the watermark.</param>
+    /// <param name="rotate">Rotation in degrees.</param>
+    /// <param name="flipMode">Flip mode applied to watermark.</param>
+    /// <param name="watermarkPercentage">Size of the watermark relative to the base image.</param>
+    public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        using var img = Image.Load(fullPath);
+        img.WatermarkImage(watermarkFilePath, x, y, opacity, rotate, flipMode, watermarkPercentage);
+        img.Save(outFullPath);
+    }
+
+    /// <summary>
+    /// Asynchronously adds an image watermark at exact coordinates.
+    /// </summary>
+    public static async Task WatermarkImageAsync(string filePath, string outFilePath, string watermarkFilePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        await Task.Run(() => {
+            using var img = Image.Load(fullPath);
+            img.WatermarkImage(watermarkFilePath, x, y, opacity, rotate, flipMode, watermarkPercentage);
+            img.Save(outFullPath);
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Tiles the watermark image across the target image.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination path.</param>
+    /// <param name="watermarkFilePath">Watermark image path.</param>
+    /// <param name="spacing">Spacing between watermark tiles.</param>
+    /// <param name="opacity">Opacity of the watermark.</param>
+    /// <param name="rotate">Rotation in degrees.</param>
+    /// <param name="flipMode">Flip mode applied to watermark.</param>
+    /// <param name="watermarkPercentage">Size of each watermark relative to the base image.</param>
+    public static void WatermarkImageTiled(string filePath, string outFilePath, string watermarkFilePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        using var img = Image.Load(fullPath);
+        img.WatermarkImageTiled(watermarkFilePath, spacing, opacity, rotate, flipMode, watermarkPercentage);
+        img.Save(outFullPath);
+    }
+
+    /// <summary>
+    /// Asynchronously tiles the watermark image across the target image.
+    /// </summary>
+    public static async Task WatermarkImageTiledAsync(string filePath, string outFilePath, string watermarkFilePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        await Task.Run(() => {
+            using var img = Image.Load(fullPath);
+            img.WatermarkImageTiled(watermarkFilePath, spacing, opacity, rotate, flipMode, watermarkPercentage);
+            img.Save(outFullPath);
+        }).ConfigureAwait(false);
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.Avatar.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Avatar.cs
@@ -1,0 +1,66 @@
+using System.IO;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+    /// <summary>
+    /// Converts an image file to an avatar and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination file path.</param>
+    /// <param name="width">Width of the avatar.</param>
+    /// <param name="height">Height of the avatar.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
+    public static void Avatar(string filePath, string outFilePath, int width, int height, float cornerRadius) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using var img = Image.Load(fullPath);
+        img.SaveAsAvatar(outFullPath, width, height, cornerRadius);
+    }
+
+    /// <summary>
+    /// Converts an image file to an avatar and writes it to a stream.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outStream">Destination stream.</param>
+    /// <param name="width">Width of the avatar.</param>
+    /// <param name="height">Height of the avatar.</param>
+    /// <param name="cornerRadius">Radius of the rounded corners.</param>
+    public static void Avatar(string filePath, Stream outStream, int width, int height, float cornerRadius) {
+        string fullPath = Helpers.ResolvePath(filePath);
+
+        using var img = Image.Load(fullPath);
+        img.SaveAsAvatar(outStream, width, height, cornerRadius);
+    }
+
+    /// <summary>
+    /// Converts an image file to a circular avatar and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination file path.</param>
+    /// <param name="size">Diameter of the avatar.</param>
+    public static void AvatarCircular(string filePath, string outFilePath, int size) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using var img = Image.Load(fullPath);
+        img.SaveAsCircularAvatar(outFullPath, size);
+    }
+
+    /// <summary>
+    /// Converts an image file to a circular avatar and writes it to a stream.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outStream">Destination stream.</param>
+    /// <param name="size">Diameter of the avatar.</param>
+    public static void AvatarCircular(string filePath, Stream outStream, int size) {
+        string fullPath = Helpers.ResolvePath(filePath);
+
+        using var img = Image.Load(fullPath);
+        img.SaveAsCircularAvatar(outStream, size);
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.Base64.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Base64.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+    /// <summary>
+    /// Reads an image file and returns its Base64 representation.
+    /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <returns>Base64 encoded string.</returns>
+    public static string ConvertToBase64(string filePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        using var stream = File.OpenRead(fullPath);
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return Convert.ToBase64String(ms.ToArray());
+    }
+
+    /// <summary>
+    /// Writes a Base64 encoded image to disk.
+    /// </summary>
+    /// <param name="base64">Base64 encoded image content.</param>
+    /// <param name="outFilePath">Destination file path.</param>
+    public static void ConvertFromBase64(string base64, string outFilePath) {
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        var bytes = Convert.FromBase64String(base64);
+        File.WriteAllBytes(outFullPath, bytes);
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.Compare.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Compare.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using Codeuctivity.ImageSharpCompare;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+
+    /// <summary>
+    /// Compares two images and returns the difference result.
+    /// </summary>
+    /// <param name="filePath">Path to the first image.</param>
+    /// <param name="filePathToCompare">Path to the image to compare against.</param>
+    /// <returns>Comparison result.</returns>
+    public static ICompareResult Compare(string filePath, string filePathToCompare) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);
+
+        return ImageSharpCompare.CalcDiff(fullPath, fullPathToCompare);
+    }
+
+    /// <summary>
+    /// Compares two images and saves the difference mask.
+    /// </summary>
+    /// <param name="filePath">Path to the first image.</param>
+    /// <param name="filePathToCompare">Path to the image to compare against.</param>
+    /// <param name="filePathToSave">Destination path for the difference mask.</param>
+    public static void Compare(string filePath, string filePathToCompare, string filePathToSave) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);
+        string outFullPath = Helpers.ResolvePath(filePathToSave);
+
+        using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
+            using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(fullPath, fullPathToCompare)) {
+                SixLabors.ImageSharp.ImageExtensions.SaveAsPng(maskImage, fileStreamDifferenceMask);
+            }
+        }
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.Crop.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Crop.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+    /// <summary>
+    /// Crops an image to the specified rectangle and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="rectangle">Rectangle to crop.</param>
+    public static void Crop(string filePath, string outFilePath, Rectangle rectangle) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using var img = Image.Load(fullPath);
+        img.Crop(rectangle);
+        img.Save(outFullPath);
+    }
+
+    /// <summary>
+    /// Crops an image to a circle and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="centerX">Circle center X.</param>
+    /// <param name="centerY">Circle center Y.</param>
+    /// <param name="radius">Circle radius.</param>
+    public static void CropCircle(string filePath, string outFilePath, float centerX, float centerY, float radius) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using var img = Image.Load(fullPath);
+        img.CropCircle(centerX, centerY, radius);
+        img.Save(outFullPath);
+    }
+
+    /// <summary>
+    /// Crops an image using a polygon and saves the result.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="points">Polygon points.</param>
+    public static void CropPolygon(string filePath, string outFilePath, params PointF[] points) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using var img = Image.Load(fullPath);
+        img.CropPolygon(points);
+        img.Save(outFullPath);
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.GetImageThumbnail.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.GetImageThumbnail.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+    private static string GetThumbnailCacheDirectory() {
+        string dir = Path.Combine(Path.GetTempPath(), "ImagePlayground", "thumbnails");
+        if (!Directory.Exists(dir)) {
+            Directory.CreateDirectory(dir);
+        }
+        return dir;
+    }
+
+    private static string ComputeFileHash(string path) {
+        using var stream = File.OpenRead(path);
+        using var sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(stream);
+        return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Gets a thumbnail for the specified image. The thumbnail is cached based on the image hash.
+    /// </summary>
+    /// <param name="filePath">Path to the image file.</param>
+    /// <param name="width">Thumbnail width.</param>
+    /// <param name="height">Thumbnail height.</param>
+    /// <param name="keepAspectRatio">Whether to maintain aspect ratio.</param>
+    /// <param name="sampler">Optional sampler algorithm.</param>
+    /// <returns>Thumbnail image.</returns>
+    public static Image GetImageThumbnail(string filePath, int width, int height, bool keepAspectRatio = true, Sampler? sampler = null) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string hash = ComputeFileHash(fullPath);
+        string cacheDir = GetThumbnailCacheDirectory();
+        string thumbPath = Path.Combine(cacheDir, $"{hash}_{width}x{height}.png");
+
+        if (!File.Exists(thumbPath)) {
+            Resize(fullPath, thumbPath, width, height, keepAspectRatio, sampler);
+        }
+
+        return Image.Load(thumbPath);
+    }
+
+    /// <summary>
+    /// Removes all cached thumbnails.
+    /// </summary>
+    public static void ClearThumbnailCache() {
+        string cacheDir = Path.Combine(Path.GetTempPath(), "ImagePlayground", "thumbnails");
+        if (Directory.Exists(cacheDir)) {
+            Directory.Delete(cacheDir, true);
+        }
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
@@ -1,0 +1,99 @@
+using System.IO;
+using System.Text.Json;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Iptc;
+using SixLabors.ImageSharp.Metadata.Profiles.Xmp;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+    /// <summary>
+    /// Serialization model for image metadata.
+    /// </summary>
+    private sealed class SerializedImageMetadata {
+        /// <summary>Horizontal resolution.</summary>
+        public double HorizontalResolution { get; set; }
+
+        /// <summary>Vertical resolution.</summary>
+        public double VerticalResolution { get; set; }
+
+        /// <summary>Resolution measurement units.</summary>
+        public PixelResolutionUnit ResolutionUnits { get; set; }
+
+        /// <summary>Serialized Exif profile.</summary>
+        public byte[]? ExifProfile { get; set; }
+
+        /// <summary>Serialized XMP profile.</summary>
+        public byte[]? XmpProfile { get; set; }
+
+        /// <summary>Serialized ICC profile.</summary>
+        public byte[]? IccProfile { get; set; }
+
+        /// <summary>Serialized IPTC profile.</summary>
+        public byte[]? IptcProfile { get; set; }
+    }
+    /// <summary>
+    /// Exports metadata from an image to a JSON string.
+    /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <returns>Serialized metadata.</returns>
+    public static string ExportMetadata(string filePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        using var img = Image.Load(fullPath);
+        var meta = img.Metadata;
+        var data = new SerializedImageMetadata {
+            HorizontalResolution = meta.HorizontalResolution,
+            VerticalResolution = meta.VerticalResolution,
+            ResolutionUnits = meta.ResolutionUnits,
+            ExifProfile = meta.ExifProfile?.ToByteArray(),
+            XmpProfile = meta.XmpProfile?.ToByteArray(),
+            IccProfile = meta.IccProfile?.ToByteArray(),
+            IptcProfile = meta.IptcProfile?.Data
+        };
+        return JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    /// <summary>
+    /// Exports metadata from an image and writes it to a file.
+    /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <param name="outFilePath">Destination file for metadata.</param>
+    public static void ExportMetadata(string filePath, string outFilePath) {
+        string json = ExportMetadata(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        File.WriteAllText(outFullPath, json);
+    }
+
+    /// <summary>
+    /// Imports metadata from a JSON file and saves the updated image.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="metadataFilePath">Path to JSON metadata file.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    public static void ImportMetadata(string filePath, string metadataFilePath, string outFilePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string metaFullPath = Helpers.ResolvePath(metadataFilePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        string json = File.ReadAllText(metaFullPath);
+        SerializedImageMetadata? data = JsonSerializer.Deserialize<SerializedImageMetadata>(json);
+        if (data is null) {
+            throw new InvalidDataException("Metadata file is invalid");
+        }
+
+        using var img = Image.Load(fullPath);
+        img.Metadata.HorizontalResolution = data.HorizontalResolution;
+        img.Metadata.VerticalResolution = data.VerticalResolution;
+        img.Metadata.ResolutionUnits = data.ResolutionUnits;
+        img.Metadata.ExifProfile = data.ExifProfile != null ? new ExifProfile(data.ExifProfile) : null;
+        img.Metadata.XmpProfile = data.XmpProfile != null ? new XmpProfile(data.XmpProfile) : null;
+        img.Metadata.IccProfile = data.IccProfile != null ? new IccProfile(data.IccProfile) : null;
+        img.Metadata.IptcProfile = data.IptcProfile != null ? new IptcProfile(data.IptcProfile) : null;
+        img.Save(outFullPath);
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.Thumbnails.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Thumbnails.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using SixLabors.ImageSharp;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+    /// <summary>
+    /// Generates resized copies for all images found in <paramref name="directoryPath"/>.
+    /// </summary>
+    /// <param name="directoryPath">Folder containing the source images.</param>
+    /// <param name="outputDirectory">Destination folder for the thumbnails.</param>
+    /// <param name="width">Thumbnail width.</param>
+    /// <param name="height">Thumbnail height.</param>
+    /// <param name="keepAspectRatio">Whether to maintain aspect ratio.</param>
+    /// <param name="sampler">Optional sampler algorithm.</param>
+    public static void GenerateThumbnails(string directoryPath, string outputDirectory, int width, int height, bool keepAspectRatio = true, Sampler? sampler = null) {
+        string inputDir = Helpers.ResolvePath(directoryPath);
+        string outDir = Helpers.ResolvePath(outputDirectory);
+
+        if (!Directory.Exists(inputDir)) {
+            throw new DirectoryNotFoundException($"Input directory not found: {directoryPath}");
+        }
+
+        if (!Directory.Exists(outDir)) {
+            Directory.CreateDirectory(outDir);
+        }
+
+        foreach (var file in Directory.EnumerateFiles(inputDir)) {
+            try {
+                using var inStream = File.OpenRead(file);
+                using SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream);
+                Resize(image, width, height, keepAspectRatio, sampler);
+                string destPath = Path.Combine(outDir, Path.GetFileName(file));
+                try {
+                    image.Save(destPath);
+                } catch (Exception ex) when (ex is SixLabors.ImageSharp.UnknownImageFormatException || ex is NotSupportedException) {
+                    File.Copy(file, destPath, true);
+                }
+            } catch (SixLabors.ImageSharp.UnknownImageFormatException) {
+            }
+        }
+    }
+}

--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Processors.Transforms;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for image manipulation.
+/// </summary>
+public partial class ImageHelper {
+    /// <summary>
+    /// Converts an image from one format to another.
+    /// Following image formats are supported: bmp, gif, jpeg, pbm, png, tga, tiff, webp
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    /// <param name="quality">Optional quality value for lossy formats.</param>
+    /// <param name="compressionLevel">Optional compression level for PNG/WebP.</param>
+    /// <exception cref="UnknownImageFormatException"></exception>
+    public static void ConvertTo(string filePath, string outFilePath, int? quality = null, int? compressionLevel = null) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        using (var inStream = System.IO.File.OpenRead(fullPath))
+        using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
+            FileInfo fileInfo = new FileInfo(outFilePath);
+            if (fileInfo.Extension == ".ico") {
+                System.IO.File.Copy(fullPath, outFullPath, true);
+            } else {
+                var encoder = Helpers.GetEncoder(fileInfo.Extension, quality, compressionLevel);
+                image.Save(outFullPath, encoder);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resizes an image to the specified width and height.
+    /// Following image formats are supported: GIF, JPEG, PNG, JFIF, GIF
+    /// </summary>
+    /// <param name="filePath"></param>
+    /// <param name="outFilePath"></param>
+    /// <param name="width"></param>
+    /// <param name="height"></param>
+    /// <param name="keepAspectRatio"></param>
+    /// <param name="sampler"></param>
+    public static void Resize(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using (var inStream = System.IO.File.OpenRead(fullPath))
+        using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
+            Resize(image, width, height, keepAspectRatio, sampler);
+            image.Save(outFullPath);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously resizes an image to the specified width and height.
+    /// </summary>
+    public static async Task ResizeAsync(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        await Task.Run(() => {
+            using var inStream = System.IO.File.OpenRead(fullPath);
+            using SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream);
+            Resize(image, width, height, keepAspectRatio, sampler);
+            image.Save(outFullPath);
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resizes the provided <paramref name="image"/> to the specified dimensions.
+    /// </summary>
+    /// <param name="image">Image instance to resize.</param>
+    /// <param name="width">Desired width or <c>null</c> to auto calculate.</param>
+    /// <param name="height">Desired height or <c>null</c> to auto calculate.</param>
+    /// <param name="keepAspectRatio">Preserve the original aspect ratio.</param>
+    /// <param name="sampler">Optional resampler algorithm.</param>
+    /// <returns>Resized image instance.</returns>
+    public static SixLabors.ImageSharp.Image Resize(SixLabors.ImageSharp.Image image, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
+        if (width == null && height == null) {
+            return image;
+        }
+
+        if (width != null && height != null && image.Width == width && image.Height == height) {
+            return image;
+        } else if (width != null && height == null && image.Width == width) {
+            return image;
+        } else if (height != null && width == null && image.Height == height) {
+            return image;
+        }
+
+        var options = new ResizeOptions();
+        if (keepAspectRatio && (width == null || height == null)) {
+            options.Mode = ResizeMode.Max;
+            options.Size = new Size(width ?? 0, height ?? 0);
+        } else {
+            options.Mode = ResizeMode.Stretch;
+            options.Size = new Size(width ?? image.Width, height ?? image.Height);
+        }
+
+        if (sampler != null) {
+            options.Sampler = Helpers.GetResampler(sampler.Value);
+        }
+
+        image.Mutate(x => x.Resize(options));
+        return image;
+    }
+
+    /// <summary>
+    /// Resizes an image to the specified percentage.
+    /// </summary>
+    /// <param name="filePath"></param>
+    /// <param name="outFilePath"></param>
+    /// <param name="percentage"></param>
+    public static void Resize(string filePath, string outFilePath, int percentage) {
+        if (percentage <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(percentage));
+        }
+
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using (var inStream = System.IO.File.OpenRead(fullPath))
+        using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
+            int width = image.Width * percentage / 100;
+            int height = image.Height * percentage / 100;
+            Resize(image, width, height, false);
+            image.Save(outFullPath);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously resizes an image to the specified percentage.
+    /// </summary>
+    public static async Task ResizeAsync(string filePath, string outFilePath, int percentage) {
+        if (percentage <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(percentage));
+        }
+
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        await Task.Run(() => {
+            using var inStream = System.IO.File.OpenRead(fullPath);
+            using SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream);
+            int width = image.Width * percentage / 100;
+            int height = image.Height * percentage / 100;
+            Resize(image, width, height, false);
+            image.Save(outFullPath);
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Combines two images either horizontally or vertically.
+    /// </summary>
+    /// <param name="filePath">Path to the first image.</param>
+    /// <param name="filePath2">Path to the second image.</param>
+    /// <param name="outFilePath">Destination path of the combined image.</param>
+    /// <param name="resizeToFit">Resize images so they fit next to each other.</param>
+    /// <param name="imagePlacement">Determines placement of <paramref name="filePath2"/>.</param>
+    public static void Combine(string filePath, string filePath2, string outFilePath, bool resizeToFit = false, ImagePlacement imagePlacement = ImagePlacement.Bottom) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string fullPath2 = Helpers.ResolvePath(filePath2);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+
+        using (var inStream = System.IO.File.OpenRead(fullPath))
+        using (var inStream2 = System.IO.File.OpenRead(fullPath2))
+        using (SixLabors.ImageSharp.Image imageIn1 = SixLabors.ImageSharp.Image.Load(inStream)) {
+            using (SixLabors.ImageSharp.Image imageIn2 = SixLabors.ImageSharp.Image.Load(inStream2)) {
+                var image = imageIn1;
+                var image2 = imageIn2;
+
+                int outputWidth = 0;
+                int outputHeight = 0;
+                if (imagePlacement == ImagePlacement.Bottom) {
+                    outputWidth = image.Width > image2.Width ? image.Width : image2.Width;
+                    outputHeight = image.Height + image2.Height;
+                    if (resizeToFit) {
+                        image = Resize(image, outputWidth, null);
+                        image2 = Resize(image2, outputWidth, null);
+                    }
+                } else if (imagePlacement == ImagePlacement.Top) {
+                    outputWidth = image.Width > image2.Width ? image.Width : image2.Width;
+                    outputHeight = image.Height + image2.Height;
+                    if (resizeToFit) {
+                        image = Resize(image, outputWidth, null);
+                        image2 = Resize(image2, outputWidth, null);
+                    }
+                } else if (imagePlacement == ImagePlacement.Left) {
+                    outputWidth = image.Width + image2.Width;
+                    outputHeight = image.Height > image2.Height ? image.Height : image2.Height;
+                    if (resizeToFit) {
+                        image = Resize(image, null, outputHeight);
+                        image2 = Resize(image2, null, outputHeight);
+                    }
+                } else if (imagePlacement == ImagePlacement.Right) {
+                    outputWidth = image.Width + image2.Width;
+                    outputHeight = image.Height > image2.Height ? image.Height : image2.Height;
+                    if (resizeToFit) {
+                        image = Resize(image, null, outputHeight);
+                        image2 = Resize(image2, null, outputHeight);
+                    }
+                } else {
+                    // this is not going to happen
+                    throw new ArgumentException("Invalid ImagePlacement");
+                }
+
+                using (Image<Rgba32> outputImage = new Image<Rgba32>(outputWidth, outputHeight)) {
+                    if (imagePlacement == ImagePlacement.Bottom) {
+                        outputImage.Mutate(x => x
+                            .DrawImage(image, new Point(0, 0), 1f)
+                            .DrawImage(image2, new Point(0, image.Height), 1f)
+                        );
+                    } else if (imagePlacement == ImagePlacement.Top) {
+                        outputImage.Mutate(x => x
+                            .DrawImage(image2, new Point(0, 0), 1f)
+                            .DrawImage(image, new Point(0, image2.Height), 1f)
+                        );
+                    } else if (imagePlacement == ImagePlacement.Left) {
+                        outputImage.Mutate(x => x
+                            .DrawImage(image2, new Point(0, 0), 1f)
+                            .DrawImage(image, new Point(image2.Width, 0), 1f)
+                        );
+                    } else if (imagePlacement == ImagePlacement.Right) {
+                        outputImage.Mutate(x => x
+                            .DrawImage(image, new Point(0, 0), 1f)
+                            .DrawImage(image2, new Point(image.Width, 0), 1f)
+                        );
+                    }
+
+                    outputImage.Save(outFullPath);
+                }
+            }
+        }
+
+    }
+
+    /// <summary>
+    /// Generates a patterned image and saves it to disk.
+    /// </summary>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="width">Image width.</param>
+    /// <param name="height">Image height.</param>
+    /// <param name="color">Background color.</param>
+    /// <param name="open">Open the image after saving.</param>
+    public static void Create(string filePath, int width, int height, Color color, bool open = false) {
+        string fullPath = Helpers.ResolvePath(filePath);
+
+        using (Image<Rgba32> outputImage = new Image<Rgba32>(width, height)) {
+            //outputImage.Mutate(x => x.Fill(color));
+            //outputImage.Mutate(x => x.BackgroundColor(color));
+
+            int sizeRow = 20;
+            int sizeColumn = 20;
+            int rowCount = height / sizeRow;
+            int columnCount = width / sizeColumn;
+            int imageRadius = 20;
+
+            outputImage.Mutate(ic => {
+                ic.Fill(color);
+
+                var rotation = GeometryUtilities.DegreeToRadian(45);
+                var rand = new Random();
+
+                for (var row = 1; row < rowCount; row++) {
+                    for (var col = 1; col < columnCount; col++) {
+                        var r = (byte)rand.Next(0, 255);
+                        var g = (byte)rand.Next(0, 255);
+                        var b = (byte)rand.Next(0, 255);
+                        var squareColor = new Color(new Rgba32(r, g, b, 255));
+
+                        var polygon = new RegularPolygon(sizeColumn * col, sizeRow * row, 4, imageRadius, rotation);
+                        ic.Fill(squareColor, polygon);
+                    }
+                }
+            });
+            outputImage.Save(fullPath);
+        }
+
+        Helpers.Open(fullPath, open);
+    }
+
+}

--- a/Sources/ImagePlayground.Core/ImagePlacement.cs
+++ b/Sources/ImagePlayground.Core/ImagePlacement.cs
@@ -1,0 +1,16 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Describes a relative placement for combining images.
+/// </summary>
+public enum ImagePlacement
+{
+    /// <summary>Place image at the bottom of the canvas.</summary>
+    Bottom,
+    /// <summary>Place image on the right side.</summary>
+    Right,
+    /// <summary>Place image at the top of the canvas.</summary>
+    Top,
+    /// <summary>Place image on the left side.</summary>
+    Left
+}

--- a/Sources/ImagePlayground.Core/ImagePlayground.Core.csproj
+++ b/Sources/ImagePlayground.Core/ImagePlayground.Core.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
+    <AssemblyName>ImagePlayground.Core</AssemblyName>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="2.0.182" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Collections" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Threading" />
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.IO" />
+    <Using Include="System.Net" />
+    <Using Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+</Project>

--- a/Sources/ImagePlayground.Core/ImageType.cs
+++ b/Sources/ImagePlayground.Core/ImageType.cs
@@ -1,0 +1,24 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Supported image container formats.
+/// </summary>
+public enum ImageType
+{
+    /// <summary>Bitmap image format.</summary>
+    Bmp,
+    /// <summary>GIF image format.</summary>
+    Gif,
+    /// <summary>JPEG image format.</summary>
+    Jpeg,
+    /// <summary>Portable bitmap format.</summary>
+    Pbm,
+    /// <summary>PNG image format.</summary>
+    Png,
+    /// <summary>TGA image format.</summary>
+    Tga,
+    /// <summary>TIFF image format.</summary>
+    Tiff,
+    /// <summary>WebP image format.</summary>
+    WebP
+}

--- a/Sources/ImagePlayground.Core/Sampler.cs
+++ b/Sources/ImagePlayground.Core/Sampler.cs
@@ -1,0 +1,36 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Resampling algorithms used when resizing images.
+/// </summary>
+public enum Sampler
+{
+    /// <summary>Nearest neighbour sampling.</summary>
+    NearestNeighbor,
+    /// <summary>Box resampling.</summary>
+    Box,
+    /// <summary>Triangle resampling.</summary>
+    Triangle,
+    /// <summary>Hermite resampling.</summary>
+    Hermite,
+    /// <summary>Lanczos with a radius of 2.</summary>
+    Lanczos2,
+    /// <summary>Lanczos with a radius of 3.</summary>
+    Lanczos3,
+    /// <summary>Lanczos with a radius of 5.</summary>
+    Lanczos5,
+    /// <summary>Lanczos with a radius of 8.</summary>
+    Lanczos8,
+    /// <summary>Mitchell–Netravali filter.</summary>
+    MitchellNetravali,
+    /// <summary>Catmull–Rom spline.</summary>
+    CatmullRom,
+    /// <summary>Robidoux filter.</summary>
+    Robidoux,
+    /// <summary>Sharper variant of Robidoux filter.</summary>
+    RobidouxSharp,
+    /// <summary>B-Spline resampling.</summary>
+    Spline,
+    /// <summary>Welch resampling.</summary>
+    Welch
+}

--- a/Sources/ImagePlayground.Core/WatermarkPlacement.cs
+++ b/Sources/ImagePlayground.Core/WatermarkPlacement.cs
@@ -1,0 +1,13 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Supported watermark placements.
+/// </summary>
+public enum WatermarkPlacement
+{
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+    Middle
+}

--- a/Sources/ImagePlayground.Examples/Example.BarCode.cs
+++ b/Sources/ImagePlayground.Examples/Example.BarCode.cs
@@ -26,11 +26,11 @@ internal partial class Example {
 
         Console.WriteLine("[*] Creating Barcode EAN13 - PNG");
         string filePath = System.IO.Path.Combine(folderPath, "BarcodeEAN13.png");
-        BarCode.Generate(BarCode.BarcodeTypes.EAN, "901234123457", filePath);
+        BarCode.Generate(BarcodeType.EAN, "901234123457", filePath);
 
         Console.WriteLine("[*] Creating Barcode EAN8 - PNG");
         filePath = System.IO.Path.Combine(folderPath, "BarcodeEAN7.png");
-        BarCode.Generate(BarCode.BarcodeTypes.EAN, "96385074", filePath);
+        BarCode.Generate(BarcodeType.EAN, "96385074", filePath);
 
         Console.WriteLine("[*] Reading Barcode code - PNG: ");
         var read = BarCode.Read(filePath);
@@ -44,7 +44,7 @@ internal partial class Example {
     public static void DataMatrixSample(string folderPath) {
         Console.WriteLine("[*] Creating Data Matrix barcode - PNG");
         string filePath = System.IO.Path.Combine(folderPath, "DataMatrix.png");
-        BarCode.Generate(BarCode.BarcodeTypes.DataMatrix, "DataMatrixExample", filePath);
+        BarCode.Generate(BarcodeType.DataMatrix, "DataMatrixExample", filePath);
 
         Console.WriteLine("[*] Reading Data Matrix barcode:");
         var read = BarCode.Read(filePath);
@@ -58,7 +58,7 @@ internal partial class Example {
     public static void Pdf417Sample(string folderPath) {
         Console.WriteLine("[*] Creating PDF417 barcode - PNG");
         string filePath = System.IO.Path.Combine(folderPath, "Pdf417.png");
-        BarCode.Generate(BarCode.BarcodeTypes.PDF417, "Pdf417Example", filePath);
+        BarCode.Generate(BarcodeType.PDF417, "Pdf417Example", filePath);
 
         Console.WriteLine("[*] Reading PDF417 barcode:");
         var read = BarCode.Read(filePath);

--- a/Sources/ImagePlayground.Examples/Example.Charts.cs
+++ b/Sources/ImagePlayground.Examples/Example.Charts.cs
@@ -72,7 +72,7 @@ internal partial class Example {
         var anns = new List<Charts.ChartAnnotation> {
                 new Charts.ChartAnnotation(1, 12, "first", true)
             };
-        Charts.Generate(lines, annotated, 500, 500, null, null, null, false, Charts.ChartTheme.Default, anns);
+        Charts.Generate(lines, annotated, 500, 500, null, null, null, false, ChartTheme.Default, anns);
 
         Console.WriteLine("[*] Creating Heatmap chart");
         string heatmap = Path.Combine(folderPath, "ChartsHeatmap.png");

--- a/Sources/ImagePlayground.Examples/Example.ImageTextWatermark.cs
+++ b/Sources/ImagePlayground.Examples/Example.ImageTextWatermark.cs
@@ -17,13 +17,13 @@ internal partial class Example {
         string targetPath = System.IO.Path.Combine(folderPath, "PrzemyslawKlysAndKulkozaurr_TextWatermark.png");
         using (var image = Image.Load(filePath)) {
             // image.Watermark("Evotec Example", Color.Red, 10, 0, 15, 30);
-            image.Watermark("Evotec Services Bottom Left", Image.WatermarkPlacement.BottomLeft, Color.DarkCyan);
-            image.Watermark("Evotec Services Bottom Right", Image.WatermarkPlacement.BottomRight, Color.DarkCyan);
-            image.Watermark("Evotec Services Top Left", Image.WatermarkPlacement.TopLeft, Color.DarkCyan);
-            image.Watermark("Evotec Services Top Right", Image.WatermarkPlacement.TopRight, Color.DarkCyan);
+            image.Watermark("Evotec Services Bottom Left", WatermarkPlacement.BottomLeft, Color.DarkCyan);
+            image.Watermark("Evotec Services Bottom Right", WatermarkPlacement.BottomRight, Color.DarkCyan);
+            image.Watermark("Evotec Services Top Left", WatermarkPlacement.TopLeft, Color.DarkCyan);
+            image.Watermark("Evotec Services Top Right", WatermarkPlacement.TopRight, Color.DarkCyan);
             //image.Watermark("Evotec Services Middle", Image.WatermarkPlacement.Middle, Color.DarkCyan);
 
-            image.WatermarkImage(waterMark, Image.WatermarkPlacement.Middle, 0.5f);
+            image.WatermarkImage(waterMark, WatermarkPlacement.Middle, 0.5f);
 
             image.Save(targetPath);
         }

--- a/Sources/ImagePlayground.Examples/ImagePlayground.Examples.csproj
+++ b/Sources/ImagePlayground.Examples/ImagePlayground.Examples.csproj
@@ -6,7 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ImagePlayground\ImagePlayground.csproj" />
+    <ProjectReference Include="..\ImagePlayground.Core\ImagePlayground.Core.csproj" />
+    <ProjectReference Include="..\ImagePlayground.Chart\ImagePlayground.Chart.csproj" />
+    <ProjectReference Include="..\ImagePlayground.BarCode\ImagePlayground.BarCode.csproj" />
+    <ProjectReference Include="..\ImagePlayground.QRCode\ImagePlayground.QRCode.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
@@ -28,7 +28,7 @@ public sealed class AddImageWatermarkCmdlet : PSCmdlet {
 
     /// <summary>Watermark placement when coordinates are not specified.</summary>
     [Parameter(ParameterSetName = ParameterSetPlacement)]
-    public ImagePlayground.Image.WatermarkPlacement Placement { get; set; } = ImagePlayground.Image.WatermarkPlacement.Middle;
+    public WatermarkPlacement Placement { get; set; } = WatermarkPlacement.Middle;
 
     /// <summary>X coordinate for custom placement.</summary>
     [Parameter(ParameterSetName = ParameterSetCoordinates)]

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageBarCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageBarCode.cs
@@ -12,7 +12,7 @@ namespace ImagePlayground.PowerShell;
 public sealed class NewImageBarCodeCmdlet : PSCmdlet {
     /// <summary>Barcode type.</summary>
     [Parameter(Mandatory = true, Position = 0)]
-    public ImagePlayground.BarCode.BarcodeTypes Type { get; set; }
+public BarcodeType Type { get; set; }
 
     /// <summary>Value encoded in the barcode.</summary>
     [Parameter(Mandatory = true, Position = 1)]
@@ -25,6 +25,6 @@ public sealed class NewImageBarCodeCmdlet : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.BarCode.Generate(Type, Value, output);
+        BarCode.Generate(Type, Value, output);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -59,7 +59,7 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
 
     /// <summary>Chart theme.</summary>
     [Parameter]
-    public Charts.ChartTheme Theme { get; set; } = Charts.ChartTheme.Default;
+    public ChartTheme Theme { get; set; } = ChartTheme.Default;
 
     /// <inheritdoc />
     protected override void ProcessRecord() {

--- a/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
+++ b/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
@@ -33,7 +33,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ImagePlayground\ImagePlayground.csproj" />
+        <ProjectReference Include="..\ImagePlayground.Core\ImagePlayground.Core.csproj" />
+        <ProjectReference Include="..\ImagePlayground.Chart\ImagePlayground.Chart.csproj" />
+        <ProjectReference Include="..\ImagePlayground.BarCode\ImagePlayground.BarCode.csproj" />
+        <ProjectReference Include="..\ImagePlayground.QRCode\ImagePlayground.QRCode.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/ImagePlayground.QRCode/ImagePlayground.QRCode.csproj
+++ b/Sources/ImagePlayground.QRCode/ImagePlayground.QRCode.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
+    <AssemblyName>ImagePlayground.QRCode</AssemblyName>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ImagePlayground.Core\ImagePlayground.Core.csproj" />
+    <PackageReference Include="QRCoder-ImageSharp" Version="0.10.0" />
+    <PackageReference Include="BarcodeReader.ImageSharp" Version="2.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Collections" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Threading" />
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.IO" />
+    <Using Include="System.Net" />
+    <Using Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+</Project>

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -1,0 +1,305 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using BarcodeReader.ImageSharp;
+using QRCoder;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace ImagePlayground;
+/// <summary>
+/// Provides helper methods for generating various QR code payloads and reading QR codes.
+/// </summary>
+public class QrCode {
+    /// <summary>
+    /// Creates a QR code image from a raw string value.
+    /// </summary>
+    /// <param name="content">Content to encode.</param>
+    /// <param name="filePath">Path where the QR image will be saved.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="eccLevel">Error correction level.</param>
+    public static void Generate(string content, string filePath, bool transparent = false, QRCodeGenerator.ECCLevel eccLevel = QRCodeGenerator.ECCLevel.Q) {
+        string fullPath = Helpers.ResolvePath(filePath);
+
+        FileInfo fileInfo = new FileInfo(fullPath);
+
+        using (QRCodeGenerator qrGenerator = new QRCodeGenerator()) {
+            using (QRCodeData qrCodeData = qrGenerator.CreateQrCode(content, eccLevel)) {
+                using (QRCoder.QRCode qrCode = new QRCoder.QRCode(qrCodeData)) {
+                    using (var qrCodeImage = qrCode.GetGraphic(20)) {
+                        if (transparent) {
+                            //qrCodeImage.MakeTransparent();
+                        }
+                        // this uses QRCoder
+                        //ImageFormat imageFormatDetected;
+                        //if (fileInfo.Extension == ".png") {
+                        //    imageFormatDetected = ImageFormat.Png;
+                        //} else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+                        //    imageFormatDetected = ImageFormat.Jpeg;
+                        //} else if (fileInfo.Extension == ".ico") {
+                        //    imageFormatDetected = ImageFormat.Icon;
+                        //} else {
+                        //    throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+                        //}
+                        //qrCodeImage.Save(filePath, imageFormatDetected);
+
+                        //this uses QRCoder.ImageSharp
+                        if (fileInfo.Extension == ".png") {
+                            qrCodeImage.SaveAsPng(fullPath);
+                        } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+                            qrCodeImage.SaveAsJpeg(fullPath);
+                        } else if (fileInfo.Extension == ".ico") {
+                            SaveImageAsIcon(qrCodeImage, fullPath);
+                        } else {
+                            throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+                        }
+                    }
+                }
+            }
+        }
+    }
+    /// <summary>
+    /// Creates a QR code containing WiFi configuration information.
+    /// </summary>
+    /// <param name="ssid">Wireless network SSID.</param>
+    /// <param name="password">Wireless password.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the QR code should have transparent background.</param>
+    public static void GenerateWiFi(string ssid, string password, string filePath, bool transparent = false) {
+        PayloadGenerator.WiFi generator = new PayloadGenerator.WiFi(ssid, password, PayloadGenerator.WiFi.Authentication.WPA, false, false);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Creates a QR code that opens WhatsApp with a pre-filled message.
+    /// </summary>
+    /// <param name="message">Message text to pre-fill.</param>
+    /// <param name="filePath">Destination path for the QR image.</param>
+    /// <param name="transparent">Whether the QR code should have transparent background.</param>
+    public static void GenerateWhatsAppMessage(string message, string filePath, bool transparent = false) {
+        PayloadGenerator.WhatsAppMessage generator = new PayloadGenerator.WhatsAppMessage(message);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+    /// <summary>
+    /// Generates a QR code representing a hyperlink.
+    /// </summary>
+    /// <param name="url">URL to encode.</param>
+    /// <param name="filePath">Destination path for the QR image.</param>
+    /// <param name="transparent">Whether the QR code should have transparent background.</param>
+    public static void GenerateUrl(string url, string filePath, bool transparent = false) {
+        PayloadGenerator.Url generator = new PayloadGenerator.Url(url);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+    /// <summary>
+    /// Generates a QR code that opens a bookmark in the browser.
+    /// </summary>
+    /// <param name="bookmarkUrl">URL of the bookmark.</param>
+    /// <param name="bookmarkName">Bookmark display name.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the QR code should have transparent background.</param>
+    public static void GenerateBookmark(string bookmarkUrl, string bookmarkName, string filePath, bool transparent = false) {
+        PayloadGenerator.Bookmark generator = new PayloadGenerator.Bookmark(bookmarkUrl, bookmarkName);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Creates a QR code for a calendar event using the iCalendar specification.
+    /// </summary>
+    /// <param name="calendarEntry">Event title.</param>
+    /// <param name="calendarMessage">Event description.</param>
+    /// <param name="calendarGeoLocation">Event location.</param>
+    /// <param name="calendarFrom">Start date.</param>
+    /// <param name="calendarTo">End date.</param>
+    /// <param name="filePath">Output image path.</param>
+    /// <param name="allDayEvent">Specifies whether the event spans the full day.</param>
+    /// <param name="calendarEventEncoding">Calendar encoding.</param>
+    /// <param name="transparent">Whether the QR code should have transparent background.</param>
+    public static void GenerateCalendarEvent(string calendarEntry, string calendarMessage, string calendarGeoLocation, DateTime calendarFrom, DateTime calendarTo, string filePath, bool allDayEvent, PayloadGenerator.CalendarEvent.EventEncoding calendarEventEncoding = PayloadGenerator.CalendarEvent.EventEncoding.iCalComplete, bool transparent = false) {
+        PayloadGenerator.CalendarEvent generator = new PayloadGenerator.CalendarEvent(calendarEntry, calendarMessage, calendarGeoLocation, calendarFrom, calendarTo, allDayEvent, calendarEventEncoding);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code containing contact information in vCard format.
+    /// </summary>
+    public static void GenerateContact(string filePath, PayloadGenerator.ContactData.ContactOutputType outputType, string firstname, string lastname, string nickname = null, string phone = null, string mobilePhone = null, string workPhone = null, string email = null, DateTime? birthday = null, string website = null, string street = null, string houseNumber = null, string city = null, string zipCode = null, string country = null, string note = null, string stateRegion = null, PayloadGenerator.ContactData.AddressOrder addressOrder = PayloadGenerator.ContactData.AddressOrder.Default, string org = null, string orgTitle = null, bool transparent = false) {
+        PayloadGenerator.ContactData generator = new PayloadGenerator.ContactData(outputType, firstname, lastname, nickname, phone, mobilePhone, workPhone, email, birthday, website, street, houseNumber, city, zipCode, country, note, stateRegion, addressOrder, org, orgTitle);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code that opens an email draft.
+    /// </summary>
+    public static void GenerateEmail(string filePath, string email, string subject = null, string message = null, PayloadGenerator.Mail.MailEncoding encoding = PayloadGenerator.Mail.MailEncoding.MAILTO, bool transparent = false) {
+        PayloadGenerator.Mail generator = new PayloadGenerator.Mail(email, subject, message, encoding);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code that opens the messaging app with an MMS draft.
+    /// </summary>
+    public static void GenerateMMS(string filePath, string phoneNumber, string subject = "", PayloadGenerator.MMS.MMSEncoding encoding = PayloadGenerator.MMS.MMSEncoding.MMSTO, bool transparent = false) {
+        var generator = subject == "" ? new PayloadGenerator.MMS(phoneNumber, encoding) : new PayloadGenerator.MMS(phoneNumber, subject, encoding);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Creates a QR code that launches the SMS application.
+    /// </summary>
+    public static void GenerateSms(string number, string? message, string filePath, PayloadGenerator.SMS.SMSEncoding encoding = PayloadGenerator.SMS.SMSEncoding.SMS, bool transparent = false) {
+        var generator = string.IsNullOrEmpty(message)
+            ? new PayloadGenerator.SMS(number, encoding)
+            : new PayloadGenerator.SMS(number, message!, encoding);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code representing a geographic location.
+    /// </summary>
+    public static void GenerateGeoLocation(string latitude, string longitude, string filePath, PayloadGenerator.Geolocation.GeolocationEncoding encoding = PayloadGenerator.Geolocation.GeolocationEncoding.GEO, bool transparent = false) {
+        var generator = new PayloadGenerator.Geolocation(latitude, longitude, encoding);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Creates a Girocode compliant QR code for SEPA credit transfers.
+    /// </summary>
+    public static void GenerateGirocode(string iban, string bic, string name, decimal amount, string filePath, string? remittanceInformation = null, PayloadGenerator.Girocode.TypeOfRemittance type = PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, string? purposeOfCreditTransfer = null, string? messageToGirocodeUser = null, PayloadGenerator.Girocode.GirocodeVersion version = PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding encoding = PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, bool transparent = false) {
+        var generator = new PayloadGenerator.Girocode(iban, bic, name, amount, remittanceInformation ?? string.Empty, type, purposeOfCreditTransfer ?? string.Empty, messageToGirocodeUser ?? string.Empty, version, encoding);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code for Bitcoin-like cryptocurrency payments.
+    /// </summary>
+    public static void GenerateBitcoinAddress(PayloadGenerator.BitcoinLikeCryptoCurrencyAddress.BitcoinLikeCryptoCurrencyType currency, string address, double? amount, string? label, string? message, string filePath, bool transparent = false) {
+        var generator = new PayloadGenerator.BitcoinLikeCryptoCurrencyAddress(currency, address, amount, label, message);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code for a Monero transfer.
+    /// </summary>
+    public static void GenerateMoneroTransaction(string address, float? amount, string? paymentId, string? recipientName, string? description, string filePath, bool transparent = false) {
+        var generator = new PayloadGenerator.MoneroTransaction(address, amount, paymentId, recipientName, description);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code that initiates a phone call.
+    /// </summary>
+    public static void GeneratePhoneNumber(string number, string filePath, bool transparent = false) {
+        var generator = new PayloadGenerator.PhoneNumber(number);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code that starts a Skype call.
+    /// </summary>
+    public static void GenerateSkypeCall(string username, string filePath, bool transparent = false) {
+        var generator = new PayloadGenerator.SkypeCall(username);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code containing Shadowsocks configuration settings.
+    /// </summary>
+    public static void GenerateShadowSocks(string hostname, int port, string password, PayloadGenerator.ShadowSocksConfig.Method method, string filePath, string? tag = null, bool transparent = false) {
+        var generator = new PayloadGenerator.ShadowSocksConfig(hostname, port, password, method, tag);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a QR code for configuring a one-time password generator.
+    /// </summary>
+    public static void GenerateOneTimePassword(PayloadGenerator.OneTimePassword otp, string filePath, bool transparent = false) {
+        Generate(otp.ToString(), filePath, transparent);
+    }
+
+
+    /// <summary>
+    /// Generates a Slovenian UPN QR payment code.
+    /// </summary>
+    public static void GenerateSlovenianUpnQr(PayloadGenerator.SlovenianUpnQr upn, string filePath, bool transparent = false) {
+        Generate(upn.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a German BezahlCode payment QR code.
+    /// </summary>
+    public static void GenerateBezahlCode(PayloadGenerator.BezahlCode.AuthorityType authority, string name, string account, string bnc, string iban, string bic, string reason, string filePath, bool transparent = false) {
+        var generator = new PayloadGenerator.BezahlCode(authority, name, account, bnc, iban, bic, reason);
+        Generate(generator.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Generates a Swiss QR invoice code.
+    /// </summary>
+    public static void GenerateSwissQrCode(PayloadGenerator.SwissQrCode swiss, string filePath, bool transparent = false) {
+        Generate(swiss.ToString(), filePath, transparent);
+    }
+
+    /// <summary>
+    /// Reads a QR code image and returns the decoded payload.
+    /// </summary>
+    public static BarcodeResult<Rgba32> Read(string filePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+
+        Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
+        BarcodeReader<Rgba32> reader = new BarcodeReader<Rgba32>(types: ZXing.BarcodeFormat.QR_CODE);
+        var response = reader.Decode(barcodeImage);
+        return response;
+    }
+
+    /// <summary>
+    /// Saves an ImageSharp image as an ICO file with multiple resolutions.
+    /// </summary>
+    private static void SaveImageAsIcon(SixLabors.ImageSharp.Image image, string filePath, params int[] sizes) {
+        if (sizes == null || sizes.Length == 0) {
+            sizes = new[] { 16, 32, 48, 64, 128, 256 };
+        }
+
+        List<byte[]> frames = new();
+        List<(int Width, int Height)> dims = new();
+
+        foreach (int size in sizes.Distinct().OrderBy(s => s)) {
+            using Image<Rgba32> clone = image.CloneAs<Rgba32>();
+            clone.Mutate(ctx => ctx.Resize(new ResizeOptions {
+                Mode = ResizeMode.Stretch,
+                Size = new Size(size, size)
+            }));
+            using MemoryStream ms = new();
+            clone.SaveAsPng(ms);
+            frames.Add(ms.ToArray());
+            dims.Add((size, size));
+        }
+
+        using FileStream fs = File.Create(filePath);
+        using BinaryWriter bw = new(fs);
+        bw.Write((ushort)0);
+        bw.Write((ushort)1);
+        bw.Write((ushort)frames.Count);
+
+        int offset = 6 + 16 * frames.Count;
+        for (int i = 0; i < frames.Count; i++) {
+            var (w, h) = dims[i];
+            bw.Write((byte)(w >= 256 ? 0 : w));
+            bw.Write((byte)(h >= 256 ? 0 : h));
+            bw.Write((byte)0);
+            bw.Write((byte)0);
+            bw.Write((ushort)1);
+            bw.Write((ushort)32);
+            bw.Write(frames[i].Length);
+            bw.Write(offset);
+            offset += frames[i].Length;
+        }
+
+        foreach (byte[] data in frames) {
+            bw.Write(data);
+        }
+
+        bw.Flush();
+    }
+}

--- a/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
+++ b/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
@@ -33,7 +33,7 @@ public partial class ImagePlayground {
         if (File.Exists(dest)) File.Delete(dest);
 
         using (var img = Image.Load(src)) {
-            img.WatermarkImage(watermark, Image.WatermarkPlacement.TopRight, 0.8f, 10f, 90, FlipMode.Horizontal, 50);
+            img.WatermarkImage(watermark, WatermarkPlacement.TopRight, 0.8f, 10f, 90, FlipMode.Horizontal, 50);
             img.Save(dest);
         }
 
@@ -103,7 +103,7 @@ public partial class ImagePlayground {
 
     [Fact]
     public void Test_GetResampler_AllMapped() {
-        foreach (Image.Sampler sampler in Enum.GetValues(typeof(Image.Sampler))) {
+        foreach (Sampler sampler in Enum.GetValues(typeof(Sampler))) {
             Assert.NotNull(Helpers.GetResampler(sampler));
         }
     }

--- a/Sources/ImagePlayground.Tests/AsyncMethods.cs
+++ b/Sources/ImagePlayground.Tests/AsyncMethods.cs
@@ -24,7 +24,7 @@ public partial class ImagePlayground {
         string dest = Path.Combine(_directoryWithTests, "wm_async.png");
         if (File.Exists(dest)) File.Delete(dest);
 
-        await ImageHelper.WatermarkImageAsync(src, dest, wmk, Image.WatermarkPlacement.Middle, watermarkPercentage: 100);
+        await ImageHelper.WatermarkImageAsync(src, dest, wmk, WatermarkPlacement.Middle, watermarkPercentage: 100);
         Assert.True(File.Exists(dest));
         using var orig = Image.Load(src);
         using var res = Image.Load(dest);

--- a/Sources/ImagePlayground.Tests/BarCodes.cs
+++ b/Sources/ImagePlayground.Tests/BarCodes.cs
@@ -6,16 +6,16 @@ namespace ImagePlayground.Tests;
 
 public partial class ImagePlayground {
     [Theory]
-    [InlineData(BarCode.BarcodeTypes.Code128, "1234567890", "barcode_code128.png", "1234567890", Status.Found)]
-    [InlineData(BarCode.BarcodeTypes.Code93, "HELLOCODE93", "barcode_code93.png", "HELLOCODE93", Status.Found)]
-    [InlineData(BarCode.BarcodeTypes.Code39, "HELLO39", "barcode_code39.png", "HELLO39N", Status.Found)]
-    [InlineData(BarCode.BarcodeTypes.KixCode, "1234567890AB", "barcode_kix.png", "", Status.NotFound)]
-    [InlineData(BarCode.BarcodeTypes.UPCE, "123456", "barcode_upce.png", "01234565", Status.Found)]
-    [InlineData(BarCode.BarcodeTypes.UPCA, "123456789012", "barcode_upca.png", "123456789012", Status.Found)]
-    [InlineData(BarCode.BarcodeTypes.EAN, "9012341234571", "barcode_ean.png", "9012341234571", Status.Found)]
-    [InlineData(BarCode.BarcodeTypes.DataMatrix, "MatrixTest", "barcode_datamatrix.png", "MatrixTest", Status.Found)]
-    [InlineData(BarCode.BarcodeTypes.PDF417, "Pdf417Example", "barcode_pdf417.png", "Pdf417Example", Status.Found)]
-    public void Test_AllBarCodes(BarCode.BarcodeTypes type, string value, string fileName, string expected, Status status) {
+    [InlineData(BarcodeType.Code128, "1234567890", "barcode_code128.png", "1234567890", Status.Found)]
+    [InlineData(BarcodeType.Code93, "HELLOCODE93", "barcode_code93.png", "HELLOCODE93", Status.Found)]
+    [InlineData(BarcodeType.Code39, "HELLO39", "barcode_code39.png", "HELLO39N", Status.Found)]
+    [InlineData(BarcodeType.KixCode, "1234567890AB", "barcode_kix.png", "", Status.NotFound)]
+    [InlineData(BarcodeType.UPCE, "123456", "barcode_upce.png", "01234565", Status.Found)]
+    [InlineData(BarcodeType.UPCA, "123456789012", "barcode_upca.png", "123456789012", Status.Found)]
+    [InlineData(BarcodeType.EAN, "9012341234571", "barcode_ean.png", "9012341234571", Status.Found)]
+    [InlineData(BarcodeType.DataMatrix, "MatrixTest", "barcode_datamatrix.png", "MatrixTest", Status.Found)]
+    [InlineData(BarcodeType.PDF417, "Pdf417Example", "barcode_pdf417.png", "Pdf417Example", Status.Found)]
+    public void Test_AllBarCodes(BarcodeType type, string value, string fileName, string expected, Status status) {
         string filePath = Path.Combine(_directoryWithTests, fileName);
         if (File.Exists(filePath)) File.Delete(filePath);
 

--- a/Sources/ImagePlayground.Tests/Charts.cs
+++ b/Sources/ImagePlayground.Tests/Charts.cs
@@ -95,7 +95,7 @@ public partial class ImagePlayground {
                 new Charts.ChartAnnotation(0, 1, "first", true)
             };
 
-        Charts.Generate(defs, file, 300, 200, null, null, null, false, Charts.ChartTheme.Default, anns);
+        Charts.Generate(defs, file, 300, 200, null, null, null, false, ChartTheme.Default, anns);
 
         Assert.True(File.Exists(file));
     }

--- a/Sources/ImagePlayground.Tests/ChartsAdditional.cs
+++ b/Sources/ImagePlayground.Tests/ChartsAdditional.cs
@@ -22,7 +22,7 @@ public partial class ImagePlayground {
         var defs = new List<Charts.ChartDefinition> {
                 new Charts.ChartBar("A", new List<double> {1,2})
             };
-        Charts.Generate(defs, file, 200, 150, null, null, null, false, Charts.ChartTheme.Dark);
+        Charts.Generate(defs, file, 200, 150, null, null, null, false, ChartTheme.Dark);
         Assert.True(File.Exists(file));
     }
 
@@ -33,7 +33,7 @@ public partial class ImagePlayground {
         var defs = new List<Charts.ChartDefinition> {
                 new Charts.ChartBar("A", new List<double> {1,2})
             };
-        Charts.Generate(defs, file, 200, 150, null, null, null, false, Charts.ChartTheme.Light);
+        Charts.Generate(defs, file, 200, 150, null, null, null, false, ChartTheme.Light);
         Assert.True(File.Exists(file));
     }
 }

--- a/Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj
+++ b/Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj
@@ -21,7 +21,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ImagePlayground\ImagePlayground.csproj" />
+        <ProjectReference Include="..\ImagePlayground.Core\ImagePlayground.Core.csproj" />
+        <ProjectReference Include="..\ImagePlayground.Chart\ImagePlayground.Chart.csproj" />
+        <ProjectReference Include="..\ImagePlayground.BarCode\ImagePlayground.BarCode.csproj" />
+        <ProjectReference Include="..\ImagePlayground.QRCode\ImagePlayground.QRCode.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -36,14 +36,14 @@ public partial class ImagePlayground {
     [Fact]
     public void Test_BarCode() {
         string filePath = System.IO.Path.Combine(_directoryWithTests, "BarcodeEAN13.png");
-        BarCode.Generate(BarCode.BarcodeTypes.EAN, "9012341234571", filePath);
+        BarCode.Generate(BarcodeType.EAN, "9012341234571", filePath);
 
         var read1 = BarCode.Read(filePath);
         Assert.True(read1.Message == "9012341234571");
         Assert.True(File.Exists(filePath) == true);
 
         filePath = System.IO.Path.Combine(_directoryWithTests, "BarcodeEAN7.png");
-        BarCode.Generate(BarCode.BarcodeTypes.EAN, "96385074", filePath);
+        BarCode.Generate(BarcodeType.EAN, "96385074", filePath);
         Assert.True(File.Exists(filePath) == true);
 
         var read2 = BarCode.Read(filePath);

--- a/Sources/ImagePlayground.Tests/Watermark.cs
+++ b/Sources/ImagePlayground.Tests/Watermark.cs
@@ -14,7 +14,7 @@ public partial class ImagePlayground {
         string dest = Path.Combine(_directoryWithTests, "watermarked.png");
         if (File.Exists(dest)) File.Delete(dest);
 
-        ImageHelper.WatermarkImage(src, dest, watermark, Image.WatermarkPlacement.Middle, watermarkPercentage: 100);
+        ImageHelper.WatermarkImage(src, dest, watermark, WatermarkPlacement.Middle, watermarkPercentage: 100);
         Assert.True(File.Exists(dest));
 
         using var result = Image.Load(dest);
@@ -30,6 +30,6 @@ public partial class ImagePlayground {
         string src = Path.Combine(_directoryWithImages, "QRCode1.png");
         string watermark = Path.Combine(_directoryWithImages, "LogoEvotec.png");
         string dest = Path.Combine(_directoryWithTests, $"invalid_{percentage}.png");
-        Assert.Throws<ArgumentOutOfRangeException>(() => ImageHelper.WatermarkImage(src, dest, watermark, Image.WatermarkPlacement.Middle, watermarkPercentage: percentage));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ImageHelper.WatermarkImage(src, dest, watermark, WatermarkPlacement.Middle, watermarkPercentage: percentage));
     }
 }

--- a/Sources/ImagePlayground.sln
+++ b/Sources/ImagePlayground.sln
@@ -17,6 +17,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImagePlayground.Tests", "Im
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImagePlayground.PowerShell", "ImagePlayground.PowerShell\ImagePlayground.PowerShell.csproj", "{63642D6E-8C0B-4436-A50F-1CA2B9361659}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImagePlayground.Core", "ImagePlayground.Core\ImagePlayground.Core.csproj", "{F7CFBE89-3AF2-400D-B12F-AB5085854143}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImagePlayground.Chart", "ImagePlayground.Chart\ImagePlayground.Chart.csproj", "{2697FEC1-F32A-49DE-A005-934064057118}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImagePlayground.BarCode", "ImagePlayground.BarCode\ImagePlayground.BarCode.csproj", "{606CD8C4-A419-4223-AAA3-0FA01D747C77}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImagePlayground.QRCode", "ImagePlayground.QRCode\ImagePlayground.QRCode.csproj", "{DF4E80FA-0538-4A8A-BD5D-EF82CD637BAA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +47,22 @@ Global
 		{63642D6E-8C0B-4436-A50F-1CA2B9361659}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63642D6E-8C0B-4436-A50F-1CA2B9361659}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63642D6E-8C0B-4436-A50F-1CA2B9361659}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7CFBE89-3AF2-400D-B12F-AB5085854143}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7CFBE89-3AF2-400D-B12F-AB5085854143}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7CFBE89-3AF2-400D-B12F-AB5085854143}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7CFBE89-3AF2-400D-B12F-AB5085854143}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2697FEC1-F32A-49DE-A005-934064057118}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2697FEC1-F32A-49DE-A005-934064057118}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2697FEC1-F32A-49DE-A005-934064057118}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2697FEC1-F32A-49DE-A005-934064057118}.Release|Any CPU.Build.0 = Release|Any CPU
+		{606CD8C4-A419-4223-AAA3-0FA01D747C77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{606CD8C4-A419-4223-AAA3-0FA01D747C77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{606CD8C4-A419-4223-AAA3-0FA01D747C77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{606CD8C4-A419-4223-AAA3-0FA01D747C77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF4E80FA-0538-4A8A-BD5D-EF82CD637BAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF4E80FA-0538-4A8A-BD5D-EF82CD637BAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF4E80FA-0538-4A8A-BD5D-EF82CD637BAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF4E80FA-0538-4A8A-BD5D-EF82CD637BAA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add ImagePlayground.Core project with core image helpers
- create ImagePlayground.Chart, ImagePlayground.BarCode and ImagePlayground.QRCode projects
- update examples, tests and PowerShell code to reference new projects
- move enums to separate files

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686d65b4aecc832e88a43c19995d1917