### PR TITLE
feat(core): auto-calculate textbox height

### DIFF
--- a/Sources/ImagePlayground.Core/ImageHelper.AddText.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.AddText.cs
@@ -51,8 +51,17 @@ public partial class ImageHelper {
     /// <param name="shadowOffsetY">Shadow offset Y.</param>
     /// <param name="outlineColor">Optional outline color.</param>
     /// <param name="outlineWidth">Outline width.</param>
-    public static void AddTextBox(string filePath, string outFilePath, float x, float y, string text, float boxWidth, Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f) =>
-        AddTextBox(filePath, outFilePath, x, y, text, boxWidth, 0f, color, fontSize, fontFamilyName, horizontalAlignment, verticalAlignment, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
+    /// <param name="boxHeight">Optional height of the box. If not provided, it will be calculated based on the text.</param>
+    public static void AddTextBox(string filePath, string outFilePath, float x, float y, string text, float boxWidth, Color color, float fontSize = 16f, string fontFamilyName = "Arial", SixLabors.Fonts.HorizontalAlignment horizontalAlignment = SixLabors.Fonts.HorizontalAlignment.Left, SixLabors.Fonts.VerticalAlignment verticalAlignment = SixLabors.Fonts.VerticalAlignment.Top, Color? shadowColor = null, float shadowOffsetX = 0f, float shadowOffsetY = 0f, Color? outlineColor = null, float outlineWidth = 0f, float? boxHeight = null) {
+        float height = boxHeight ?? 0f;
+        if (height <= 0f) {
+            string fullPath = Helpers.ResolvePath(filePath);
+            using var img = Image.Load(fullPath);
+            height = img.GetTextSize(text, fontSize, fontFamilyName).Height;
+        }
+
+        AddTextBox(filePath, outFilePath, x, y, text, boxWidth, height, color, fontSize, fontFamilyName, horizontalAlignment, verticalAlignment, shadowColor, shadowOffsetX, shadowOffsetY, outlineColor, outlineWidth);
+    }
 
     /// <summary>
     /// Adds text within a bounding box to an image file and saves the result.

--- a/Sources/ImagePlayground.Tests/ImageHelperTextAndCompare.cs
+++ b/Sources/ImagePlayground.Tests/ImageHelperTextAndCompare.cs
@@ -71,6 +71,26 @@ public partial class ImagePlayground {
     }
 
     [Fact]
+    public void Test_AddTextBoxAutoHeightEqualsExplicitHeight() {
+        string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+        string autoDest = Path.Combine(_directoryWithTests, "textbox_autoheight.png");
+        string explicitDest = Path.Combine(_directoryWithTests, "textbox_explicitheight.png");
+        if (File.Exists(autoDest)) File.Delete(autoDest);
+        if (File.Exists(explicitDest)) File.Delete(explicitDest);
+
+        ImageHelper.AddTextBox(src, autoDest, 1, 1, "Wrapped Text", 100, SixLabors.ImageSharp.Color.Red);
+
+        using var img = global::ImagePlayground.Image.Load(src);
+        float height = img.GetTextSize("Wrapped Text", 16f, "Arial").Height;
+
+        ImageHelper.AddTextBox(src, explicitDest, 1, 1, "Wrapped Text", 100, height, SixLabors.ImageSharp.Color.Red);
+
+        byte[] autoBytes = File.ReadAllBytes(autoDest);
+        byte[] explicitBytes = File.ReadAllBytes(explicitDest);
+        Assert.Equal(explicitBytes, autoBytes);
+    }
+
+    [Fact]
     public void Test_GridImageContainsMultipleColors() {
         string dest = Path.Combine(_directoryWithTests, "gridcolors.png");
         if (File.Exists(dest)) File.Delete(dest);


### PR DESCRIPTION
## Summary
- compute text box height from font metrics when not supplied
- test automatic height against explicit height

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_688f0dbcb120832ea302c4c2e753bd0e