### PR TITLE
feat(core): add metadata removal helper

### DIFF
--- a/Examples/Images.RemoveMetadata.ps1
+++ b/Examples/Images.RemoveMetadata.ps1
@@ -1,0 +1,11 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+Get-ImageExif -FilePath "$PSScriptRoot\Samples\Snow.jpeg" | Format-Table
+
+$removeSplat = @{
+    FilePath    = "$PSScriptRoot\Samples\Snow.jpeg"
+    OutFilePath = "$PSScriptRoot\Output\Snow_NoMeta.jpeg"
+}
+[ImagePlayground.ImageHelper]::RemoveMetadata($removeSplat.FilePath, $removeSplat.OutFilePath)
+
+Get-ImageExif -FilePath "$PSScriptRoot\Output\Snow_NoMeta.jpeg" | Format-Table

--- a/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Metadata.cs
@@ -166,4 +166,23 @@ public partial class ImageHelper {
         img.Metadata.IptcProfile = data.IptcProfile != null ? new IptcProfile(data.IptcProfile) : null;
         img.Save(outFullPath);
     }
+
+    /// <summary>
+    /// Removes all metadata profiles from an image and saves it to the specified path.
+    /// </summary>
+    /// <param name="filePath">Source image path.</param>
+    /// <param name="outFilePath">Destination image path.</param>
+    public static void RemoveMetadata(string filePath, string outFilePath) {
+        string fullPath = Helpers.ResolvePath(filePath);
+        string outFullPath = Helpers.ResolvePath(outFilePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
+
+        using var img = Image.Load(fullPath);
+        var meta = img.Metadata;
+        meta.ExifProfile = null;
+        meta.XmpProfile = null;
+        meta.IccProfile = null;
+        meta.IptcProfile = null;
+        img.Save(outFullPath);
+    }
 }

--- a/Sources/ImagePlayground.Tests/MetadataRemove.cs
+++ b/Sources/ImagePlayground.Tests/MetadataRemove.cs
@@ -1,0 +1,36 @@
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Iptc;
+using SixLabors.ImageSharp.Metadata.Profiles.Xmp;
+using System.IO;
+using Xunit;
+using PlaygroundImage = ImagePlayground.Image;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for removing metadata profiles.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_Remove_Metadata() {
+        string imgPath = Path.Combine(_directoryWithTests, "metadata_remove.jpg");
+        string outPath = Path.Combine(_directoryWithTests, "metadata_removed.jpg");
+        if (File.Exists(imgPath)) File.Delete(imgPath);
+        if (File.Exists(outPath)) File.Delete(outPath);
+
+        using (var img = new PlaygroundImage()) {
+            img.Create(imgPath, 20, 20);
+            img.SetExifValue(ExifTag.Software, "ImagePlayground");
+            img.Metadata.XmpProfile = new XmpProfile();
+            img.Metadata.IptcProfile = new IptcProfile();
+            img.Save();
+        }
+
+        ImageHelper.RemoveMetadata(imgPath, outPath);
+
+        using var check = PlaygroundImage.Load(outPath);
+        Assert.Null(check.Metadata.ExifProfile);
+        Assert.Null(check.Metadata.XmpProfile);
+        Assert.Null(check.Metadata.IptcProfile);
+    }
+}


### PR DESCRIPTION
## Summary
- clear metadata profiles before saving images
- cover metadata removal with unit test and example script

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0`
- `pwsh ./ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_688f0dd5fe5c832e91bf837fd7fd201b