### PR TITLE
Add sampler support to New-ImageThumbnail

### DIFF
--- a/Docs/New-ImageThumbnail.md
+++ b/Docs/New-ImageThumbnail.md
@@ -1,0 +1,109 @@
+---
+external help file: ImagePlayground-help.xml
+Module Name: ImagePlayground
+online version:
+schema: 2.0.0
+---
+
+# New-ImageThumbnail
+
+## SYNOPSIS
+Creates thumbnails for all images in a directory.
+
+## SYNTAX
+```
+New-ImageThumbnail [-DirectoryPath] <String> [-OutputDirectory] <String> [-Width <Int32>] [-Height <Int32>] [-DontRespectAspectRatio] [-Sampler <Sampler>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+`New-ImageThumbnail` scans a directory and saves resized copies of each image to the specified output directory.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> New-ImageThumbnail -DirectoryPath .\Images -OutputDirectory .\Thumbs -Width 64 -Height 64 -Sampler Lanczos3
+```
+Creates 64x64 thumbnails using the Lanczos3 sampler.
+
+## PARAMETERS
+
+### -DirectoryPath
+Directory containing the source images.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Required: True
+Position: 0
+```
+
+### -OutputDirectory
+Directory where thumbnails will be saved.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Required: True
+Position: 1
+```
+
+### -Width
+Thumbnail width in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+```
+
+### -Height
+Thumbnail height in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+```
+
+### -DontRespectAspectRatio
+If present, forces the thumbnails to stretch to the specified width and height.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+```
+
+### -Sampler
+Optional resampling algorithm to use when resizing.
+
+```yaml
+Type: Sampler
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.IO.FileInfo[]
+## NOTES
+
+## RELATED LINKS

--- a/Examples/Images.Thumbnails.ps1
+++ b/Examples/Images.Thumbnails.ps1
@@ -1,0 +1,11 @@
+#Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+$thumbParams = @{
+    DirectoryPath    = "$PSScriptRoot\Samples"
+    OutputDirectory  = "$PSScriptRoot\Output\Thumbs"
+    Width            = 64
+    Height           = 64
+    Sampler          = 'Lanczos3'
+}
+
+New-ImageThumbnail @thumbParams

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
@@ -33,6 +33,10 @@ public sealed class NewImageThumbnailCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter DontRespectAspectRatio { get; set; }
 
+    /// <summary>Resampling algorithm.</summary>
+    [Parameter]
+    public Sampler? Sampler { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var dir = Helpers.ResolvePath(DirectoryPath);
@@ -41,6 +45,6 @@ public sealed class NewImageThumbnailCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(OutputDirectory);
-        ImagePlayground.ImageHelper.GenerateThumbnails(dir, output, Width, Height, !DontRespectAspectRatio.IsPresent);
+        ImagePlayground.ImageHelper.GenerateThumbnails(dir, output, Width, Height, !DontRespectAspectRatio.IsPresent, Sampler);
     }
 }

--- a/Tests/New-ImageThumbnail.Tests.ps1
+++ b/Tests/New-ImageThumbnail.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'New-ImageThumbnail' {
         $srcDir = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images'
         $outDir = Join-Path $TestDir 'thumbs'
         if (Test-Path $outDir) { Remove-Item $outDir -Recurse -Force }
-        New-ImageThumbnail -DirectoryPath $srcDir -OutputDirectory $outDir -Width 20 -Height 20
+        New-ImageThumbnail -DirectoryPath $srcDir -OutputDirectory $outDir -Width 20 -Height 20 -Sampler Lanczos3
         (Test-Path $outDir) | Should -BeTrue
         (Get-ChildItem -Path $outDir -File | Measure-Object).Count | Should -BeGreaterThan 0
         $file = Get-ChildItem -Path $outDir -File | Select-Object -First 1


### PR DESCRIPTION
## Summary
- add `Sampler` parameter to `New-ImageThumbnail` cmdlet
- document `New-ImageThumbnail` usage with sampler
- add new example script
- extend Pester tests for sampler support

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6874b4868c2c832e8967cda189489598