### PR TITLE
Validate Exif value type

### DIFF
--- a/Examples/Images.SetExifData.InvalidType.ps1
+++ b/Examples/Images.SetExifData.InvalidType.ps1
@@ -1,0 +1,12 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+# This will throw because the value type does not match the tag's expected type
+$setImageExifSplat = @{
+    FilePath = "$PSScriptRoot\Samples\Snow.jpeg"
+    ExifTag  = [SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::DateTimeOriginal
+    Value    = 123 # should be a string or DateTime
+}
+
+Set-ImageExif @setImageExifSplat
+
+

--- a/Sources/ImagePlayground.Core/Image.Exif.cs
+++ b/Sources/ImagePlayground.Core/Image.Exif.cs
@@ -20,8 +20,15 @@ public partial class Image {
     /// <param name="value">Value for the tag.</param>
     public void SetExifValue(ExifTag tag, object value) {
         _image.Metadata.ExifProfile ??= new ExifProfile();
+
         var method = typeof(ExifProfile).GetMethod("SetValue")!;
-        var generic = method.MakeGenericMethod(tag.GetType().GenericTypeArguments[0]);
+        Type expectedType = tag.GetType().GenericTypeArguments[0];
+
+        if (value is not null && !expectedType.IsInstanceOfType(value)) {
+            throw new ArgumentException($"Value of type '{value.GetType()}' does not match tag type '{expectedType}'.", nameof(value));
+        }
+
+        var generic = method.MakeGenericMethod(expectedType);
         generic.Invoke(_image.Metadata.ExifProfile, new[] { tag, value });
     }
 

--- a/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
@@ -36,6 +36,13 @@ public sealed class SetImageExifCmdlet : PSCmdlet {
             return;
         }
 
+        Type expectedType = ExifTag.GetType().GenericTypeArguments[0];
+        if (Value is not null && !expectedType.IsInstanceOfType(Value)) {
+            throw new ArgumentException(
+                $"Value type '{Value.GetType()}' does not match tag type '{expectedType}'.",
+                nameof(Value));
+        }
+
         using var img = ImagePlayground.Image.Load(filePath);
         img.SetExifValue(ExifTag, Value);
 

--- a/Sources/ImagePlayground.Tests/Exif.cs
+++ b/Sources/ImagePlayground.Tests/Exif.cs
@@ -46,4 +46,12 @@ public partial class ImagePlayground {
         using var check = Image.Load(dest);
         Assert.Empty(check.GetExifValues());
     }
+
+    [Fact]
+    public void Test_SetExifValue_InvalidType_Throws() {
+        using var img = new PlaygroundImage();
+        img.Create(Path.Combine(_directoryWithTests, "invalid.jpg"), 10, 10);
+
+        Assert.Throws<ArgumentException>(() => img.SetExifValue(ExifTag.Software, 123));
+    }
 }

--- a/Tests/Set-ImageExif.Tests.ps1
+++ b/Tests/Set-ImageExif.Tests.ps1
@@ -38,5 +38,21 @@ Describe 'Set-ImageExif' {
 
     }
 
+    It 'throws when value type mismatches tag' {
+
+        $dest = Join-Path $TestDir 'exif-type-error.jpg'
+        if (Test-Path $dest) { Remove-Item $dest }
+
+        $img = [ImagePlayground.Image]::new()
+        $img.Create($dest, 10, 10)
+        $img.Save()
+        $img.Dispose()
+
+        {
+            Set-ImageExif -FilePath $dest -ExifTag ([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software) -Value 123
+        } | Should -Throw
+
+    }
+
 }
 


### PR DESCRIPTION
## Summary
- validate value type before calling `SetExifValue`
- raise `ArgumentException` when mismatch occurs
- test invalid type in core and PowerShell module
- add example showing the new error

## Testing
- `dotnet test Sources/ImagePlayground.sln -v minimal` *(fails: Could not find 'mono' host)*
- `pwsh -NoLogo -File ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6875504a75b0832eb7894fcbe9e1143d