### PR TITLE
Add ImportMetadata options

### DIFF
--- a/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
@@ -37,6 +37,28 @@ public partial class ImageHelper {
         /// <summary>Serialized IPTC profile.</summary>
         public byte[]? IptcProfile { get; set; }
     }
+
+    /// <summary>Options for importing metadata.</summary>
+    public sealed class ImportMetadataOptions {
+        /// <summary>Source image path.</summary>
+        public string FilePath { get; }
+
+        /// <summary>JSON metadata file.</summary>
+        public string MetadataPath { get; }
+
+        /// <summary>Destination image path.</summary>
+        public string? OutputPath { get; }
+
+        /// <summary>Create import options.</summary>
+        /// <param name="filePath">Path to the source image.</param>
+        /// <param name="metadataPath">Path to the metadata file.</param>
+        /// <param name="outputPath">Destination image path.</param>
+        public ImportMetadataOptions(string filePath, string metadataPath, string? outputPath = null) {
+            FilePath = filePath;
+            MetadataPath = metadataPath;
+            OutputPath = outputPath;
+        }
+    }
     /// <summary>
     /// Exports metadata from an image to a JSON string.
     /// </summary>
@@ -67,6 +89,22 @@ public partial class ImageHelper {
         string json = ExportMetadata(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
         File.WriteAllText(outFullPath, json);
+    }
+
+    /// <summary>
+    /// Imports metadata using the specified <see cref="ImportMetadataOptions"/>.
+    /// </summary>
+    /// <param name="options">Import options.</param>
+    public static void ImportMetadata(ImportMetadataOptions options) {
+        if (options is null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        string output = string.IsNullOrWhiteSpace(options.OutputPath)
+            ? options.FilePath
+            : options.OutputPath!;
+
+        ImportMetadata(options.FilePath, options.MetadataPath, output);
     }
 
     /// <summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletImportImageMetadata.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletImportImageMetadata.cs
@@ -42,6 +42,7 @@ public sealed class ImportImageMetadataCmdlet : PSCmdlet {
         }
 
         var output = string.IsNullOrWhiteSpace(OutputPath) ? filePath : Helpers.ResolvePath(OutputPath!);
-        ImageHelper.ImportMetadata(filePath, metaPath, output);
+        var options = new ImageHelper.ImportMetadataOptions(filePath, metaPath, output);
+        ImageHelper.ImportMetadata(options);
     }
 }


### PR DESCRIPTION
## Summary
- wrap ImportMetadata with options class
- update cmdlet to use options
- test import round-trip via options
- add roundtrip edits test

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --framework net8.0 --verbosity minimal`
- `pwsh ./ImagePlayground.Tests.ps1` *(fails: Unable to find type [ImagePlayground.Image])*

------
https://chatgpt.com/codex/tasks/task_e_6874b4be3f24832eb2a611ec2670fcd3