### PR TITLE
Handle failing Process.Start

### DIFF
--- a/Sources/ImagePlayground.Core/Helpers.cs
+++ b/Sources/ImagePlayground.Core/Helpers.cs
@@ -19,15 +19,23 @@ public static partial class Helpers {
     /// <param name="filePath">Path to the file.</param>
     /// <param name="open">Whether to open the file.</param>
     public static void Open(string filePath, bool open) {
-        if (open) {
-            ProcessStartInfo startInfo = new(filePath) {
-                UseShellExecute = true
-            };
-            try {
-                Process.Start(startInfo);
-            } catch (Exception ex) {
-                Console.Error.WriteLine($"Unable to open {filePath}: {ex.Message}");
-            }
+        if (!open) {
+            return;
+        }
+
+        if (!File.Exists(filePath)) {
+            Console.Error.WriteLine($"Unable to open {filePath}: file does not exist.");
+            return;
+        }
+
+        ProcessStartInfo startInfo = new(filePath) {
+            UseShellExecute = true
+        };
+
+        try {
+            Process.Start(startInfo);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Unable to open {filePath}: {ex.Message}");
         }
     }
 

--- a/Sources/ImagePlayground.Core/Helpers.cs
+++ b/Sources/ImagePlayground.Core/Helpers.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace ImagePlayground;
@@ -19,10 +20,14 @@ public static partial class Helpers {
     /// <param name="open">Whether to open the file.</param>
     public static void Open(string filePath, bool open) {
         if (open) {
-            ProcessStartInfo startInfo = new ProcessStartInfo(filePath) {
+            ProcessStartInfo startInfo = new(filePath) {
                 UseShellExecute = true
             };
-            Process.Start(startInfo);
+            try {
+                Process.Start(startInfo);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"Unable to open {filePath}: {ex.Message}");
+            }
         }
     }
 

--- a/Sources/ImagePlayground.Tests/HelpersOpen.cs
+++ b/Sources/ImagePlayground.Tests/HelpersOpen.cs
@@ -17,5 +17,6 @@ public partial class ImagePlayground {
         }
         string output = sw.ToString();
         Assert.Contains("Unable to open", output);
+        Assert.Contains("file does not exist", output);
     }
 }

--- a/Sources/ImagePlayground.Tests/HelpersOpen.cs
+++ b/Sources/ImagePlayground.Tests/HelpersOpen.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_Open_InvalidPath_Handled() {
+        string invalid = Path.Combine(_directoryWithTests, "notexisting.exe");
+        using var sw = new StringWriter();
+        TextWriter original = Console.Error;
+        Console.SetError(sw);
+        try {
+            Helpers.Open(invalid, true);
+        } finally {
+            Console.SetError(original);
+        }
+        string output = sw.ToString();
+        Assert.Contains("Unable to open", output);
+    }
+}


### PR DESCRIPTION
## Summary
- catch `Process.Start` failures in `Helpers.Open`
- warn on open failure
- test `Helpers.Open` when process start throws

## Testing
- `dotnet build ImagePlayground.sln -c Release`
- `dotnet test ImagePlayground.sln --no-build -v minimal` *(fails: invalid argument)*
- `Invoke-Pester -Output Detailed` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874bc656ce8832e91d80b86756a8a53