### PR TITLE
Ensure output directories exist

### DIFF
--- a/Sources/ImagePlayground.Core/Image.Avatar.cs
+++ b/Sources/ImagePlayground.Core/Image.Avatar.cs
@@ -29,6 +29,7 @@ public partial class Image : IDisposable {
     /// <param name="cornerRadius">Radius of the rounded corners.</param>
     public void SaveAsAvatar(string filePath, int width, int height, float cornerRadius) {
         string fullPath = Helpers.ResolvePath(filePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(fullPath)!);
         using var clone = _image.Clone(x => ConvertToAvatar(x, new Size(width, height), cornerRadius));
         clone.Save(fullPath);
     }

--- a/Sources/ImagePlayground.Core/Image.cs
+++ b/Sources/ImagePlayground.Core/Image.cs
@@ -128,6 +128,7 @@ public partial class Image : IDisposable {
     /// <param name="filePathToSave">Output path for the mask image.</param>
     public void Compare(Image imageToCompare, string filePathToSave) {
         string outFullPath = Helpers.ResolvePath(filePathToSave);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
             using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(_image, imageToCompare._image)) {
                 SixLabors.ImageSharp.ImageExtensions.SaveAsPng(maskImage, fileStreamDifferenceMask);
@@ -143,6 +144,7 @@ public partial class Image : IDisposable {
     public void Compare(string filePathToCompare, string filePathToSave) {
         string fullPath = Helpers.ResolvePath(filePathToCompare);
         string outFullPath = Helpers.ResolvePath(filePathToSave);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
             using (var imageToCompare = GetImage(fullPath)) {

--- a/Sources/ImagePlayground.Core/ImageHelper.AddText.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.AddText.cs
@@ -25,6 +25,7 @@ public partial class ImageHelper {
     public static void AddText(string filePath, string outFilePath, float x, float y, string text, Color color, float fontSize = 16f, string fontFamilyName = "Arial", Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using var img = Image.Load(fullPath);
         img.AddText(x, y, text, color, fontSize, fontFamilyName, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
@@ -76,6 +77,7 @@ public partial class ImageHelper {
     public static void AddTextBox(string filePath, string outFilePath, float x, float y, string text, float boxWidth, float boxHeight, Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using var img = Image.Load(fullPath);
         img.AddTextBox(x, y, text, boxWidth, boxHeight, color, fontSize, fontFamilyName, horizontalAlignment, verticalAlignment, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);

--- a/Sources/ImagePlayground.Core/ImageHelper.AddWatermark.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.AddWatermark.cs
@@ -23,6 +23,7 @@ public partial class ImageHelper {
     public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         using var img = Image.Load(fullPath);
         img.WatermarkImage(watermarkFilePath, placement, opacity, padding, rotate, flipMode, watermarkPercentage);
         img.Save(outFullPath);
@@ -34,6 +35,7 @@ public partial class ImageHelper {
     public static async Task WatermarkImageAsync(string filePath, string outFilePath, string watermarkFilePath, WatermarkPlacement placement, float opacity = 1f, float padding = 18f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         await Task.Run(() => {
             using var img = Image.Load(fullPath);
             img.WatermarkImage(watermarkFilePath, placement, opacity, padding, rotate, flipMode, watermarkPercentage);
@@ -56,6 +58,7 @@ public partial class ImageHelper {
     public static void WatermarkImage(string filePath, string outFilePath, string watermarkFilePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         using var img = Image.Load(fullPath);
         img.WatermarkImage(watermarkFilePath, x, y, opacity, rotate, flipMode, watermarkPercentage);
         img.Save(outFullPath);
@@ -67,6 +70,7 @@ public partial class ImageHelper {
     public static async Task WatermarkImageAsync(string filePath, string outFilePath, string watermarkFilePath, int x, int y, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         await Task.Run(() => {
             using var img = Image.Load(fullPath);
             img.WatermarkImage(watermarkFilePath, x, y, opacity, rotate, flipMode, watermarkPercentage);
@@ -88,6 +92,7 @@ public partial class ImageHelper {
     public static void WatermarkImageTiled(string filePath, string outFilePath, string watermarkFilePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         using var img = Image.Load(fullPath);
         img.WatermarkImageTiled(watermarkFilePath, spacing, opacity, rotate, flipMode, watermarkPercentage);
         img.Save(outFullPath);
@@ -99,6 +104,7 @@ public partial class ImageHelper {
     public static async Task WatermarkImageTiledAsync(string filePath, string outFilePath, string watermarkFilePath, int spacing, float opacity = 1f, int rotate = 0, FlipMode flipMode = FlipMode.None, int watermarkPercentage = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         await Task.Run(() => {
             using var img = Image.Load(fullPath);
             img.WatermarkImageTiled(watermarkFilePath, spacing, opacity, rotate, flipMode, watermarkPercentage);

--- a/Sources/ImagePlayground.Core/ImageHelper.Avatar.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Avatar.cs
@@ -17,6 +17,7 @@ public partial class ImageHelper {
     public static void Avatar(string filePath, string outFilePath, int width, int height, float cornerRadius) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using var img = Image.Load(fullPath);
         img.SaveAsAvatar(outFullPath, width, height, cornerRadius);
@@ -46,6 +47,7 @@ public partial class ImageHelper {
     public static void AvatarCircular(string filePath, string outFilePath, int size) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using var img = Image.Load(fullPath);
         img.SaveAsCircularAvatar(outFullPath, size);

--- a/Sources/ImagePlayground.Core/ImageHelper.Base64.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Base64.cs
@@ -26,6 +26,7 @@ public partial class ImageHelper {
     /// <param name="outFilePath">Destination file path.</param>
     public static void ConvertFromBase64(string base64, string outFilePath) {
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         var bytes = Convert.FromBase64String(base64);
         File.WriteAllBytes(outFullPath, bytes);
     }

--- a/Sources/ImagePlayground.Core/ImageHelper.Compare.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Compare.cs
@@ -30,6 +30,7 @@ public partial class ImageHelper {
         string fullPath = Helpers.ResolvePath(filePath);
         string fullPathToCompare = Helpers.ResolvePath(filePathToCompare);
         string outFullPath = Helpers.ResolvePath(filePathToSave);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using (var fileStreamDifferenceMask = File.Create(outFullPath)) {
             using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(fullPath, fullPathToCompare)) {

--- a/Sources/ImagePlayground.Core/ImageHelper.Crop.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Crop.cs
@@ -15,6 +15,7 @@ public partial class ImageHelper {
     public static void Crop(string filePath, string outFilePath, Rectangle rectangle) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using var img = Image.Load(fullPath);
         img.Crop(rectangle);
@@ -32,6 +33,7 @@ public partial class ImageHelper {
     public static void CropCircle(string filePath, string outFilePath, float centerX, float centerY, float radius) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using var img = Image.Load(fullPath);
         img.CropCircle(centerX, centerY, radius);
@@ -47,6 +49,7 @@ public partial class ImageHelper {
     public static void CropPolygon(string filePath, string outFilePath, params PointF[] points) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using var img = Image.Load(fullPath);
         img.CropPolygon(points);

--- a/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
@@ -88,6 +88,7 @@ public partial class ImageHelper {
     public static void ExportMetadata(string filePath, string outFilePath) {
         string json = ExportMetadata(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         File.WriteAllText(outFullPath, json);
     }
 
@@ -117,6 +118,7 @@ public partial class ImageHelper {
         string fullPath = Helpers.ResolvePath(filePath);
         string metaFullPath = Helpers.ResolvePath(metadataFilePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         string json = File.ReadAllText(metaFullPath);
         SerializedImageMetadata? data = JsonSerializer.Deserialize<SerializedImageMetadata>(json);

--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -26,6 +26,7 @@ public partial class ImageHelper {
     public static void ConvertTo(string filePath, string outFilePath, int? quality = null, int? compressionLevel = null) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         using (var inStream = System.IO.File.OpenRead(fullPath))
         using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
             FileInfo fileInfo = new FileInfo(outFilePath);
@@ -51,6 +52,7 @@ public partial class ImageHelper {
     public static void Resize(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using (var inStream = System.IO.File.OpenRead(fullPath))
         using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
@@ -65,6 +67,7 @@ public partial class ImageHelper {
     public static async Task ResizeAsync(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         await Task.Run(() => {
             using var inStream = System.IO.File.OpenRead(fullPath);
@@ -126,6 +129,7 @@ public partial class ImageHelper {
 
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         using (var inStream = System.IO.File.OpenRead(fullPath))
         using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
@@ -146,6 +150,7 @@ public partial class ImageHelper {
 
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
         await Task.Run(() => {
             using var inStream = System.IO.File.OpenRead(fullPath);
@@ -252,6 +257,7 @@ public partial class ImageHelper {
     /// <param name="open">Open the image after saving.</param>
     public static void Create(string filePath, int width, int height, Color color, bool open = false) {
         string fullPath = Helpers.ResolvePath(filePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(fullPath)!);
 
         using (Image<Rgba32> outputImage = new Image<Rgba32>(width, height)) {
             //outputImage.Mutate(x => x.Fill(color));

--- a/Tests/Add-ImageWatermark.Tests.ps1
+++ b/Tests/Add-ImageWatermark.Tests.ps1
@@ -37,4 +37,16 @@ Describe 'Add-ImageWatermark' {
         $out.Dispose()
         $orig.Dispose()
     }
+
+    It 'creates directory when adding watermark to a new folder' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $wmk = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $folder = Join-Path $TestDir 'WatermarkFolder'
+        $dest = Join-Path $folder 'watermark.png'
+        if (Test-Path $folder) { Remove-Item $folder -Recurse -Force }
+
+        Add-ImageWatermark -FilePath $src -OutputPath $dest -WatermarkPath $wmk -WatermarkPercentage 100
+
+        Test-Path $dest | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- automatically create output directories before saving files
- add regression test for Add-ImageWatermark when output folder is missing

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Debug`
- `pwsh ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6874bc54dae0832e9119dcf8a0b4fe66