### PR TITLE
fix(core): ensure combine creates output directory

### DIFF
--- a/Sources/ImagePlayground.Core/Helpers.Path.cs
+++ b/Sources/ImagePlayground.Core/Helpers.Path.cs
@@ -50,6 +50,17 @@ public static partial class Helpers {
     }
 
     /// <summary>
+    /// Ensures the parent directory for the specified file path exists.
+    /// </summary>
+    /// <param name="path">File path whose parent directory should be created.</param>
+    public static void CreateParentDirectory(string path) {
+        string? directory = System.IO.Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory)) {
+            System.IO.Directory.CreateDirectory(directory);
+        }
+    }
+
+    /// <summary>
     /// Reads the contents of a file after verifying that it exists.
     /// </summary>
     /// <param name="path">Path to the file.</param>

--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -178,6 +178,7 @@ public partial class ImageHelper {
         string fullPath = Helpers.ResolvePath(filePath);
         string fullPath2 = Helpers.ResolvePath(filePath2);
         string outFullPath = Helpers.ResolvePath(outFilePath);
+        Helpers.CreateParentDirectory(outFullPath);
 
         using (var inStream = System.IO.File.OpenRead(fullPath))
         using (var inStream2 = System.IO.File.OpenRead(fullPath2))

--- a/Sources/ImagePlayground.Tests/CombineCreatesDirectory.cs
+++ b/Sources/ImagePlayground.Tests/CombineCreatesDirectory.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for output directory creation in Combine.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_Combine_CreatesOutputDirectory() {
+        string file1 = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+        string file2 = Path.Combine(_directoryWithImages, "QRCode1.png");
+        string destDir = Path.Combine(_directoryWithTests, "combine_created");
+        string dest = Path.Combine(destDir, "combine.png");
+        if (Directory.Exists(destDir)) {
+            Directory.Delete(destDir, true);
+        }
+
+        ImageHelper.Combine(file1, file2, dest);
+
+        Assert.True(File.Exists(dest));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `Combine` resolves output path and creates parent directory
- add helper to create parent directory
- test combine output directory creation

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0`
- `pwsh ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_688f0d88eda8832e99cf0e1a885dd0a7