### PR TITLE
refactor(qrcode): ♻️ handle extensions case-insensitively

### DIFF
--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -31,29 +31,20 @@ public class QrCode {
                 using (QRCoder.QRCode qrCode = new QRCoder.QRCode(qrCodeData)) {
                     Color lightColor = transparent ? Color.Transparent : Color.White;
                     using (var qrCodeImage = qrCode.GetGraphic(20, Color.Black, lightColor, true)) {
-                        // this uses QRCoder
-                        //ImageFormat imageFormatDetected;
-                        //if (fileInfo.Extension == ".png") {
-                        //    imageFormatDetected = ImageFormat.Png;
-                        //} else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
-                        //    imageFormatDetected = ImageFormat.Jpeg;
-                        //} else if (fileInfo.Extension == ".ico") {
-                        //    imageFormatDetected = ImageFormat.Icon;
-                        //} else {
-                        //    throw new UnknownImageFormatException("Image format not supported. Feel free to open an issue/fix it.");
-                        //}
-                        //qrCodeImage.Save(filePath, imageFormatDetected);
-
-                        //this uses QRCoder.ImageSharp
-                        if (fileInfo.Extension == ".png") {
-                            qrCodeImage.SaveAsPng(fullPath);
-                        } else if (fileInfo.Extension == ".jpg" || fileInfo.Extension == ".jpeg") {
-                            qrCodeImage.SaveAsJpeg(fullPath);
-                        } else if (fileInfo.Extension == ".ico") {
-                            SaveImageAsIcon(qrCodeImage, fullPath);
-                        } else {
-                            throw new UnknownImageFormatException(
-                                $"Image format not supported. Supported extensions: {string.Join(", ", Helpers.SupportedExtensions)}");
+                        switch (fileInfo.Extension.ToLowerInvariant()) {
+                            case ".png":
+                                qrCodeImage.SaveAsPng(fullPath);
+                                break;
+                            case ".jpg":
+                            case ".jpeg":
+                                qrCodeImage.SaveAsJpeg(fullPath);
+                                break;
+                            case ".ico":
+                                SaveImageAsIcon(qrCodeImage, fullPath);
+                                break;
+                            default:
+                                throw new UnknownImageFormatException(
+                                    $"Image format not supported. Supported extensions: {string.Join(", ", Helpers.SupportedExtensions)}");
                         }
                     }
                 }

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -94,4 +94,15 @@ public partial class ImagePlayground {
 
         Assert.True(File.Exists(filePath) == true);
     }
+
+    [Theory]
+    [InlineData("PNG")]
+    [InlineData("JPG")]
+    [InlineData("ICO")]
+    public void Test_QRCodeUppercaseExtensions(string extension) {
+        string filePath = System.IO.Path.Combine(_directoryWithImages, $"QRCodeUpper.{extension}");
+        File.Delete(filePath);
+        QrCode.Generate("https://evotec.xyz", filePath);
+        Assert.True(File.Exists(filePath));
+    }
 }


### PR DESCRIPTION
## Summary
- refactor QR code generation to handle image extensions via case-insensitive switch
- add tests to ensure uppercase file extensions are processed
- remove obsolete commented code from QR generation

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `dotnet test Sources/ImagePlayground.sln` *(failed: Test_BarCodeRead_MemoryUsageStable; run canceled)*

------
https://chatgpt.com/codex/tasks/task_e_688f0d9dbcdc832e827faec3d4ead176