### PR TITLE
Validate icon conversion

### DIFF
--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -30,7 +30,11 @@ public partial class ImageHelper {
         using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
             FileInfo fileInfo = new FileInfo(outFilePath);
             if (fileInfo.Extension == ".ico") {
-                System.IO.File.Copy(fullPath, outFullPath, true);
+                if (System.IO.Path.GetExtension(fullPath).Equals(".ico", StringComparison.OrdinalIgnoreCase)) {
+                    System.IO.File.Copy(fullPath, outFullPath, true);
+                } else {
+                    throw new NotSupportedException("Conversion to .ico is only supported from .ico files.");
+                }
             } else {
                 var encoder = Helpers.GetEncoder(fileInfo.Extension, quality, compressionLevel);
                 image.Save(outFullPath, encoder);

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
@@ -6,6 +6,7 @@ namespace ImagePlayground.PowerShell;
 
 /// <summary>Converts an image to a different format.</summary>
 /// <para>Outputs a new file using the extension from <see cref="OutputPath"/>.</para>
+/// <para>When <see cref="OutputPath"/> ends with <c>.ico</c>, the file is only copied if the source file is also an icon.</para>
 /// <example>
 ///   <summary>Convert PNG to JPEG</summary>
 ///   <code>ConvertTo-Image -FilePath image.png -OutputPath image.jpg -Quality 85</code>

--- a/Sources/ImagePlayground.Tests/ConvertToIcon.cs
+++ b/Sources/ImagePlayground.Tests/ConvertToIcon.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_ConvertToIcon_FromIcon_CopiesFile() {
+        string src = Path.Combine(_directoryWithImages, "QRCode1.ico");
+        string dest = Path.Combine(_directoryWithTests, "copy.ico");
+        if (File.Exists(dest)) File.Delete(dest);
+
+        ImageHelper.ConvertTo(src, dest);
+        Assert.True(File.Exists(dest));
+        Assert.Equal(new FileInfo(src).Length, new FileInfo(dest).Length);
+    }
+
+    [Fact]
+    public void Test_ConvertToIcon_FromPng_Throws() {
+        string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+        string dest = Path.Combine(_directoryWithTests, "invalid.ico");
+        Assert.Throws<NotSupportedException>(() => ImageHelper.ConvertTo(src, dest));
+    }
+}

--- a/Tests/ConvertTo-Image.Tests.ps1
+++ b/Tests/ConvertTo-Image.Tests.ps1
@@ -1,30 +1,31 @@
 Describe 'ConvertTo-Image' {
-
     BeforeAll {
-
         Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
 
-
-
         $TestDir = Join-Path $PSScriptRoot 'Artifacts'
-
         if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
-
     }
 
     It 'converts image format' {
-
         $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
-
         $dest = Join-Path $TestDir 'qr.jpg'
-
         if (Test-Path $dest) { Remove-Item $dest }
-
         ConvertTo-Image -FilePath $src -OutputPath $dest -Quality 80
-
         Test-Path $dest | Should -BeTrue
-
     }
 
-}
+    It 'copies icon when converting icon to icon' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.ico'
+        $dest = Join-Path $TestDir 'qr_copy.ico'
+        if (Test-Path $dest) { Remove-Item $dest }
+        ConvertTo-Image -FilePath $src -OutputPath $dest
+        Test-Path $dest | Should -BeTrue
+        (Get-Item $dest).Length | Should -Be (Get-Item $src).Length
+    }
 
+    It 'throws when converting non-icon to icon' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'invalid.ico'
+        { ConvertTo-Image -FilePath $src -OutputPath $dest } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `ImageHelper.ConvertTo` only copies when source is an icon
- document the copy behaviour in `ConvertTo-Image` help
- add tests for icon conversion logic

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --framework net8.0 --verbosity minimal`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6874bc738df4832e8d0b1aec5ca10f04