### PR TITLE
Dispose temporary image after QrCode.Read

### DIFF
--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -252,6 +252,7 @@ public class QrCode {
         using Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
         BarcodeReader<Rgba32> reader = new BarcodeReader<Rgba32>(types: ZXing.BarcodeFormat.QR_CODE);
         BarcodeResult<Rgba32> response = reader.Decode(barcodeImage);
+        response.Image?.Dispose();
         BarcodeResult<Rgba32> result = new() {
             Value = response.Value,
             Status = response.Status,

--- a/Sources/ImagePlayground.Tests/BarCodeDispose.cs
+++ b/Sources/ImagePlayground.Tests/BarCodeDispose.cs
@@ -16,6 +16,7 @@ public partial class ImagePlayground {
         string filePath = Path.Combine(_directoryWithImages, "QRCode1.png");
         var result = QrCode.Read(filePath);
         Assert.True(!string.IsNullOrEmpty(result.Message));
+        Assert.Null(result.Image);
         using var stream = File.Open(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 }


### PR DESCRIPTION
## Summary
- dispose barcode image inside `QrCode.Read`
- ensure test asserts `result.Image` is null after reading

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -nologo -f net8.0 --no-build -v:m`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -nologo -f net472 --no-build -v:m` *(fails: Attempting to cancel the build...)*

------
https://chatgpt.com/codex/tasks/task_e_6874bc493260832ea57aed38fa7051a0