### PR TITLE
feat: ✨ add ImagePlayground aggregator project

### DIFF
--- a/Sources/ImagePlayground.Tests/HelpersPath.cs
+++ b/Sources/ImagePlayground.Tests/HelpersPath.cs
@@ -84,7 +84,7 @@ public partial class ImagePlayground {
     }
 
     [Fact]
-    public void Test_CleanupTempFiles_Idempotent() {
+    public async Task Test_CleanupTempFiles_Idempotent() {
         var tcp = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
         tcp.Start();
         int port = ((System.Net.IPEndPoint)tcp.LocalEndpoint).Port;
@@ -101,9 +101,8 @@ public partial class ImagePlayground {
             context.Response.OutputStream.Write(data, 0, data.Length);
             context.Response.OutputStream.Close();
         });
-
-        string path = Helpers.ResolvePath(prefix + "file.txt");
-        serverTask.Wait();
+        string path = await Helpers.ResolvePathAsync(prefix + "file.txt");
+        await serverTask;
         string content = File.ReadAllText(path);
         Assert.Equal("hello", content);
         Helpers.CleanupTempFiles();

--- a/Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj
+++ b/Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj
@@ -21,10 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ImagePlayground.Core\ImagePlayground.Core.csproj" />
-        <ProjectReference Include="..\ImagePlayground.Chart\ImagePlayground.Chart.csproj" />
-        <ProjectReference Include="..\ImagePlayground.BarCode\ImagePlayground.BarCode.csproj" />
-        <ProjectReference Include="..\ImagePlayground.QRCode\ImagePlayground.QRCode.csproj" />
+        <ProjectReference Include="..\ImagePlayground\ImagePlayground.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/ImagePlayground.sln
+++ b/Sources/ImagePlayground.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImagePlayground.BarCode", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImagePlayground.QRCode", "ImagePlayground.QRCode\ImagePlayground.QRCode.csproj", "{DF4E80FA-0538-4A8A-BD5D-EF82CD637BAA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImagePlayground", "ImagePlayground\ImagePlayground.csproj", "{2CFA340A-689D-424C-BF01-860BF492571C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{DF4E80FA-0538-4A8A-BD5D-EF82CD637BAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF4E80FA-0538-4A8A-BD5D-EF82CD637BAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF4E80FA-0538-4A8A-BD5D-EF82CD637BAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2CFA340A-689D-424C-BF01-860BF492571C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CFA340A-689D-424C-BF01-860BF492571C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2CFA340A-689D-424C-BF01-860BF492571C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2CFA340A-689D-424C-BF01-860BF492571C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sources/ImagePlayground/ImagePlayground.cs
+++ b/Sources/ImagePlayground/ImagePlayground.cs
@@ -1,0 +1,6 @@
+namespace ImagePlayground
+{
+    internal static class AssemblyInfo
+    {
+    }
+}

--- a/Sources/ImagePlayground/ImagePlayground.csproj
+++ b/Sources/ImagePlayground/ImagePlayground.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
+    <AssemblyName>ImagePlayground</AssemblyName>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\ImagePlayground.Core\\ImagePlayground.Core.csproj" />
+    <ProjectReference Include="..\\ImagePlayground.Chart\\ImagePlayground.Chart.csproj" />
+    <ProjectReference Include="..\\ImagePlayground.BarCode\\ImagePlayground.BarCode.csproj" />
+    <ProjectReference Include="..\\ImagePlayground.QRCode\\ImagePlayground.QRCode.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add meta ImagePlayground project that aggregates core components
- route tests through ImagePlayground project
- drop redundant System.Net.Http reference and stabilize cleanup test

## Testing
- `dotnet test Sources/ImagePlayground.sln -c Release` *(net472: 2 failed, net8.0: 136 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688f08ce92d8832e958c415cb2d6a98c