### PR TITLE
Validate grid creation dimensions

### DIFF
--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -261,6 +261,12 @@ public partial class ImageHelper {
     /// <param name="open">Open the image after saving.</param>
     public static void Create(string filePath, int width, int height, Color color, bool open = false) {
         string fullPath = Helpers.ResolvePath(filePath);
+        if (width < 20) {
+            throw new ArgumentOutOfRangeException(nameof(width), "Width must be at least 20.");
+        }
+        if (height < 20) {
+            throw new ArgumentOutOfRangeException(nameof(height), "Height must be at least 20.");
+        }
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(fullPath)!);
 
         using (Image<Rgba32> outputImage = new Image<Rgba32>(width, height)) {

--- a/Sources/ImagePlayground.Tests/CreateValidation.cs
+++ b/Sources/ImagePlayground.Tests/CreateValidation.cs
@@ -1,0 +1,15 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+public partial class ImagePlayground {
+    [Theory]
+    [InlineData(10, 30)]
+    [InlineData(30, 10)]
+    [InlineData(5, 5)]
+    public void Test_CreateGridImage_InvalidDimensions_Throws(int width, int height) {
+        string dest = Path.Combine(_directoryWithTests, $"invalid_{width}_{height}.png");
+        Assert.Throws<ArgumentOutOfRangeException>(() => ImageHelper.Create(dest, width, height, SixLabors.ImageSharp.Color.White));
+    }
+}

--- a/Sources/ImagePlayground.Tests/Exif.cs
+++ b/Sources/ImagePlayground.Tests/Exif.cs
@@ -11,7 +11,7 @@ public partial class ImagePlayground {
     public void Test_ReadExif() {
         string filePath = Path.Combine(_directoryWithImages, "exif-read.jpg");
         using (var img = new PlaygroundImage()) {
-            img.Create(filePath, 10, 10);
+            img.Create(filePath, 20, 20);
             img.SetExifValue(ExifTag.Software, "ImagePlayground");
             img.Save();
         }
@@ -27,7 +27,7 @@ public partial class ImagePlayground {
         if (File.Exists(dest)) File.Delete(dest);
 
         using (var img = new PlaygroundImage()) {
-            img.Create(dest, 10, 10);
+            img.Create(dest, 20, 20);
             img.SetExifValue(ExifTag.Software, "ImagePlayground");
             img.Save();
         }

--- a/Sources/ImagePlayground.Tests/Metadata.cs
+++ b/Sources/ImagePlayground.Tests/Metadata.cs
@@ -13,7 +13,7 @@ public partial class ImagePlayground {
         if (File.Exists(metaPath)) File.Delete(metaPath);
 
         using (var img = new PlaygroundImage()) {
-            img.Create(imgPath, 10, 10);
+            img.Create(imgPath, 20, 20);
             img.Metadata.HorizontalResolution = 300;
             img.Metadata.VerticalResolution = 300;
             img.SetExifValue(ExifTag.Software, "ImagePlayground");
@@ -46,7 +46,7 @@ public partial class ImagePlayground {
         if (File.Exists(metaPath)) File.Delete(metaPath);
 
         using (var img = new PlaygroundImage()) {
-            img.Create(imgPath, 10, 10);
+            img.Create(imgPath, 20, 20);
             img.Metadata.HorizontalResolution = 72;
             img.Metadata.VerticalResolution = 72;
             img.Save();
@@ -75,7 +75,7 @@ public partial class ImagePlayground {
         if (File.Exists(metaPath)) File.Delete(metaPath);
 
         using (var img = new PlaygroundImage()) {
-            img.Create(imgPath, 10, 10);
+            img.Create(imgPath, 20, 20);
             img.Save();
         }
 
@@ -93,7 +93,7 @@ public partial class ImagePlayground {
         if (File.Exists(metaPath)) File.Delete(metaPath);
 
         using (var img = new PlaygroundImage()) {
-            img.Create(imgPath, 10, 10);
+            img.Create(imgPath, 20, 20);
             img.Metadata.HorizontalResolution = 72;
             img.Metadata.VerticalResolution = 72;
             img.Save();


### PR DESCRIPTION
## Summary
- add width & height validation to `ImageHelper.Create`
- update tests for new minimum size
- cover invalid dimensions with a new unit test

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --configuration Release --framework net8.0 --no-build`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --configuration Debug --framework net472 --no-build` *(fails: LoadException)*

------
https://chatgpt.com/codex/tasks/task_e_6875505070dc832eb5b23fa11d923415