### PR TITLE
Add transparent QR support

### DIFF
--- a/Examples/QrCode.ps1
+++ b/Examples/QrCode.ps1
@@ -1,3 +1,3 @@
 ﻿Import-Module .\ImagePlayground.psd1 -Force
 
-New-ImageQRCode -Content 'https://evotec.xyz' -FilePath "$PSScriptRoot\Samples\QRCode.png" -Verbose
+New-ImageQRCode -Content 'https://evotec.xyz' -FilePath "$PSScriptRoot\Samples\QRCode.png" -Transparent -Verbose

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
@@ -29,6 +29,10 @@ public sealed class NewImageQrCodeCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Create QR code with transparent background.</summary>
+    [Parameter]
+    public SwitchParameter Transparent { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -37,7 +41,7 @@ public sealed class NewImageQrCodeCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.Generate(Content, output, false);
+        ImagePlayground.QrCode.Generate(Content, output, Transparent.IsPresent);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -29,10 +29,8 @@ public class QrCode {
         using (QRCodeGenerator qrGenerator = new QRCodeGenerator()) {
             using (QRCodeData qrCodeData = qrGenerator.CreateQrCode(content, eccLevel)) {
                 using (QRCoder.QRCode qrCode = new QRCoder.QRCode(qrCodeData)) {
-                    using (var qrCodeImage = qrCode.GetGraphic(20)) {
-                        if (transparent) {
-                            //qrCodeImage.MakeTransparent();
-                        }
+                    Color lightColor = transparent ? Color.Transparent : Color.White;
+                    using (var qrCodeImage = qrCode.GetGraphic(20, Color.Black, lightColor, true)) {
                         // this uses QRCoder
                         //ImageFormat imageFormatDetected;
                         //if (fileInfo.Extension == ".png") {

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -41,7 +41,7 @@ public partial class ImagePlayground {
         string filePath = Path.Combine(_directoryWithImages, "QRCodeTransparent.png");
         File.Delete(filePath);
         QrCode.Generate("https://evotec.xyz", filePath, true);
-        using var img = Image.Load<Rgba32>(filePath);
+        using SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32> img = SixLabors.ImageSharp.Image.Load<SixLabors.ImageSharp.PixelFormats.Rgba32>(filePath);
         Assert.Equal(0, img[0, 0].A);
     }
 

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using System.Net;
 using Xunit;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 
 namespace ImagePlayground.Tests;
@@ -32,6 +34,15 @@ public partial class ImagePlayground {
 
         var read = QrCode.Read(filePath);
         Assert.True(read.Message == "WIFI:T:WPA;S:Evotec;P:superHardPassword123!;;");
+    }
+
+    [Fact]
+    public void Test_QRCode_Transparent() {
+        string filePath = Path.Combine(_directoryWithImages, "QRCodeTransparent.png");
+        File.Delete(filePath);
+        QrCode.Generate("https://evotec.xyz", filePath, true);
+        using var img = Image.Load<Rgba32>(filePath);
+        Assert.Equal(0, img[0, 0].A);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- support transparent background in QR code generation
- expose `Transparent` switch in New-ImageQRCode
- example uses transparent QR
- add test for transparent QR

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0 --no-build --verbosity normal`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_687550552c00832ea5ad7382511519a4