### PR TITLE
Fix chart disposal

### DIFF
--- a/Sources/ImagePlayground.Chart/Charts.cs
+++ b/Sources/ImagePlayground.Chart/Charts.cs
@@ -246,172 +246,173 @@ public static class Charts {
         var list = definitions.ToList();
         if (list.Count == 0) throw new ArgumentException("No chart definitions provided", nameof(definitions));
 
-        var plot = new Plot();
-        switch (theme) {
-            case ChartTheme.Dark:
-                new ScottPlot.PlotStyles.Dark().Apply(plot);
-                break;
-            case ChartTheme.Light:
-                new ScottPlot.PlotStyles.Light().Apply(plot);
-                break;
-        }
-        var type = list[0].Type;
-        if (list.Any(d => d.Type != type))
-            throw new ArgumentException("Mixed chart definition types provided. All chart definitions must have the same ChartDefinitionType.", nameof(definitions));
-
-        switch (type) {
-            case ChartDefinitionType.Bar:
-                var positions = new List<int>();
-                var labels = new List<string>();
-                var dict = new Dictionary<int, List<double>>();
-                int pos = 0;
-                foreach (var bar in list.Cast<ChartBar>()) {
-                    for (int i = 0; i < bar.Value.Count; i++) {
-                        if (!dict.TryGetValue(i, out var vals)) {
-                            vals = new List<double>();
-                            dict[i] = vals;
+        using (var plot = new Plot()) {
+            switch (theme) {
+                case ChartTheme.Dark:
+                    new ScottPlot.PlotStyles.Dark().Apply(plot);
+                    break;
+                case ChartTheme.Light:
+                    new ScottPlot.PlotStyles.Light().Apply(plot);
+                    break;
+            }
+            var type = list[0].Type;
+            if (list.Any(d => d.Type != type))
+                throw new ArgumentException("Mixed chart definition types provided. All chart definitions must have the same ChartDefinitionType.", nameof(definitions));
+    
+            switch (type) {
+                case ChartDefinitionType.Bar:
+                    var positions = new List<int>();
+                    var labels = new List<string>();
+                    var dict = new Dictionary<int, List<double>>();
+                    int pos = 0;
+                    foreach (var bar in list.Cast<ChartBar>()) {
+                        for (int i = 0; i < bar.Value.Count; i++) {
+                            if (!dict.TryGetValue(i, out var vals)) {
+                                vals = new List<double>();
+                                dict[i] = vals;
+                            }
+                            vals.Add(bar.Value[i]);
                         }
-                        vals.Add(bar.Value[i]);
+                        labels.Add(bar.Name);
+                        positions.Add(pos++);
                     }
-                    labels.Add(bar.Name);
-                    positions.Add(pos++);
-                }
-                foreach (var kv in dict.OrderBy(k => k.Key)) {
-                    var plottable = plot.Add.Bars(kv.Value.ToArray());
-                    plottable.ValueLabelStyle.IsVisible = barOptions?.ShowValuesAboveBars == true;
-                    if (barOptions?.ShowValuesAboveBars == true) {
-                        for (int i = 0; i < plottable.Bars.Count; i++) {
-                            plottable.Bars[i].ValueLabel = plottable.Bars[i].Value.ToString();
+                    foreach (var kv in dict.OrderBy(k => k.Key)) {
+                        var plottable = plot.Add.Bars(kv.Value.ToArray());
+                        plottable.ValueLabelStyle.IsVisible = barOptions?.ShowValuesAboveBars == true;
+                        if (barOptions?.ShowValuesAboveBars == true) {
+                            for (int i = 0; i < plottable.Bars.Count; i++) {
+                                plottable.Bars[i].ValueLabel = plottable.Bars[i].Value.ToString();
+                            }
+                        }
+                        for (int i = 0; i < plottable.Bars.Count && i < list.Count; i++) {
+                            var c = ((ChartBar)list[i]).Color;
+                            if (c.HasValue) {
+                                var px = c.Value.ToPixel<Rgba32>();
+                                plottable.Bars[i].FillColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                            }
                         }
                     }
-                    for (int i = 0; i < plottable.Bars.Count && i < list.Count; i++) {
-                        var c = ((ChartBar)list[i]).Color;
+                    plot.Axes.Bottom.SetTicks(positions.Select(x => (double)x).ToArray(), labels.ToArray());
+                    break;
+                case ChartDefinitionType.Line:
+                    foreach (var line in list.Cast<ChartLine>()) {
+                        var sig = plot.Add.Signal(line.Value.ToArray());
+                        if (line.Smooth) {
+                            var prop = sig.GetType().GetProperty("SignalLineStyle");
+                            if (prop is not null) {
+                                var enumType = prop.PropertyType;
+                                var spline = Enum.Parse(enumType, "Spline");
+                                prop.SetValue(sig, spline);
+                            }
+                        }
+                        sig.LegendText = line.Name;
+                        sig.MarkerShape = line.MarkerShape;
+                        if (line.MarkerSize.HasValue)
+                            sig.MarkerSize = line.MarkerSize.Value;
+                        if (line.Color.HasValue) {
+                            var px = line.Color.Value.ToPixel<Rgba32>();
+                            sig.LineColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                        }
+                    }
+                    plot.ShowLegend();
+                    break;
+                case ChartDefinitionType.Scatter:
+                    foreach (var scatter in list.Cast<ChartScatter>()) {
+                        var sc = plot.Add.Scatter(scatter.X.ToArray(), scatter.Y.ToArray());
+                        sc.LegendText = scatter.Name;
+                        if (scatter.Color.HasValue) {
+                            var px = scatter.Color.Value.ToPixel<Rgba32>();
+                            sc.Color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                        }
+                    }
+                    plot.ShowLegend();
+                    break;
+                case ChartDefinitionType.Polar:
+                    foreach (var polar in list.Cast<ChartPolar>()) {
+                        var pp = plot.Add.Polar(polar.Angle.ToArray(), polar.Value.ToArray());
+                        pp.LegendText = polar.Name;
+                        if (polar.Color.HasValue) {
+                            var px = polar.Color.Value.ToPixel<Rgba32>();
+                            pp.Color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                        }
+                    }
+                    plot.ShowLegend();
+                    break;
+                case ChartDefinitionType.Pie:
+                    var pieValues = list.Cast<ChartPie>().Select(p => p.Value).ToArray();
+                    var pieLabels = list.Cast<ChartPie>().Select(p => p.Name).ToArray();
+                    var pie = plot.Add.Pie(pieValues);
+                    for (int i = 0; i < pie.Slices.Count && i < pieLabels.Length; i++) {
+                        pie.Slices[i].Label = pieLabels[i];
+                        var c = ((ChartPie)list[i]).Color;
                         if (c.HasValue) {
                             var px = c.Value.ToPixel<Rgba32>();
-                            plottable.Bars[i].FillColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                            pie.Slices[i].FillColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
                         }
                     }
-                }
-                plot.Axes.Bottom.SetTicks(positions.Select(x => (double)x).ToArray(), labels.ToArray());
-                break;
-            case ChartDefinitionType.Line:
-                foreach (var line in list.Cast<ChartLine>()) {
-                    var sig = plot.Add.Signal(line.Value.ToArray());
-                    if (line.Smooth) {
-                        var prop = sig.GetType().GetProperty("SignalLineStyle");
-                        if (prop is not null) {
-                            var enumType = prop.PropertyType;
-                            var spline = Enum.Parse(enumType, "Spline");
-                            prop.SetValue(sig, spline);
+                    break;
+                case ChartDefinitionType.Radial:
+                    var rValues = list.Cast<ChartRadial>().Select(r => r.Value).ToArray();
+                    var rLabels = list.Cast<ChartRadial>().Select(r => r.Name).ToArray();
+                    var radial = plot.Add.RadialGaugePlot(rValues);
+                    radial.Labels = rLabels;
+                    var rColors = list.Cast<ChartRadial>().Select(r => r.Color).ToArray();
+                    if (rColors.Any(c => c.HasValue)) {
+                        radial.Colors = rColors.Select(c => {
+                            if (c.HasValue) {
+                                var px = c.Value.ToPixel<Rgba32>();
+                                return new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                            }
+                            return new ScottPlot.Color();
+                        }).ToArray();
+                    }
+                    plot.ShowLegend();
+                    break;
+                case ChartDefinitionType.Heatmap:
+                    foreach (var map in list.Cast<ChartHeatmap>()) {
+                        plot.Add.Heatmap(map.Data);
+                    }
+                    break;
+                case ChartDefinitionType.Histogram:
+                    foreach (var hist in list.Cast<ChartHistogram>()) {
+                        var histogram = hist.BinSize.HasValue
+                            ? ScottPlot.Statistics.Histogram.WithBinSize(hist.BinSize.Value, hist.Values)
+                            : ScottPlot.Statistics.Histogram.WithBinCount(10, hist.Values);
+                        var bp = plot.Add.Bars(histogram.Bins, histogram.Counts);
+                        bp.LegendText = hist.Name;
+                        foreach (var bar in bp.Bars) {
+                            bar.Size = histogram.FirstBinSize * 0.8;
                         }
                     }
-                    sig.LegendText = line.Name;
-                    sig.MarkerShape = line.MarkerShape;
-                    if (line.MarkerSize.HasValue)
-                        sig.MarkerSize = line.MarkerSize.Value;
-                    if (line.Color.HasValue) {
-                        var px = line.Color.Value.ToPixel<Rgba32>();
-                        sig.LineColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                    plot.ShowLegend();
+                    break;
+            }
+    
+            if (!string.IsNullOrEmpty(xTitle)) {
+                plot.Axes.Bottom.Label.Text = xTitle;
+            }
+    
+            if (!string.IsNullOrEmpty(yTitle)) {
+                plot.Axes.Left.Label.Text = yTitle;
+            }
+    
+            if (showGrid) {
+                plot.ShowGrid();
+            } else {
+                plot.HideGrid();
+            }
+    
+            if (annotations is not null) {
+                foreach (var ann in annotations) {
+                    var callout = plot.Add.Callout(ann.Text, new Coordinates(ann.X, ann.Y), new Coordinates(ann.X, ann.Y));
+                    if (!ann.Arrow) {
+                        callout.ArrowLineWidth = 0;
                     }
-                }
-                plot.ShowLegend();
-                break;
-            case ChartDefinitionType.Scatter:
-                foreach (var scatter in list.Cast<ChartScatter>()) {
-                    var sc = plot.Add.Scatter(scatter.X.ToArray(), scatter.Y.ToArray());
-                    sc.LegendText = scatter.Name;
-                    if (scatter.Color.HasValue) {
-                        var px = scatter.Color.Value.ToPixel<Rgba32>();
-                        sc.Color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
-                    }
-                }
-                plot.ShowLegend();
-                break;
-            case ChartDefinitionType.Polar:
-                foreach (var polar in list.Cast<ChartPolar>()) {
-                    var pp = plot.Add.Polar(polar.Angle.ToArray(), polar.Value.ToArray());
-                    pp.LegendText = polar.Name;
-                    if (polar.Color.HasValue) {
-                        var px = polar.Color.Value.ToPixel<Rgba32>();
-                        pp.Color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
-                    }
-                }
-                plot.ShowLegend();
-                break;
-            case ChartDefinitionType.Pie:
-                var pieValues = list.Cast<ChartPie>().Select(p => p.Value).ToArray();
-                var pieLabels = list.Cast<ChartPie>().Select(p => p.Name).ToArray();
-                var pie = plot.Add.Pie(pieValues);
-                for (int i = 0; i < pie.Slices.Count && i < pieLabels.Length; i++) {
-                    pie.Slices[i].Label = pieLabels[i];
-                    var c = ((ChartPie)list[i]).Color;
-                    if (c.HasValue) {
-                        var px = c.Value.ToPixel<Rgba32>();
-                        pie.Slices[i].FillColor = new ScottPlot.Color(px.R, px.G, px.B, px.A);
-                    }
-                }
-                break;
-            case ChartDefinitionType.Radial:
-                var rValues = list.Cast<ChartRadial>().Select(r => r.Value).ToArray();
-                var rLabels = list.Cast<ChartRadial>().Select(r => r.Name).ToArray();
-                var radial = plot.Add.RadialGaugePlot(rValues);
-                radial.Labels = rLabels;
-                var rColors = list.Cast<ChartRadial>().Select(r => r.Color).ToArray();
-                if (rColors.Any(c => c.HasValue)) {
-                    radial.Colors = rColors.Select(c => {
-                        if (c.HasValue) {
-                            var px = c.Value.ToPixel<Rgba32>();
-                            return new ScottPlot.Color(px.R, px.G, px.B, px.A);
-                        }
-                        return new ScottPlot.Color();
-                    }).ToArray();
-                }
-                plot.ShowLegend();
-                break;
-            case ChartDefinitionType.Heatmap:
-                foreach (var map in list.Cast<ChartHeatmap>()) {
-                    plot.Add.Heatmap(map.Data);
-                }
-                break;
-            case ChartDefinitionType.Histogram:
-                foreach (var hist in list.Cast<ChartHistogram>()) {
-                    var histogram = hist.BinSize.HasValue
-                        ? ScottPlot.Statistics.Histogram.WithBinSize(hist.BinSize.Value, hist.Values)
-                        : ScottPlot.Statistics.Histogram.WithBinCount(10, hist.Values);
-                    var bp = plot.Add.Bars(histogram.Bins, histogram.Counts);
-                    bp.LegendText = hist.Name;
-                    foreach (var bar in bp.Bars) {
-                        bar.Size = histogram.FirstBinSize * 0.8;
-                    }
-                }
-                plot.ShowLegend();
-                break;
-        }
-
-        if (!string.IsNullOrEmpty(xTitle)) {
-            plot.Axes.Bottom.Label.Text = xTitle;
-        }
-
-        if (!string.IsNullOrEmpty(yTitle)) {
-            plot.Axes.Left.Label.Text = yTitle;
-        }
-
-        if (showGrid) {
-            plot.ShowGrid();
-        } else {
-            plot.HideGrid();
-        }
-
-        if (annotations is not null) {
-            foreach (var ann in annotations) {
-                var callout = plot.Add.Callout(ann.Text, new Coordinates(ann.X, ann.Y), new Coordinates(ann.X, ann.Y));
-                if (!ann.Arrow) {
-                    callout.ArrowLineWidth = 0;
                 }
             }
+    
+            filePath = Helpers.ResolvePath(filePath);
+            plot.SavePng(filePath, width, height);
         }
-
-        filePath = Helpers.ResolvePath(filePath);
-        plot.SavePng(filePath, width, height);
     }
 }

--- a/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
+++ b/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
@@ -129,6 +129,7 @@ public partial class ImagePlayground {
             };
         Charts.Generate(defs, file, 300, 200);
         Assert.True(File.Exists(file));
+        using var stream = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 
     [Fact]
@@ -145,6 +146,7 @@ public partial class ImagePlayground {
             };
         Charts.Generate(defs, file, 300, 200);
         Assert.True(File.Exists(file));
+        using var stream = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 
     [Fact]
@@ -157,6 +159,7 @@ public partial class ImagePlayground {
             };
         Charts.Generate(defs, file, 300, 200);
         Assert.True(File.Exists(file));
+        using var stream = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 
     [Fact]
@@ -169,6 +172,7 @@ public partial class ImagePlayground {
             };
         Charts.Generate(pies, pie);
         Assert.True(File.Exists(pie));
+        using var streamPie = File.Open(pie, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
 
         string radial = Path.Combine(_directoryWithTests, "chart_radial.png");
         if (File.Exists(radial)) File.Delete(radial);
@@ -179,6 +183,7 @@ public partial class ImagePlayground {
             };
         Charts.Generate(radials, radial, 300, 200);
         Assert.True(File.Exists(radial));
+        using var streamRadial = File.Open(radial, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 
     [Fact]
@@ -191,5 +196,6 @@ public partial class ImagePlayground {
             };
         Charts.Generate(defs, file, 100, 100);
         Assert.True(File.Exists(file));
+        using var stream = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 }

--- a/Sources/ImagePlayground.Tests/Charts.cs
+++ b/Sources/ImagePlayground.Tests/Charts.cs
@@ -19,6 +19,7 @@ public partial class ImagePlayground {
         global::ImagePlayground.Charts.Generate(defs, file, 300, 200);
 
         Assert.True(File.Exists(file));
+        using var stream = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 
     [Fact]
@@ -34,6 +35,7 @@ public partial class ImagePlayground {
         global::ImagePlayground.Charts.Generate(defs, file, 300, 200, null, "X", "Y");
 
         Assert.True(File.Exists(file));
+        using var stream = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 
     [Fact]
@@ -49,6 +51,7 @@ public partial class ImagePlayground {
         global::ImagePlayground.Charts.Generate(defs, file, 300, 200, null, null, null, true);
 
         Assert.True(File.Exists(file));
+        using var stream = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 
     [Fact]
@@ -98,5 +101,6 @@ public partial class ImagePlayground {
         Charts.Generate(defs, file, 300, 200, null, null, null, false, ChartTheme.Default, anns);
 
         Assert.True(File.Exists(file));
+        using var stream = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 }

--- a/Sources/ImagePlayground.Tests/ChartsAdditional.cs
+++ b/Sources/ImagePlayground.Tests/ChartsAdditional.cs
@@ -13,6 +13,7 @@ public partial class ImagePlayground {
             };
         Charts.Generate(defs, file, 200, 150);
         Assert.True(File.Exists(file));
+        using var stream = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 
     [Fact]
@@ -24,6 +25,7 @@ public partial class ImagePlayground {
             };
         Charts.Generate(defs, file, 200, 150, null, null, null, false, ChartTheme.Dark);
         Assert.True(File.Exists(file));
+        using var streamDark = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 
     [Fact]
@@ -35,5 +37,6 @@ public partial class ImagePlayground {
             };
         Charts.Generate(defs, file, 200, 150, null, null, null, false, ChartTheme.Light);
         Assert.True(File.Exists(file));
+        using var streamLight = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 }


### PR DESCRIPTION
## Summary
- wrap ScottPlot `Plot` in a using block
- verify generated chart files aren't locked

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -c Release --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6874bcb30030832ebc61d4d03b805225