### PR TITLE
Add parameter validation for Add-ImageText

### DIFF
--- a/Tests/Add-ImageText.Tests.ps1
+++ b/Tests/Add-ImageText.Tests.ps1
@@ -51,5 +51,15 @@ Describe 'Add-ImageText' {
         Test-Path $dest | Should -BeTrue
     }
 
+    It 'throws for invalid coordinates' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'invalid.png'
+        $img = [ImagePlayground.Image]::Load($src)
+        $x = $img.Width + 10
+        $img.Dispose()
+        { Add-ImageText -FilePath $src -OutputPath $dest -Text 'Test' -X $x -Y 0 } | Should -Throw
+        { Add-ImageText -FilePath $src -OutputPath $dest -Text 'Test' -X 0 -Y -1 } | Should -Throw
+    }
+
 }
 


### PR DESCRIPTION
## Summary
- validate coordinates for `Add-ImageText` cmdlet
- throw terminating error when coordinates exceed image bounds
- test invalid parameters in Pester suite

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release --no-restore`
- `dotnet build Sources/ImagePlayground.sln -c Debug --no-restore`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --no-build` *(fails: No test is available in net472; net8.0 tests pass)*
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6874b441ce38832ea2941e43ed240dc1