### PR TITLE
fix(qrcode): remove WiFi password URL encoding

### DIFF
--- a/Examples/QrCodeWiFi.ps1
+++ b/Examples/QrCodeWiFi.ps1
@@ -1,3 +1,3 @@
-﻿Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
 
-New-ImageQRCodeWiFi -SSID 'Evotec' -Password 'Evotec' -FilePath "$PSScriptRoot\Samples\QRCodeWiFi.png"
+New-ImageQRCodeWiFi -SSID 'Evotec' -Password 'Evotec;123!' -FilePath "$PSScriptRoot\Samples\QRCodeWiFi.png"

--- a/Sources/ImagePlayground.QRCode/ImagePlayground.QRCode.csproj
+++ b/Sources/ImagePlayground.QRCode/ImagePlayground.QRCode.csproj
@@ -27,7 +27,6 @@
     <Using Include="System.Linq" />
     <Using Include="System.Text" />
     <Using Include="System.IO" />
-    <Using Include="System.Net" />
     <Using Include="System.Net.Http" />
   </ItemGroup>
 

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using BarcodeReader.ImageSharp;
 using QRCoder;
 using SixLabors.ImageSharp;
@@ -68,8 +67,7 @@ public class QrCode {
     /// <param name="filePath">Destination image path.</param>
     /// <param name="transparent">Whether the QR code should have transparent background.</param>
     public static void GenerateWiFi(string ssid, string password, string filePath, bool transparent = false) {
-        string encodedPassword = WebUtility.UrlEncode(password);
-        PayloadGenerator.WiFi generator = new PayloadGenerator.WiFi(ssid, encodedPassword, PayloadGenerator.WiFi.Authentication.WPA, false, false);
+        PayloadGenerator.WiFi generator = new PayloadGenerator.WiFi(ssid, password, PayloadGenerator.WiFi.Authentication.WPA, false, false);
         Generate(generator.ToString(), filePath, transparent);
     }
 

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Net;
 using Xunit;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -80,7 +79,8 @@ public partial class ImagePlayground {
         Assert.True(File.Exists(filePath) == true);
 
         var read = QrCode.Read(filePath);
-        string expected = $"WIFI:T:WPA;S:TestSSID;P:{WebUtility.UrlEncode(password)};;";
+        string escapedPassword = password.Replace(";", "\\;");
+        string expected = $"WIFI:T:WPA;S:TestSSID;P:{escapedPassword};;";
         Assert.Equal(expected, read.Message);
     }
 


### PR DESCRIPTION
## Summary
- stop URL-encoding WiFi passwords when generating QR codes
- escape semicolons in WiFi password tests
- show WiFi password example with special characters

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `dotnet test Sources/ImagePlayground.sln` *(fails: Test_BarCodeRead_MemoryUsageStable, Test_QrCodeRead_MemoryUsageStable)*
- `pwsh -NoLogo -NoProfile -File ImagePlayground.Tests.ps1` *(fails: 1)*

------
https://chatgpt.com/codex/tasks/task_e_688f0da69be4832ea37b51af01a057fd