### PR TITLE
Add async ResolvePath

### DIFF
--- a/Examples/Helpers.ResolvePath.Async.ps1
+++ b/Examples/Helpers.ResolvePath.Async.ps1
@@ -1,0 +1,7 @@
+Import-Module .\ImagePlayground.psd1 -Force
+
+$url = 'https://example.com/image.png'
+$task = [ImagePlayground.Helpers]::ResolvePathAsync($url)
+$path = $task.GetAwaiter().GetResult()
+Write-Host "Downloaded to $path"
+[ImagePlayground.Helpers]::CleanupTempFiles()

--- a/Sources/ImagePlayground.Tests/HelpersPath.cs
+++ b/Sources/ImagePlayground.Tests/HelpersPath.cs
@@ -53,7 +53,7 @@ public partial class ImagePlayground {
     }
 
     [Fact]
-    public void Test_ResolvePath_DownloadsUrl() {
+    public async Task Test_ResolvePath_DownloadsUrlAsync() {
         var tcp = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
         tcp.Start();
         int port = ((System.Net.IPEndPoint)tcp.LocalEndpoint).Port;
@@ -71,8 +71,8 @@ public partial class ImagePlayground {
             context.Response.OutputStream.Close();
         });
 
-        string path = Helpers.ResolvePath(prefix + "file.txt");
-        serverTask.Wait();
+        string path = await Helpers.ResolvePathAsync(prefix + "file.txt");
+        await serverTask;
         string content = File.ReadAllText(path);
         Assert.Equal("hello", content);
         Helpers.CleanupTempFiles();


### PR DESCRIPTION
## Summary
- add async `ResolvePathAsync` and sync wrapper
- update `ReadFileCheckedAsync` and tests
- add example for async path resolution

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --no-build -c Debug --framework net8.0`
- `pwsh -NoLogo -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6874b42e1d40832e8780c0054e9b0b43