### PR TITLE
Fix temp file cleanup concurrency

### DIFF
--- a/Sources/ImagePlayground.Core/Helpers.Path.cs
+++ b/Sources/ImagePlayground.Core/Helpers.Path.cs
@@ -5,6 +5,7 @@ namespace ImagePlayground;
 /// </summary>
 public static partial class Helpers {
     private static readonly System.Collections.Concurrent.ConcurrentBag<string> _tempFiles = new();
+    private static readonly object _tempFilesLock = new();
 
     static Helpers() {
         System.AppDomain.CurrentDomain.ProcessExit += (_, _) => CleanupTempFiles();
@@ -125,7 +126,12 @@ public static partial class Helpers {
     /// Removes any temporary files created when resolving URLs.
     /// </summary>
     public static void CleanupTempFiles() {
-        foreach (string file in _tempFiles) {
+        string[] files;
+        lock (_tempFilesLock) {
+            files = _tempFiles.ToArray();
+        }
+
+        foreach (string file in System.Linq.Enumerable.Distinct(files)) {
             try {
                 if (System.IO.File.Exists(file)) {
                     System.IO.File.Delete(file);
@@ -133,8 +139,10 @@ public static partial class Helpers {
             } catch {
             }
         }
-        while (!_tempFiles.IsEmpty) {
-            _tempFiles.TryTake(out _);
+
+        lock (_tempFilesLock) {
+            while (_tempFiles.TryTake(out _)) {
+            }
         }
     }
 }

--- a/Sources/ImagePlayground.Tests/HelpersPath.cs
+++ b/Sources/ImagePlayground.Tests/HelpersPath.cs
@@ -78,4 +78,32 @@ public partial class ImagePlayground {
         Helpers.CleanupTempFiles();
         Assert.False(File.Exists(path));
     }
+
+    [Fact]
+    public void Test_CleanupTempFiles_Idempotent() {
+        var tcp = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        tcp.Start();
+        int port = ((System.Net.IPEndPoint)tcp.LocalEndpoint).Port;
+        tcp.Stop();
+        string prefix = $"http://localhost:{port}/";
+
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        var serverTask = System.Threading.Tasks.Task.Run(() => {
+            var context = listener.GetContext();
+            byte[] data = System.Text.Encoding.UTF8.GetBytes("hello");
+            context.Response.ContentLength64 = data.Length;
+            context.Response.OutputStream.Write(data, 0, data.Length);
+            context.Response.OutputStream.Close();
+        });
+
+        string path = Helpers.ResolvePath(prefix + "file.txt");
+        serverTask.Wait();
+        string content = File.ReadAllText(path);
+        Assert.Equal("hello", content);
+        Helpers.CleanupTempFiles();
+        Assert.False(File.Exists(path));
+        Helpers.CleanupTempFiles();
+    }
 }


### PR DESCRIPTION
## Summary
- snapshot and lock temp file list during cleanup
- clear bag after deletion
- test cleanup idempotency

## Testing
- `dotnet test Sources/ImagePlayground.sln -c Release`
- `VSTEST_CONNECTION_TIMEOUT=900 dotnet test Sources/ImagePlayground.sln -c Release` *(fails: Failed to negotiate protocol)*

------
https://chatgpt.com/codex/tasks/task_e_6874b43431b4832ea8484febf744a73c