### PR TITLE
Add missing documentation to classes

### DIFF
--- a/Sources/ImagePlayground.Core/Helpers.Encoder.cs
+++ b/Sources/ImagePlayground.Core/Helpers.Encoder.cs
@@ -11,6 +11,10 @@ using SixLabors.ImageSharp.Formats.Tiff;
 using SixLabors.ImageSharp.Formats.Webp;
 
 namespace ImagePlayground;
+
+/// <summary>
+/// Image encoding helper methods.
+/// </summary>
 public static partial class Helpers {
     /// <summary>
     /// Returns an image encoder instance appropriate for the given file extension.

--- a/Sources/ImagePlayground.Core/Helpers.Resampler.cs
+++ b/Sources/ImagePlayground.Core/Helpers.Resampler.cs
@@ -2,6 +2,10 @@ using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
 
 namespace ImagePlayground;
+
+/// <summary>
+/// Image resampling helper methods.
+/// </summary>
 public static partial class Helpers {
     /// <summary>
     /// Maps the <see cref="Sampler"/> enumeration to a concrete resampler implementation.

--- a/Sources/ImagePlayground.Core/Helpers.cs
+++ b/Sources/ImagePlayground.Core/Helpers.cs
@@ -3,6 +3,10 @@ using System.Diagnostics;
 using System.IO;
 
 namespace ImagePlayground;
+
+/// <summary>
+/// General helper utilities for the library.
+/// </summary>
 public static partial class Helpers {
     /// <summary>
     /// List of supported file extensions for image encoding.

--- a/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
+++ b/Sources/ImagePlayground.Tests/AdditionalCoverage.cs
@@ -6,6 +6,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for AdditionalCoverage.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_AddImage_Overlay() {

--- a/Sources/ImagePlayground.Tests/AsyncMethods.cs
+++ b/Sources/ImagePlayground.Tests/AsyncMethods.cs
@@ -4,6 +4,10 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for AsyncMethods.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public async Task Test_ResizeAsync() {

--- a/Sources/ImagePlayground.Tests/AvatarAndIcon.cs
+++ b/Sources/ImagePlayground.Tests/AvatarAndIcon.cs
@@ -3,6 +3,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for AvatarAndIcon.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_SaveAsAvatar_File() {

--- a/Sources/ImagePlayground.Tests/AvatarStream.cs
+++ b/Sources/ImagePlayground.Tests/AvatarStream.cs
@@ -2,6 +2,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for AvatarStream.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_SaveAsAvatar_StreamReset() {

--- a/Sources/ImagePlayground.Tests/BarCodeDispose.cs
+++ b/Sources/ImagePlayground.Tests/BarCodeDispose.cs
@@ -2,6 +2,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for BarCodeDispose.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_BarCodeRead_DoesNotLockFile() {

--- a/Sources/ImagePlayground.Tests/BarCodes.cs
+++ b/Sources/ImagePlayground.Tests/BarCodes.cs
@@ -4,6 +4,10 @@ using Xunit;
 
 namespace ImagePlayground.Tests;
 
+/// <summary>
+/// Tests for BarCodes.
+/// </summary>
+
 public partial class ImagePlayground {
     [Theory]
     [InlineData(BarcodeType.Code128, "1234567890", "barcode_code128.png", "1234567890", Status.Found)]

--- a/Sources/ImagePlayground.Tests/Charts.cs
+++ b/Sources/ImagePlayground.Tests/Charts.cs
@@ -5,6 +5,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for Charts.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_GenerateBarChart() {

--- a/Sources/ImagePlayground.Tests/ChartsAdditional.cs
+++ b/Sources/ImagePlayground.Tests/ChartsAdditional.cs
@@ -3,6 +3,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ChartsAdditional.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_GenerateHistogram() {

--- a/Sources/ImagePlayground.Tests/CombinePlacements.cs
+++ b/Sources/ImagePlayground.Tests/CombinePlacements.cs
@@ -3,6 +3,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for CombinePlacements.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_Combine_Bottom() {

--- a/Sources/ImagePlayground.Tests/CompareOverloads.cs
+++ b/Sources/ImagePlayground.Tests/CompareOverloads.cs
@@ -2,6 +2,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for CompareOverloads.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_ImageCompare_WithImageOverload() {

--- a/Sources/ImagePlayground.Tests/ConvertToIcon.cs
+++ b/Sources/ImagePlayground.Tests/ConvertToIcon.cs
@@ -3,6 +3,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ConvertToIcon.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_ConvertToIcon_FromIcon_CopiesFile() {

--- a/Sources/ImagePlayground.Tests/CreateValidation.cs
+++ b/Sources/ImagePlayground.Tests/CreateValidation.cs
@@ -3,6 +3,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for CreateValidation.
+/// </summary>
 public partial class ImagePlayground {
     [Theory]
     [InlineData(10, 30)]

--- a/Sources/ImagePlayground.Tests/Exif.cs
+++ b/Sources/ImagePlayground.Tests/Exif.cs
@@ -6,6 +6,10 @@ using Xunit;
 using PlaygroundImage = ImagePlayground.Image;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for Exif.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_ReadExif() {

--- a/Sources/ImagePlayground.Tests/GifAndEncoder.cs
+++ b/Sources/ImagePlayground.Tests/GifAndEncoder.cs
@@ -7,6 +7,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for GifAndEncoder.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_GifGenerate_Success() {

--- a/Sources/ImagePlayground.Tests/HelpersEncoding.cs
+++ b/Sources/ImagePlayground.Tests/HelpersEncoding.cs
@@ -9,6 +9,10 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for HelpersEncoding.
+/// </summary>
 public partial class ImagePlayground {
     private class FakeHttpHandler : HttpMessageHandler {
         private readonly HttpResponseMessage _response;

--- a/Sources/ImagePlayground.Tests/HelpersOpen.cs
+++ b/Sources/ImagePlayground.Tests/HelpersOpen.cs
@@ -3,6 +3,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for HelpersOpen.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_Open_InvalidPath_Handled() {

--- a/Sources/ImagePlayground.Tests/HelpersPath.cs
+++ b/Sources/ImagePlayground.Tests/HelpersPath.cs
@@ -5,6 +5,10 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for HelpersPath.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_ResolvePath_ExpandsEnvironment() {

--- a/Sources/ImagePlayground.Tests/ImageHelperAdditional.cs
+++ b/Sources/ImagePlayground.Tests/ImageHelperAdditional.cs
@@ -4,6 +4,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ImageHelperAdditional.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_ConvertImageFormat() {

--- a/Sources/ImagePlayground.Tests/ImageHelperTextAndCompare.cs
+++ b/Sources/ImagePlayground.Tests/ImageHelperTextAndCompare.cs
@@ -5,6 +5,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ImageHelperTextAndCompare.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_CompareImages() {

--- a/Sources/ImagePlayground.Tests/ImageHelpers.cs
+++ b/Sources/ImagePlayground.Tests/ImageHelpers.cs
@@ -8,6 +8,10 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ImageHelpers.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_ResizeImage() {

--- a/Sources/ImagePlayground.Tests/ImageLoadSave.cs
+++ b/Sources/ImagePlayground.Tests/ImageLoadSave.cs
@@ -2,6 +2,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ImageLoadSave.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_LoadImage() {

--- a/Sources/ImagePlayground.Tests/ImageManipulation.cs
+++ b/Sources/ImagePlayground.Tests/ImageManipulation.cs
@@ -3,6 +3,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ImageManipulation.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_ImageManipulation() {

--- a/Sources/ImagePlayground.Tests/ImagePlayground.cs
+++ b/Sources/ImagePlayground.Tests/ImagePlayground.cs
@@ -6,6 +6,10 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ImagePlayground.
+/// </summary>
 public partial class ImagePlayground {
     internal readonly string _directoryWithImages;
     internal readonly string _directoryWithTests;

--- a/Sources/ImagePlayground.Tests/Metadata.cs
+++ b/Sources/ImagePlayground.Tests/Metadata.cs
@@ -4,6 +4,10 @@ using Xunit;
 using PlaygroundImage = ImagePlayground.Image;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for Metadata.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_Metadata_RoundTrip() {

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -6,6 +6,10 @@ using SixLabors.ImageSharp.PixelFormats;
 
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for QRCode.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_QRCodeUrl() {

--- a/Sources/ImagePlayground.Tests/QRCodeAdditional.cs
+++ b/Sources/ImagePlayground.Tests/QRCodeAdditional.cs
@@ -4,6 +4,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for QRCodeAdditional.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_QRCode_Bookmark() {

--- a/Sources/ImagePlayground.Tests/ResizeNoChange.cs
+++ b/Sources/ImagePlayground.Tests/ResizeNoChange.cs
@@ -4,6 +4,10 @@ using Xunit;
 using ImageSharpImage = SixLabors.ImageSharp.Image;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ResizeNoChange.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_Resize_NoChange_ReturnsSame() {

--- a/Sources/ImagePlayground.Tests/StreamTests.cs
+++ b/Sources/ImagePlayground.Tests/StreamTests.cs
@@ -3,6 +3,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for StreamTests.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_Image_ToStream_ReturnsResetStream() {

--- a/Sources/ImagePlayground.Tests/ThumbnailDispose.cs
+++ b/Sources/ImagePlayground.Tests/ThumbnailDispose.cs
@@ -3,6 +3,10 @@ using Xunit;
 
 namespace ImagePlayground.Tests;
 
+/// <summary>
+/// Tests for ThumbnailDispose.
+/// </summary>
+
 public partial class ImagePlayground {
     [Fact]
     public void Test_GetImageThumbnail_DoesNotLockSourceFile() {

--- a/Sources/ImagePlayground.Tests/Watermark.cs
+++ b/Sources/ImagePlayground.Tests/Watermark.cs
@@ -6,6 +6,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for Watermark.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_WatermarkImageOriginalSize() {

--- a/Sources/ImagePlayground.Tests/WatermarkCoordinates.cs
+++ b/Sources/ImagePlayground.Tests/WatermarkCoordinates.cs
@@ -4,6 +4,10 @@ using System.IO;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for WatermarkCoordinates.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_WatermarkImage_Coordinates() {

--- a/Sources/ImagePlayground.Tests/ZXingMemory.cs
+++ b/Sources/ImagePlayground.Tests/ZXingMemory.cs
@@ -4,6 +4,10 @@ using BarcodeReader.ImageSharp;
 using Xunit;
 
 namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for ZXingMemory.
+/// </summary>
 public partial class ImagePlayground {
     [Fact]
     public void Test_QrCodeRead_MemoryUsageStable() {


### PR DESCRIPTION
## Summary
- document helper classes
- add descriptions to all test classes

## Testing
- `dotnet build Sources/ImagePlayground.sln --configuration Debug --no-restore`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --configuration Debug --no-build --framework net8.0`
- `pwsh -NoLogo -NoProfile -Command ./ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_687567af5238832eb6bab1764b676e5b