### PR TITLE
Add pipeline support for FilePath

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -42,6 +42,8 @@ It works fine when running in PowerShell 5.1 console, or ISE (shrug!).
 - ☑️ **Base64 conversion**
 - ☑️ **EXIF metadata management**
 - ☑️ **Image comparison**
+- ☑️ **Pipeline support**  
+  Cmdlets that use `-FilePath` accept the path from the pipeline.
 
 
 ## Available Cmdlets

--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
@@ -25,7 +25,7 @@ namespace ImagePlayground.PowerShell;
 [Cmdlet(VerbsCommon.Add, "ImageText")]
 public sealed class AddImageTextCmdlet : PSCmdlet {
     /// <summary>Source image path.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     [ValidateNotNullOrEmpty]
     public string FilePath { get; set; } = string.Empty;
 

--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageTextBox.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageTextBox.cs
@@ -12,7 +12,7 @@ namespace ImagePlayground.PowerShell;
 [Cmdlet(VerbsCommon.Add, "ImageTextBox")]
 public sealed class AddImageTextBoxCmdlet : PSCmdlet {
     /// <summary>Source image path.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Destination image path.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletCompareImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletCompareImage.cs
@@ -12,7 +12,7 @@ namespace ImagePlayground.PowerShell;
 [Cmdlet(VerbsData.Compare, "Image")]
 public sealed class CompareImageCmdlet : PSCmdlet {
     /// <summary>First image path.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Second image path.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
@@ -19,7 +19,7 @@ namespace ImagePlayground.PowerShell;
 public sealed class ConvertToImageCmdlet : PSCmdlet {
     /// <summary>Path to the source image.</summary>
     /// <para>The file must exist.</para>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Destination file path including extension.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertToImageBase64.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertToImageBase64.cs
@@ -19,7 +19,7 @@ namespace ImagePlayground.PowerShell;
 [OutputType(typeof(string))]
 public sealed class ConvertToImageBase64Cmdlet : PSCmdlet {
     /// <summary>Path to the image to convert.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <inheritdoc />

--- a/Sources/ImagePlayground.PowerShell/CmdletExportImageMetadata.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletExportImageMetadata.cs
@@ -17,7 +17,7 @@ namespace ImagePlayground.PowerShell;
 [OutputType(typeof(string))]
 public sealed class ExportImageMetadataCmdlet : PSCmdlet {
     /// <summary>Source image file.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Optional path to write metadata JSON.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImage.cs
@@ -18,7 +18,7 @@ namespace ImagePlayground.PowerShell;
 public sealed class GetImageCmdlet : PSCmdlet {
     /// <summary>Path to the image file.</summary>
     /// <para>The file must exist.</para>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <inheritdoc />

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageBarCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageBarCode.cs
@@ -13,7 +13,7 @@ namespace ImagePlayground.PowerShell;
 public sealed class GetImageBarCodeCmdlet : PSCmdlet {
     /// <summary>Path to the image.</summary>
     /// <para>The file must exist.</para>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <inheritdoc />

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageExif.cs
@@ -19,7 +19,7 @@ namespace ImagePlayground.PowerShell;
 [Cmdlet(VerbsCommon.Get, "ImageExif")]
 public sealed class GetImageExifCmdlet : PSCmdlet {
     /// <summary>Path to the image file.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Return dictionary with tag names and values.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageQRCode.cs
@@ -18,7 +18,7 @@ namespace ImagePlayground.PowerShell;
 public sealed class GetImageQrCodeCmdlet : PSCmdlet {
     /// <summary>Path to the image file.</summary>
     /// <para>The file must exist.</para>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <inheritdoc />

--- a/Sources/ImagePlayground.PowerShell/CmdletImportImageMetadata.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletImportImageMetadata.cs
@@ -16,7 +16,7 @@ namespace ImagePlayground.PowerShell;
 [Cmdlet(VerbsData.Import, "ImageMetadata")]
 public sealed class ImportImageMetadataCmdlet : PSCmdlet {
     /// <summary>Image to update.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>JSON metadata file.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletMergeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletMergeImage.cs
@@ -13,7 +13,7 @@ namespace ImagePlayground.PowerShell;
 public sealed class MergeImageCmdlet : PSCmdlet {
     /// <summary>Base image path.</summary>
     /// <para>Must exist.</para>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Second image path.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
@@ -15,7 +15,7 @@ public sealed class NewImageAvatarCmdlet : PSCmdlet {
     private const string ParameterSetStream = "Stream";
 
     /// <summary>Path to the input image.</summary>
-    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetPath)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0, ParameterSetName = ParameterSetPath)]
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetStream)]
     public string FilePath { get; set; } = string.Empty;
 

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageBarCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageBarCode.cs
@@ -19,7 +19,7 @@ public BarcodeType Type { get; set; }
     public string Value { get; set; } = string.Empty;
 
     /// <summary>Output path for the barcode image.</summary>
-    [Parameter(Mandatory = true, Position = 2)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 2)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <inheritdoc />

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -46,7 +46,7 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
     public string? YTitle { get; set; }
 
     /// <summary>Output file path.</summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Open the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageCrop.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageCrop.cs
@@ -24,7 +24,7 @@ public sealed class NewImageCropCmdlet : PSCmdlet {
     private const string ParameterSetPolygon = "Polygon";
 
     /// <summary>Path to the image being cropped.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Where to save the cropped image.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageGif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageGif.cs
@@ -18,7 +18,7 @@ public sealed class NewImageGifCmdlet : PSCmdlet {
     public string[] Frames { get; set; } = Array.Empty<string>();
 
     /// <summary>Output path for the GIF animation.</summary>
-    [Parameter(Mandatory = true, Position = 1)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 1)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Delay between frames in milliseconds.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
@@ -11,7 +11,7 @@ namespace ImagePlayground.PowerShell;
 [Cmdlet(VerbsCommon.New, "ImageGrid")]
 public sealed class NewImageGridCmdlet : PSCmdlet {
     /// <summary>Output file path.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Width of the new image.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
@@ -14,7 +14,7 @@ namespace ImagePlayground.PowerShell;
 public sealed class NewImageIconCmdlet : PSCmdlet {
     /// <summary>Path to the source image.</summary>
     /// <para>The file must exist.</para>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Destination icon file.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
@@ -22,7 +22,7 @@ public sealed class NewImageQrCodeCmdlet : PSCmdlet {
     public string Content { get; set; } = string.Empty;
 
     /// <summary>Output path for the QR code image.</summary>
-    [Parameter(Mandatory = true, Position = 1)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 1)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Open the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
@@ -41,7 +41,7 @@ public sealed class NewImageQrCodeBezahlCodeCmdlet : PSCmdlet {
     public string Reason { get; set; } = string.Empty;
 
     /// <summary>Output image path.</summary>
-    [Parameter(Mandatory = true, Position = 7)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 7)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
@@ -33,7 +33,7 @@ public sealed class NewImageQrCodeBitcoinCmdlet : PSCmdlet {
     public string? Message { get; set; }
 
     /// <summary>Path to the output image.</summary>
-    [Parameter(Mandatory = true, Position = 5)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 5)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
@@ -21,7 +21,7 @@ public sealed class NewImageQrCodeGeoLocationCmdlet : PSCmdlet {
     public string Longitude { get; set; } = string.Empty;
 
     /// <summary>Output path for the QR code.</summary>
-    [Parameter(Mandatory = true, Position = 2)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 2)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Open image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
@@ -33,7 +33,7 @@ public sealed class NewImageQrCodeGirocodeCmdlet : PSCmdlet {
     public string? RemittanceInformation { get; set; }
 
     /// <summary>Path to save the QR code.</summary>
-    [Parameter(Mandatory = true, Position = 5)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 5)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
@@ -33,7 +33,7 @@ public sealed class NewImageQrCodeMoneroCmdlet : PSCmdlet {
     public string? Description { get; set; }
 
     /// <summary>Path to save the QR code image.</summary>
-    [Parameter(Mandatory = true, Position = 5)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 5)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
@@ -17,7 +17,7 @@ public sealed class NewImageQrCodeOtpCmdlet : PSCmdlet {
     public PayloadGenerator.OneTimePassword Payload { get; set; } = null!;
 
     /// <summary>Path to save the QR code image.</summary>
-    [Parameter(Mandatory = true, Position = 1)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 1)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
@@ -17,7 +17,7 @@ public sealed class NewImageQrCodePhoneNumberCmdlet : PSCmdlet {
     public string Number { get; set; } = string.Empty;
 
     /// <summary>Output path of the QR code image.</summary>
-    [Parameter(Mandatory = true, Position = 1)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 1)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
@@ -33,7 +33,7 @@ public sealed class NewImageQrCodeShadowSocksCmdlet : PSCmdlet {
     public string? Tag { get; set; }
 
     /// <summary>Path where the QR code image is stored.</summary>
-    [Parameter(Mandatory = true, Position = 5)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 5)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
@@ -17,7 +17,7 @@ public sealed class NewImageQrCodeSkypeCallCmdlet : PSCmdlet {
     public string UserName { get; set; } = string.Empty;
 
     /// <summary>Output path for the QR image.</summary>
-    [Parameter(Mandatory = true, Position = 1)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 1)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
@@ -17,7 +17,7 @@ public sealed class NewImageQrCodeSlovenianUpnQrCmdlet : PSCmdlet {
     public PayloadGenerator.SlovenianUpnQr Payload { get; set; } = null!;
 
     /// <summary>Location of the output image.</summary>
-    [Parameter(Mandatory = true, Position = 1)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 1)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
@@ -21,7 +21,7 @@ public sealed class NewImageQrCodeSmsCmdlet : PSCmdlet {
     public string? Message { get; set; }
 
     /// <summary>Output path for the QR code image.</summary>
-    [Parameter(Mandatory = true, Position = 2)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 2)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Open the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
@@ -17,7 +17,7 @@ public sealed class NewImageQrCodeSwissCmdlet : PSCmdlet {
     public PayloadGenerator.SwissQrCode Payload { get; set; } = null!;
 
     /// <summary>Path for the generated image.</summary>
-    [Parameter(Mandatory = true, Position = 1)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 1)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Opens the image once generated.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
@@ -22,7 +22,7 @@ public sealed class NewImageQrCodeWiFiCmdlet : PSCmdlet {
     public string Password { get; set; } = string.Empty;
 
     /// <summary>Output path for the QR code image.</summary>
-    [Parameter(Mandatory = true, Position = 2)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 2)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Open the image after creation.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
@@ -14,7 +14,7 @@ namespace ImagePlayground.PowerShell;
 [Cmdlet(VerbsCommon.New, "ImageQRContact")]
 public sealed class NewImageQrContactCmdlet : PSCmdlet {
     /// <summary>Output file path.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Contact output type.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
@@ -20,7 +20,7 @@ public sealed class RemoveImageExifCmdlet : PSCmdlet {
     private const string ParameterSetAll = "All";
 
     /// <summary>Path to the image file.</summary>
-    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetTag)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0, ParameterSetName = ParameterSetTag)]
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetAll)]
     public string FilePath { get; set; } = string.Empty;
 

--- a/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
@@ -18,7 +18,7 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
 
         /// <summary>Path to the source image.</summary>
         /// <para>The image must exist.</para>
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetHeightWidth)]
+        [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0, ParameterSetName = ParameterSetHeightWidth)]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetPercentage)]
         public string FilePath { get; set; } = string.Empty;
 

--- a/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
@@ -19,7 +19,7 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     public ImagePlayground.Image Image { get; set; } = null!;
 
     /// <summary>Optional path for the new file.</summary>
-    [Parameter(Position = 1)]
+    [Parameter(ValueFromPipeline = true, Position = 1)]
     public string? FilePath { get; set; }
 
     /// <summary>Quality for JPEG or WEBP images.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
@@ -13,7 +13,7 @@ namespace ImagePlayground.PowerShell;
 [Cmdlet(VerbsCommon.Set, "ImageExif")]
 public sealed class SetImageExifCmdlet : PSCmdlet {
     /// <summary>Image file to modify.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Optional output path. When not specified the file is overwritten.</summary>

--- a/Tests/Add-ImageText.Tests.ps1
+++ b/Tests/Add-ImageText.Tests.ps1
@@ -26,6 +26,16 @@ Describe 'Add-ImageText' {
 
     }
 
+    It 'accepts FilePath from pipeline' {
+
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = Join-Path $TestDir 'text_pipeline.png'
+        if (Test-Path $dest) { Remove-Item $dest }
+        $src | Add-ImageText -OutputPath $dest -Text 'Pipe' -X 1 -Y 1 -Color ([SixLabors.ImageSharp.Color]::Red)
+        Test-Path $dest | Should -BeTrue
+
+    }
+
     It 'adds text with shadow and outline' {
 
         $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'

--- a/Tests/Get-Image.Tests.ps1
+++ b/Tests/Get-Image.Tests.ps1
@@ -26,5 +26,19 @@ Describe 'Get-Image' {
 
     }
 
+    It 'accepts FilePath from pipeline' {
+
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+
+        $img = $src | Get-Image
+
+        $img.Width | Should -Be 660
+
+        $img.Height | Should -Be 660
+
+        $img.Dispose()
+
+    }
+
 }
 


### PR DESCRIPTION
## Summary
- allow FilePath parameters to take pipeline input
- document pipeline support in README
- test piping paths to Add-ImageText and Get-Image

## Testing
- `dotnet restore Sources/ImagePlayground.sln --force`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --framework net8.0 --no-build` *(fails: invalid argument)*
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1` *(fails: module build issues)*

------
https://chatgpt.com/codex/tasks/task_e_6875505d009c832e93e88cf23912c568