### PR TITLE
fix: enforce aspect ratio validation

### DIFF
--- a/Examples/Images.Resize.ps1
+++ b/Examples/Images.Resize.ps1
@@ -7,3 +7,5 @@ Resize-Image -FilePath $PSScriptRoot\Samples\LogoEvotec.png -OutputPath $PSScrip
 Resize-Image -FilePath $PSScriptRoot\Samples\LogoEvotec.png -OutputPath $PSScriptRoot\Output\LogoEvotecResizeDontMaintainAspectRatio.png -Width 300 -DontRespectAspectRatio
 
 Resize-Image -FilePath $PSScriptRoot\Samples\LogoEvotec.png -OutputPath $PSScriptRoot\Output\LogoEvotecResizePercent.png -Percentage 200
+
+#Resize-Image -FilePath $PSScriptRoot\Samples\LogoEvotec.png -OutputPath $PSScriptRoot\Output\LogoEvotecInvalid.png -DontRespectAspectRatio

--- a/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
@@ -76,6 +76,12 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
         bool widthBound = MyInvocation.BoundParameters.ContainsKey(nameof(Width));
         bool heightBound = MyInvocation.BoundParameters.ContainsKey(nameof(Height));
 
+        if (DontRespectAspectRatio.IsPresent && !widthBound && !heightBound) {
+            var ex = new PSArgumentException("DontRespectAspectRatio requires Width or Height");
+            ThrowTerminatingError(new ErrorRecord(ex, "MissingWidthOrHeight", ErrorCategory.InvalidArgument, null));
+            return;
+        }
+
         if (!widthBound && !heightBound) {
             WriteWarning("Resize-Image - Please specify Width or Height or Percentage.");
             return;

--- a/Tests/Resize-Image.Tests.ps1
+++ b/Tests/Resize-Image.Tests.ps1
@@ -81,6 +81,12 @@ Describe 'Resize-Image' {
         { Resize-Image -FilePath $src -OutputPath $dest -Width 10 -Height -5 } | Should -Throw
     }
 
+    It 'throws when DontRespectAspectRatio without dimensions' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dest = Join-Path $TestDir 'logo-invalid-aspect.png'
+        { Resize-Image -FilePath $src -OutputPath $dest -DontRespectAspectRatio } | Should -Throw
+    }
+
 
 }
 


### PR DESCRIPTION
## Summary
- validate DontRespectAspectRatio only if width or height is specified
- test for aspect ratio validation
- update example script

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6874b4557e70832e8040351c5faa3955