### PR TITLE
fix(barcode): 🐛 ensure parent directory exists before saving

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -33,13 +33,18 @@ public class BarCode {
         ImageFormat imageFormatDetected;
         FileInfo fileInfo = new FileInfo(fullPath);
 
-        if (fileInfo.Extension == ".png") {
+        switch (fileInfo.Extension) {
+        case var ext when string.Equals(ext, ".png", StringComparison.OrdinalIgnoreCase):
             imageFormatDetected = ImageFormat.Png;
-        } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+            break;
+        case var ext when string.Equals(ext, ".jpg", StringComparison.OrdinalIgnoreCase) ||
+                             string.Equals(ext, ".jpeg", StringComparison.OrdinalIgnoreCase):
             imageFormatDetected = ImageFormat.Jpeg;
-        } else if (fileInfo.Extension == ".bmp") {
+            break;
+        case var ext when string.Equals(ext, ".bmp", StringComparison.OrdinalIgnoreCase):
             imageFormatDetected = ImageFormat.Bmp;
-        } else {
+            break;
+        default:
             throw new UnknownImageFormatException(
                 $"Image format not supported. Supported extensions: {string.Join(", ", Helpers.SupportedExtensions)}");
         }
@@ -49,6 +54,7 @@ public class BarCode {
         var renderer = new ImageRenderer(options);
         //var renderer = new ImageRenderer(imageFormat: imageFormatDetected);
 
+        Helpers.CreateParentDirectory(fullPath);
         using (var stream = new FileStream(fullPath, FileMode.Create)) {
             renderer.Render(barcode, stream);
         }
@@ -58,13 +64,21 @@ public class BarCode {
         string fullPath = Helpers.ResolvePath(filePath);
         FileInfo fileInfo = new FileInfo(fullPath);
 
-        if (fileInfo.Extension == ".png") {
+        switch (fileInfo.Extension) {
+        case var ext when string.Equals(ext, ".png", StringComparison.OrdinalIgnoreCase):
+            Helpers.CreateParentDirectory(fullPath);
             image.SaveAsPng(fullPath);
-        } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
+            break;
+        case var ext when string.Equals(ext, ".jpg", StringComparison.OrdinalIgnoreCase) ||
+                             string.Equals(ext, ".jpeg", StringComparison.OrdinalIgnoreCase):
+            Helpers.CreateParentDirectory(fullPath);
             image.SaveAsJpeg(fullPath);
-        } else if (fileInfo.Extension == ".bmp") {
+            break;
+        case var ext when string.Equals(ext, ".bmp", StringComparison.OrdinalIgnoreCase):
+            Helpers.CreateParentDirectory(fullPath);
             image.SaveAsBmp(fullPath);
-        } else {
+            break;
+        default:
             throw new UnknownImageFormatException(
                 $"Image format not supported. Supported extensions: {string.Join(", ", Helpers.SupportedExtensions)}");
         }

--- a/Sources/ImagePlayground.Core/Helpers.CreateParentDirectory.cs
+++ b/Sources/ImagePlayground.Core/Helpers.CreateParentDirectory.cs
@@ -1,0 +1,17 @@
+namespace ImagePlayground;
+
+/// <summary>
+/// Helper methods for directory creation.
+/// </summary>
+public static partial class Helpers {
+    /// <summary>
+    /// Creates the parent directory for the specified file path if it does not exist.
+    /// </summary>
+    /// <param name="fullPath">Full file path.</param>
+    public static void CreateParentDirectory(string fullPath) {
+        string? directory = System.IO.Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(directory)) {
+            System.IO.Directory.CreateDirectory(directory);
+        }
+    }
+}

--- a/Sources/ImagePlayground.Tests/BarCodeCreateDirectory.cs
+++ b/Sources/ImagePlayground.Tests/BarCodeCreateDirectory.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for directory creation when saving barcodes.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_BarCodeSave_CreatesParentDirectory() {
+        string dir = Path.Combine(_directoryWithTests, "BarcodeOutput");
+        string file = Path.Combine(dir, "code128.png");
+        if (Directory.Exists(dir)) {
+            Directory.Delete(dir, true);
+        }
+
+        BarCode.GenerateCode128("123456", file);
+
+        Assert.True(Directory.Exists(dir));
+        Assert.True(File.Exists(file));
+    }
+}


### PR DESCRIPTION
## Summary
- switch file extension handling to use case-insensitive switch
- ensure parent directories are created before saving barcode images
- add regression test for barcode directory creation

## Testing
- `dotnet test Sources/ImagePlayground.sln` *(net472 tests aborted: Could not find 'mono' host)*
- `pwsh -NoLogo -Command ./ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_688f0d928c20832e8ef653e0fb3784d9