### PR TITLE
Ensure QR code image disposed

### DIFF
--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -29,7 +29,7 @@ public class QrCode {
         using (QRCodeGenerator qrGenerator = new QRCodeGenerator()) {
             using (QRCodeData qrCodeData = qrGenerator.CreateQrCode(content, eccLevel)) {
                 using (QRCoder.QRCode qrCode = new QRCoder.QRCode(qrCodeData)) {
-                    using SixLabors.ImageSharp.Image qrCodeImage = qrCode.GetGraphic(20);
+                    using (SixLabors.ImageSharp.Image qrCodeImage = qrCode.GetGraphic(20)) {
                     if (transparent) {
                         //qrCodeImage.MakeTransparent();
                     }
@@ -55,6 +55,7 @@ public class QrCode {
                         SaveImageAsIcon(qrCodeImage, fullPath);
                     } else {
                         throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+                    }
                     }
                 }
             }

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -29,33 +29,32 @@ public class QrCode {
         using (QRCodeGenerator qrGenerator = new QRCodeGenerator()) {
             using (QRCodeData qrCodeData = qrGenerator.CreateQrCode(content, eccLevel)) {
                 using (QRCoder.QRCode qrCode = new QRCoder.QRCode(qrCodeData)) {
-                    using (var qrCodeImage = qrCode.GetGraphic(20)) {
-                        if (transparent) {
-                            //qrCodeImage.MakeTransparent();
-                        }
-                        // this uses QRCoder
-                        //ImageFormat imageFormatDetected;
-                        //if (fileInfo.Extension == ".png") {
-                        //    imageFormatDetected = ImageFormat.Png;
-                        //} else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
-                        //    imageFormatDetected = ImageFormat.Jpeg;
-                        //} else if (fileInfo.Extension == ".ico") {
-                        //    imageFormatDetected = ImageFormat.Icon;
-                        //} else {
-                        //    throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
-                        //}
-                        //qrCodeImage.Save(filePath, imageFormatDetected);
+                    using SixLabors.ImageSharp.Image qrCodeImage = qrCode.GetGraphic(20);
+                    if (transparent) {
+                        //qrCodeImage.MakeTransparent();
+                    }
+                    // this uses QRCoder
+                    //ImageFormat imageFormatDetected;
+                    //if (fileInfo.Extension == ".png") {
+                    //    imageFormatDetected = ImageFormat.Png;
+                    //} else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+                    //    imageFormatDetected = ImageFormat.Jpeg;
+                    //} else if (fileInfo.Extension == ".ico") {
+                    //    imageFormatDetected = ImageFormat.Icon;
+                    //} else {
+                    //    throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+                    //}
+                    //qrCodeImage.Save(filePath, imageFormatDetected);
 
-                        //this uses QRCoder.ImageSharp
-                        if (fileInfo.Extension == ".png") {
-                            qrCodeImage.SaveAsPng(fullPath);
-                        } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
-                            qrCodeImage.SaveAsJpeg(fullPath);
-                        } else if (fileInfo.Extension == ".ico") {
-                            SaveImageAsIcon(qrCodeImage, fullPath);
-                        } else {
-                            throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
-                        }
+                    //this uses QRCoder.ImageSharp
+                    if (fileInfo.Extension == ".png") {
+                        qrCodeImage.SaveAsPng(fullPath);
+                    } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+                        qrCodeImage.SaveAsJpeg(fullPath);
+                    } else if (fileInfo.Extension == ".ico") {
+                        SaveImageAsIcon(qrCodeImage, fullPath);
+                    } else {
+                        throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
                     }
                 }
             }

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -26,39 +26,37 @@ public class QrCode {
 
         FileInfo fileInfo = new FileInfo(fullPath);
 
-        using (QRCodeGenerator qrGenerator = new QRCodeGenerator()) {
-            using (QRCodeData qrCodeData = qrGenerator.CreateQrCode(content, eccLevel)) {
-                using (QRCoder.QRCode qrCode = new QRCoder.QRCode(qrCodeData)) {
-                    using (SixLabors.ImageSharp.Image qrCodeImage = qrCode.GetGraphic(20)) {
-                    if (transparent) {
-                        //qrCodeImage.MakeTransparent();
-                    }
-                    // this uses QRCoder
-                    //ImageFormat imageFormatDetected;
-                    //if (fileInfo.Extension == ".png") {
-                    //    imageFormatDetected = ImageFormat.Png;
-                    //} else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
-                    //    imageFormatDetected = ImageFormat.Jpeg;
-                    //} else if (fileInfo.Extension == ".ico") {
-                    //    imageFormatDetected = ImageFormat.Icon;
-                    //} else {
-                    //    throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
-                    //}
-                    //qrCodeImage.Save(filePath, imageFormatDetected);
+        using QRCodeGenerator qrGenerator = new QRCodeGenerator();
+        using QRCodeData qrCodeData = qrGenerator.CreateQrCode(content, eccLevel);
+        using QRCoder.QRCode qrCode = new QRCoder.QRCode(qrCodeData);
+        using SixLabors.ImageSharp.Image qrCodeImage = qrCode.GetGraphic(20);
 
-                    //this uses QRCoder.ImageSharp
-                    if (fileInfo.Extension == ".png") {
-                        qrCodeImage.SaveAsPng(fullPath);
-                    } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
-                        qrCodeImage.SaveAsJpeg(fullPath);
-                    } else if (fileInfo.Extension == ".ico") {
-                        SaveImageAsIcon(qrCodeImage, fullPath);
-                    } else {
-                        throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
-                    }
-                    }
-                }
-            }
+        if (transparent) {
+            //qrCodeImage.MakeTransparent();
+        }
+
+        // this uses QRCoder
+        //ImageFormat imageFormatDetected;
+        //if (fileInfo.Extension == ".png") {
+        //    imageFormatDetected = ImageFormat.Png;
+        //} else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+        //    imageFormatDetected = ImageFormat.Jpeg;
+        //} else if (fileInfo.Extension == ".ico") {
+        //    imageFormatDetected = ImageFormat.Icon;
+        //} else {
+        //    throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+        //}
+        //qrCodeImage.Save(filePath, imageFormatDetected);
+
+        //this uses QRCoder.ImageSharp
+        if (fileInfo.Extension == ".png") {
+            qrCodeImage.SaveAsPng(fullPath);
+        } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+            qrCodeImage.SaveAsJpeg(fullPath);
+        } else if (fileInfo.Extension == ".ico") {
+            SaveImageAsIcon(qrCodeImage, fullPath);
+        } else {
+            throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
         }
     }
     /// <summary>

--- a/Sources/ImagePlayground.Tests/QrCodeMemory.cs
+++ b/Sources/ImagePlayground.Tests/QrCodeMemory.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_QrCodeGenerate_MemoryUsageStable() {
+        string filePath = Path.Combine(_directoryWithTests, "qr_mem.png");
+        long before = GC.GetTotalMemory(true);
+        for (int i = 0; i < 50; i++) {
+            QrCode.Generate("https://example.com", filePath);
+            if (File.Exists(filePath)) {
+                File.Delete(filePath);
+            }
+        }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        long after = GC.GetTotalMemory(true);
+        Assert.True(Math.Abs(after - before) < 1024 * 1024);
+    }
+}


### PR DESCRIPTION
## Summary
- wrap qrCodeImage in using declaration
- add memory usage test to confirm disposal

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6874bc6bd800832ea34db6b80479a1dc