### PR TITLE
Fix QR code file lock

### DIFF
--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -247,7 +247,7 @@ public class QrCode {
     public static BarcodeResult<Rgba32> Read(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
 
-        Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
+        using Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
         BarcodeReader<Rgba32> reader = new BarcodeReader<Rgba32>(types: ZXing.BarcodeFormat.QR_CODE);
         var response = reader.Decode(barcodeImage);
         return response;

--- a/Tests/Get-ImageQRCode.Tests.ps1
+++ b/Tests/Get-ImageQRCode.Tests.ps1
@@ -14,5 +14,17 @@ Describe 'Get-ImageQRCode' {
 
     }
 
+    It 'does not lock file' {
+
+        $file = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+
+        Get-ImageQRCode -FilePath $file | Out-Null
+
+        {
+            [System.IO.File]::Open($file, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None).Dispose()
+        } | Should -Not -Throw
+
+    }
+
 }
 


### PR DESCRIPTION
## Summary
- dispose images in QR code reader
- check for file locks in QR code cmdlet test

## Testing
- `dotnet test Sources/ImagePlayground.sln -c Release`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6874b439d6d8832eacfa5ba33eea9e77