### PR TITLE
fix: compute missing dimension when preserving aspect ratio

### DIFF
--- a/Sources/ImagePlayground.Core/Image.cs
+++ b/Sources/ImagePlayground.Core/Image.cs
@@ -384,7 +384,13 @@ public partial class Image : IDisposable {
         var options = new ResizeOptions();
         if (keepAspectRatio && (width == null || height == null)) {
             options.Mode = ResizeMode.Max;
-            options.Size = new Size(width ?? 0, height ?? 0);
+            if (width == null) {
+                int calculatedWidth = (int)Math.Round(height!.Value * _image.Width / (double)_image.Height);
+                options.Size = new Size(calculatedWidth, height.Value);
+            } else {
+                int calculatedHeight = (int)Math.Round(width.Value * _image.Height / (double)_image.Width);
+                options.Size = new Size(width.Value, calculatedHeight);
+            }
         } else if (keepAspectRatio) {
             options.Mode = ResizeMode.Max;
             options.Size = new Size(width ?? _image.Width, height ?? _image.Height);

--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -106,7 +106,13 @@ public partial class ImageHelper {
         var options = new ResizeOptions();
         if (keepAspectRatio && (width == null || height == null)) {
             options.Mode = ResizeMode.Max;
-            options.Size = new Size(width ?? 0, height ?? 0);
+            if (width == null) {
+                int calculatedWidth = (int)Math.Round(height!.Value * image.Width / (double)image.Height);
+                options.Size = new Size(calculatedWidth, height.Value);
+            } else {
+                int calculatedHeight = (int)Math.Round(width.Value * image.Height / (double)image.Width);
+                options.Size = new Size(width.Value, calculatedHeight);
+            }
         } else {
             options.Mode = ResizeMode.Stretch;
             options.Size = new Size(width ?? image.Width, height ?? image.Height);

--- a/Sources/ImagePlayground.Tests/ResizeAspectRatio.cs
+++ b/Sources/ImagePlayground.Tests/ResizeAspectRatio.cs
@@ -1,0 +1,37 @@
+using SixLabors.ImageSharp;
+using System.IO;
+using Xunit;
+using ImageSharpImage = SixLabors.ImageSharp.Image;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for aspect ratio preservation when one dimension is missing.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_Resize_KeepAspectRatio_WidthOnly() {
+        string src = Path.Combine(_directoryWithImages, "PrzemyslawKlysAndKulkozaurr.jpg");
+        using var img = ImageSharpImage.Load(src);
+        int originalWidth = img.Width;
+        int originalHeight = img.Height;
+        int newWidth = 200;
+        int expectedHeight = (int)System.Math.Round(newWidth * originalHeight / (double)originalWidth);
+        ImageHelper.Resize(img, newWidth, null);
+        Assert.Equal(newWidth, img.Width);
+        Assert.Equal(expectedHeight, img.Height);
+    }
+
+    [Fact]
+    public void Test_Resize_KeepAspectRatio_HeightOnly() {
+        string src = Path.Combine(_directoryWithImages, "PrzemyslawKlysAndKulkozaurr.jpg");
+        using var img = ImageSharpImage.Load(src);
+        int originalWidth = img.Width;
+        int originalHeight = img.Height;
+        int newHeight = 150;
+        int expectedWidth = (int)System.Math.Round(newHeight * originalWidth / (double)originalHeight);
+        ImageHelper.Resize(img, null, newHeight);
+        Assert.Equal(expectedWidth, img.Width);
+        Assert.Equal(newHeight, img.Height);
+    }
+}


### PR DESCRIPTION
## Summary
- calculate missing width or height using original aspect ratio instead of zero when resizing with keepAspectRatio
- cover aspect-ratio resizing with new unit tests

## Testing
- `dotnet test Sources/ImagePlayground.sln --framework net8.0`
- `dotnet test Sources/ImagePlayground.sln` *(fails: Test_CleanupTempFiles_Idempotent)*

------
https://chatgpt.com/codex/tasks/task_e_688f0dae26f4832ea3b86699cf9aa73d