### PR TITLE
Fix file handle management in image loader

### DIFF
--- a/Sources/ImagePlayground.Core/Image.cs
+++ b/Sources/ImagePlayground.Core/Image.cs
@@ -490,9 +490,10 @@ public partial class Image : IDisposable {
     public static Image Load(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
 
+        using var stream = System.IO.File.OpenRead(fullPath);
         Image image = new Image {
             _filePath = fullPath,
-            _image = SixLabors.ImageSharp.Image.Load(fullPath)
+            _image = SixLabors.ImageSharp.Image.Load(stream)
         };
 
         return image;

--- a/Sources/ImagePlayground.Tests/ThumbnailDispose.cs
+++ b/Sources/ImagePlayground.Tests/ThumbnailDispose.cs
@@ -1,0 +1,14 @@
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_GetImageThumbnail_DoesNotLockSourceFile() {
+        string src = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+        using var thumb = ImageHelper.GetImageThumbnail(src, 32, 32);
+        thumb.Dispose();
+        using var stream = File.Open(src, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `Image.Load` closes opened streams
- add a regression test for thumbnail handling

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -c Debug -f net8.0 --no-build`
- `pwsh -NoLogo -NoProfile -File ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6874b46a8bb0832e8e2547127cc58022