### PR TITLE
Fix save path handling

### DIFF
--- a/Sources/ImagePlayground.Core/Image.cs
+++ b/Sources/ImagePlayground.Core/Image.cs
@@ -511,6 +511,12 @@ public partial class Image : IDisposable {
         } else {
             filePath = Helpers.ResolvePath(filePath);
         }
+
+        string? directory = System.IO.Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory) && !System.IO.Directory.Exists(directory)) {
+            System.IO.Directory.CreateDirectory(directory);
+        }
+
         var encoder = Helpers.GetEncoder(System.IO.Path.GetExtension(filePath), quality, compressionLevel);
         _image.Save(filePath, encoder);
         Helpers.Open(filePath, openImage);

--- a/Tests/Save-Image.Tests.ps1
+++ b/Tests/Save-Image.Tests.ps1
@@ -58,4 +58,14 @@ Describe 'Save-Image' {
         $stream.Length | Should -BeGreaterThan 0
     }
 
+    It 'creates directory when saving to a new folder' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $folder = Join-Path $TestDir 'NewFolder'
+        $dest = Join-Path $folder 'saved.png'
+        if (Test-Path $folder) { Remove-Item $folder -Recurse -Force }
+        $img = Get-Image -FilePath $src
+        Save-Image -Image $img -FilePath $dest
+        $img.Dispose()
+        Test-Path $dest | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- ensure directories exist before saving images
- test saving to new folder

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command "& ./ImagePlayground.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_6874b45ba78c832ea9ef25f90ae7644a