### PR TITLE
Add PSD1 auto commit in workflow

### DIFF
--- a/.github/workflows/test_powershell.yml
+++ b/.github/workflows/test_powershell.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
 
       - name: Setup PowerShell modules
         shell: pwsh
@@ -31,11 +34,21 @@ jobs:
           Install-Module PSPublishModule -Force -Scope CurrentUser -AllowClobber
 
       - name: Refresh module manifest
-        shell: pwsh
         env:
           RefreshPSD1Only: 'true'
+        run: .\Build\Build-Module.ps1
+        shell: pwsh
+
+      - name: Commit refreshed PSD1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
         run: |
-          .\Build\Build-Module.ps1
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add ImagePlayground.psd1
+          git commit -m "chore: regenerate psd1" || echo "No changes to commit"
+          git push origin HEAD:$Env:HEAD_BRANCH
 
       - name: Upload refreshed manifest
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- autocommit refreshed PSD1 in CI so manifest stays up to date

## Testing
- `pwsh ./ImagePlayground.Tests.ps1` *(fails: Get-Image cmdlet not found)*

------
https://chatgpt.com/codex/tasks/task_e_687361215f14832ebe0ee94860ff7956