### PR TITLE
Encode wifi password

### DIFF
--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using BarcodeReader.ImageSharp;
 using QRCoder;
 using SixLabors.ImageSharp;
@@ -68,7 +69,8 @@ public class QrCode {
     /// <param name="filePath">Destination image path.</param>
     /// <param name="transparent">Whether the QR code should have transparent background.</param>
     public static void GenerateWiFi(string ssid, string password, string filePath, bool transparent = false) {
-        PayloadGenerator.WiFi generator = new PayloadGenerator.WiFi(ssid, password, PayloadGenerator.WiFi.Authentication.WPA, false, false);
+        string encodedPassword = WebUtility.UrlEncode(password);
+        PayloadGenerator.WiFi generator = new PayloadGenerator.WiFi(ssid, encodedPassword, PayloadGenerator.WiFi.Authentication.WPA, false, false);
         Generate(generator.ToString(), filePath, transparent);
     }
 

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Net;
 using Xunit;
 
 
@@ -53,6 +54,7 @@ public partial class ImagePlayground {
     [Theory]
     [InlineData("12345678")]
     [InlineData("pass123")]
+    [InlineData("pass;123!")]
     public void Test_QRCodeWiFi_Passwords(string password) {
         string filePath = System.IO.Path.Combine(_directoryWithImages, $"WiFi_{password}.png");
         File.Delete(filePath);
@@ -63,7 +65,8 @@ public partial class ImagePlayground {
         Assert.True(File.Exists(filePath) == true);
 
         var read = QrCode.Read(filePath);
-        Assert.True(read.Message == $"WIFI:T:WPA;S:TestSSID;P:{password};;");
+        string expected = $"WIFI:T:WPA;S:TestSSID;P:{WebUtility.UrlEncode(password)};;";
+        Assert.Equal(expected, read.Message);
     }
 
     [Fact]

--- a/Tests/New-ImageQRCodeWiFi.Tests.ps1
+++ b/Tests/New-ImageQRCodeWiFi.Tests.ps1
@@ -36,5 +36,12 @@ Describe 'New-ImageQRCodeWiFi password quoting' {
 
     }
 
+    It 'handles passwords with symbols' {
+
+        $file = Join-Path $TestDrive 'wifi_symbols.png'
+        New-ImageQRCodeWiFi -SSID 'Test' -Password 'pass;123!' -FilePath $file
+        $result = Get-ImageQRCode -FilePath $file
+        $result.Message | Should -Be 'WIFI:T:WPA;S:Test;P:pass%3B123!;;'
+    }
 }
 


### PR DESCRIPTION
## Summary
- URL encode WiFi passwords before generating payloads
- cover WiFi passwords with symbols in tests
- add regression Pester test for symbol passwords

## Testing
- `dotnet test Sources/ImagePlayground.sln --framework net8.0`
- `pwsh ./ImagePlayground.Tests.ps1` *(fails: Get-Image cmdlet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b47f7d4c832e84f68d242c5caaa3