### PR TITLE
Ensure UTF-8 metadata exports

### DIFF
--- a/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Metadata;
@@ -88,7 +89,7 @@ public partial class ImageHelper {
     public static void ExportMetadata(string filePath, string outFilePath) {
         string json = ExportMetadata(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
-        File.WriteAllText(outFullPath, json);
+        File.WriteAllText(outFullPath, json, Encoding.UTF8);
     }
 
     /// <summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletExportImageMetadata.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletExportImageMetadata.cs
@@ -1,6 +1,7 @@
 using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
+using System.Text;
 
 namespace ImagePlayground.PowerShell;
 
@@ -37,7 +38,7 @@ public sealed class ExportImageMetadataCmdlet : PSCmdlet {
             WriteObject(json);
         } else {
             var output = Helpers.ResolvePath(OutputPath!);
-            File.WriteAllText(output, json);
+            File.WriteAllText(output, json, Encoding.UTF8);
         }
     }
 }

--- a/Sources/ImagePlayground.Tests/Metadata.cs
+++ b/Sources/ImagePlayground.Tests/Metadata.cs
@@ -66,4 +66,24 @@ public partial class ImagePlayground {
         Assert.Equal(150, check.Metadata.HorizontalResolution);
         Assert.Equal(150, check.Metadata.VerticalResolution);
     }
+
+    [Fact]
+    public void Test_ExportMetadata_Utf8Encoding() {
+        string imgPath = Path.Combine(_directoryWithTests, "metadata_utf8.jpg");
+        string metaPath = Path.Combine(_directoryWithTests, "metadata_utf8.json");
+        if (File.Exists(imgPath)) File.Delete(imgPath);
+        if (File.Exists(metaPath)) File.Delete(metaPath);
+
+        using (var img = new PlaygroundImage()) {
+            img.Create(imgPath, 1, 1);
+            img.Save();
+        }
+
+        string json = ImageHelper.ExportMetadata(imgPath);
+        ImageHelper.ExportMetadata(imgPath, metaPath);
+
+        byte[] expected = System.Text.Encoding.UTF8.GetBytes(json);
+        byte[] actual = File.ReadAllBytes(metaPath);
+        Assert.Equal(expected, actual);
+    }
 }


### PR DESCRIPTION
## Summary
- use `File.WriteAllText(..., Encoding.UTF8)` for metadata export
- test UTF-8 encoding when exporting metadata

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --no-build --verbosity minimal --framework net8.0`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --no-build --verbosity minimal --framework net472` *(fails: Failed to negotiate protocol)*

------
https://chatgpt.com/codex/tasks/task_e_6874bc4e03c0832e867a435f0baa0454