### PR TITLE
Handle UnknownImageFormatException with list

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -40,7 +40,8 @@ public class BarCode {
         } else if (fileInfo.Extension == ".bmp") {
             imageFormatDetected = ImageFormat.Bmp;
         } else {
-            throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+            throw new UnknownImageFormatException(
+                $"Image format not supported. Supported extensions: {string.Join(", ", Helpers.SupportedExtensions)}");
         }
 
         var options = new ImageRendererOptions();
@@ -64,7 +65,8 @@ public class BarCode {
         } else if (fileInfo.Extension == ".bmp") {
             image.SaveAsBmp(fullPath);
         } else {
-            throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+            throw new UnknownImageFormatException(
+                $"Image format not supported. Supported extensions: {string.Join(", ", Helpers.SupportedExtensions)}");
         }
     }
 

--- a/Sources/ImagePlayground.Core/Helpers.Encoder.cs
+++ b/Sources/ImagePlayground.Core/Helpers.Encoder.cs
@@ -47,7 +47,8 @@ public static partial class Helpers {
                     ? Math.Max(0, Math.Min(100, quality.Value))
                     : 75
             },
-            _ => throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it."),
+            _ => throw new UnknownImageFormatException(
+                $"Image format not supported. Supported extensions: {string.Join(", ", SupportedExtensions)}"),
         };
     }
 }

--- a/Sources/ImagePlayground.Core/Helpers.cs
+++ b/Sources/ImagePlayground.Core/Helpers.cs
@@ -5,6 +5,20 @@ using System.IO;
 namespace ImagePlayground;
 public static partial class Helpers {
     /// <summary>
+    /// List of supported file extensions for image encoding.
+    /// </summary>
+    public static readonly string[] SupportedExtensions = new[] {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".bmp",
+        ".gif",
+        ".pbm",
+        ".tga",
+        ".tiff",
+        ".webp"
+    };
+    /// <summary>
     /// Converts a <see cref="SixLabors.ImageSharp.Color"/> to a 6 character hex string.
     /// </summary>
     /// <param name="c">Color value to convert.</param>

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -54,7 +54,8 @@ public class QrCode {
                         } else if (fileInfo.Extension == ".ico") {
                             SaveImageAsIcon(qrCodeImage, fullPath);
                         } else {
-                            throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
+                            throw new UnknownImageFormatException(
+                                $"Image format not supported. Supported extensions: {string.Join(", ", Helpers.SupportedExtensions)}");
                         }
                     }
                 }

--- a/Sources/ImagePlayground.Tests/GifAndEncoder.cs
+++ b/Sources/ImagePlayground.Tests/GifAndEncoder.cs
@@ -53,6 +53,7 @@ public partial class ImagePlayground {
 
     [Fact]
     public void Test_GetEncoder_UnknownExtensionThrows() {
-        Assert.Throws<SixLabors.ImageSharp.UnknownImageFormatException>(() => Helpers.GetEncoder(".xyz", null, null));
+        var ex = Assert.Throws<SixLabors.ImageSharp.UnknownImageFormatException>(() => Helpers.GetEncoder(".xyz", null, null));
+        Assert.Contains(".png", ex.Message);
     }
 }


### PR DESCRIPTION
## Summary
- add `Helpers.SupportedExtensions` constant
- include supported extension list in `UnknownImageFormatException` messages
- test that encoder error message contains the list

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release`
- `dotnet test Sources/ImagePlayground.sln -c Release` *(fails: protocol negotiation timeout)*

------
https://chatgpt.com/codex/tasks/task_e_687550944664832e9bca550da88a56f2