### PR TITLE
Reduce dimension maximum

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
@@ -62,7 +62,7 @@ public sealed class AddImageWatermarkCmdlet : PSCmdlet {
 
     /// <summary>Tile watermark across the image with given spacing.</summary>
     [Parameter]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int? Spacing { get; set; }
 
     /// <summary>Use asynchronous processing.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
@@ -29,12 +29,12 @@ public sealed class NewImageAvatarCmdlet : PSCmdlet {
 
     /// <summary>Width of the avatar.</summary>
     [Parameter]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int Width { get; set; } = 200;
 
     /// <summary>Height of the avatar.</summary>
     [Parameter]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int Height { get; set; } = 200;
 
     /// <summary>Corner radius for rounding.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -29,12 +29,12 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
 
     /// <summary>Width of the chart.</summary>
     [Parameter]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int Width { get; set; } = 600;
 
     /// <summary>Height of the chart.</summary>
     [Parameter]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int Height { get; set; } = 400;
 
     /// <summary>X axis title.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
@@ -16,12 +16,12 @@ public sealed class NewImageGridCmdlet : PSCmdlet {
 
     /// <summary>Width of the new image.</summary>
     [Parameter(Mandatory = true, Position = 1)]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int Width { get; set; }
 
     /// <summary>Height of the new image.</summary>
     [Parameter(Mandatory = true, Position = 2)]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int Height { get; set; }
 
     /// <summary>Background color.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
@@ -24,7 +24,7 @@ public sealed class NewImageIconCmdlet : PSCmdlet {
     /// <summary>Icon sizes to include.</summary>
     /// <para>Defaults to common icon sizes when empty.</para>
     [Parameter]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int[] Size { get; set; } = Array.Empty<int>();
 
     /// <summary>Open the icon after saving.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
@@ -21,12 +21,12 @@ public sealed class NewImageThumbnailCmdlet : PSCmdlet {
 
     /// <summary>Thumbnail width.</summary>
     [Parameter]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int Width { get; set; } = 100;
 
     /// <summary>Thumbnail height.</summary>
     [Parameter]
-    [ValidateRange(1, 10000)]
+    [ValidateRange(1, 1000)]
     public int Height { get; set; } = 100;
 
     /// <summary>Ignore aspect ratio.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
@@ -31,19 +31,19 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
         /// <summary>New width of the image.</summary>
         /// <para>Used with <see cref="Height"/> when not using <see cref="Percentage"/>.</para>
         [Parameter(ParameterSetName = ParameterSetHeightWidth)]
-        [ValidateRange(1, 10000)]
+        [ValidateRange(1, 1000)]
         public int Width { get; set; }
 
         /// <summary>New height of the image.</summary>
         /// <para>Used with <see cref="Width"/> when not using <see cref="Percentage"/>.</para>
         [Parameter(ParameterSetName = ParameterSetHeightWidth)]
-        [ValidateRange(1, 10000)]
+        [ValidateRange(1, 1000)]
         public int Height { get; set; }
 
         /// <summary>Percentage based resize.</summary>
         /// <para>Applies uniform scaling relative to the original size.</para>
         [Parameter(ParameterSetName = ParameterSetPercentage)]
-        [ValidateRange(1, 10000)]
+        [ValidateRange(1, 1000)]
         public int Percentage { get; set; }
 
         /// <summary>Ignore aspect ratio.</summary>

--- a/Tests/Resize-Image.Tests.ps1
+++ b/Tests/Resize-Image.Tests.ps1
@@ -81,6 +81,13 @@ Describe 'Resize-Image' {
         { Resize-Image -FilePath $src -OutputPath $dest -Width 10 -Height -5 } | Should -Throw
     }
 
+    It 'throws for dimensions above maximum' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dest = Join-Path $TestDir 'logo-too-large.png'
+        { Resize-Image -FilePath $src -OutputPath $dest -Width 1200 -Height 100 } | Should -Throw
+        { Resize-Image -FilePath $src -OutputPath $dest -Width 100 -Height 1200 } | Should -Throw
+    }
+
     It 'throws when DontRespectAspectRatio without dimensions' {
         $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
         $dest = Join-Path $TestDir 'logo-invalid-aspect.png'

--- a/Tests/Resize-Image.Tests.ps1
+++ b/Tests/Resize-Image.Tests.ps1
@@ -87,6 +87,12 @@ Describe 'Resize-Image' {
         { Resize-Image -FilePath $src -OutputPath $dest -Width 1200 -Height 100 } | Should -Throw
         { Resize-Image -FilePath $src -OutputPath $dest -Width 100 -Height 1200 } | Should -Throw
     }
+    It 'accepts maximum dimension values' {
+        $src = Join-Path $PSScriptRoot "../Sources/ImagePlayground.Tests/Images/LogoEvotec.png"
+        $dest = Join-Path $TestDir "logo-max.png"
+        { Resize-Image -FilePath $src -OutputPath $dest -Width 1000 -Height 1000 } | Should -Not -Throw
+    }
+
 
     It 'throws when DontRespectAspectRatio without dimensions' {
         $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'


### PR DESCRIPTION
## Summary
- decrease maximum value validations from 10k to 1k
- guard against overly large dimensions in Resize-Image tests

## Testing
- `pwsh -NoLogo -NoProfile -File ./ImagePlayground.Tests.ps1` *(fails: Resolve-Path cannot find bin/Debug)*
- `dotnet restore` *(fails: Unable to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_6874bc7bac4c832ea1d401ae02a984db