### PR TITLE
Clone ZXing result and add memory tests

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -175,10 +175,14 @@ public class BarCode {
     public static BarcodeResult<Rgba32> Read(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
 
-        using (Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath)) {
-            BarcodeReader.ImageSharp.BarcodeReader<Rgba32> reader = new(types: new[] { ZXing.BarcodeFormat.All_1D, ZXing.BarcodeFormat.DATA_MATRIX, ZXing.BarcodeFormat.PDF_417 });
-            var response = reader.Decode(barcodeImage);
-            return response;
-        }
+        using Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
+        BarcodeReader.ImageSharp.BarcodeReader<Rgba32> reader = new(types: new[] { ZXing.BarcodeFormat.All_1D, ZXing.BarcodeFormat.DATA_MATRIX, ZXing.BarcodeFormat.PDF_417 });
+        BarcodeResult<Rgba32> response = reader.Decode(barcodeImage);
+        BarcodeResult<Rgba32> result = new() {
+            Value = response.Value,
+            Status = response.Status,
+            Message = response.Message
+        };
+        return result;
     }
 }

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -247,10 +247,15 @@ public class QrCode {
     public static BarcodeResult<Rgba32> Read(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
 
-        Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
+        using Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
         BarcodeReader<Rgba32> reader = new BarcodeReader<Rgba32>(types: ZXing.BarcodeFormat.QR_CODE);
-        var response = reader.Decode(barcodeImage);
-        return response;
+        BarcodeResult<Rgba32> response = reader.Decode(barcodeImage);
+        BarcodeResult<Rgba32> result = new() {
+            Value = response.Value,
+            Status = response.Status,
+            Message = response.Message
+        };
+        return result;
     }
 
     /// <summary>

--- a/Sources/ImagePlayground.Tests/ZXingMemory.cs
+++ b/Sources/ImagePlayground.Tests/ZXingMemory.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using BarcodeReader.ImageSharp;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_QrCodeRead_MemoryUsageStable() {
+        string filePath = Path.Combine(_directoryWithImages, "QRCode1.png");
+        long before = GC.GetTotalMemory(true);
+        for (int i = 0; i < 50; i++) {
+            var result = QrCode.Read(filePath);
+            Assert.Equal(Status.Found, result.Status);
+        }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        long after = GC.GetTotalMemory(true);
+        Assert.True(Math.Abs(after - before) < 1024 * 1024); // less than 1MB diff
+    }
+
+    [Fact]
+    public void Test_BarCodeRead_MemoryUsageStable() {
+        string filePath = Path.Combine(_directoryWithImages, "BarcodeEAN13.png");
+        long before = GC.GetTotalMemory(true);
+        for (int i = 0; i < 50; i++) {
+            var result = BarCode.Read(filePath);
+            Assert.Equal(Status.Found, result.Status);
+        }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        long after = GC.GetTotalMemory(true);
+        Assert.True(Math.Abs(after - before) < 1024 * 1024); // less than 1MB diff
+    }
+}


### PR DESCRIPTION
## Summary
- prevent leaking ZXing images by cloning returned data
- add xUnit tests to monitor memory usage when decoding

## Testing
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`
- `dotnet test Sources/ImagePlayground.sln -c Debug -f net8.0 --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6874b473730c832e81698a8f7ba71cca