### PR TITLE
fix(barcode): 🐛 dispose decoded image to stabilize memory

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -180,6 +180,7 @@ public class BarCode {
         using Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
         BarcodeReader.ImageSharp.BarcodeReader<Rgba32> reader = new(types: new[] { ZXing.BarcodeFormat.All_1D, ZXing.BarcodeFormat.DATA_MATRIX, ZXing.BarcodeFormat.PDF_417 });
         BarcodeResult<Rgba32> response = reader.Decode(barcodeImage);
+        response.Image?.Dispose();
         BarcodeResult<Rgba32> result = new() {
             Value = response.Value,
             Status = response.Status,


### PR DESCRIPTION
## Summary
- ensure `BarCode.Read` disposes decoded image to prevent memory growth and stabilize repeated reads

## Testing
- `dotnet test Sources/ImagePlayground.sln --framework net8.0 --no-build`
- ⚠️ `dotnet test Sources/ImagePlayground.sln` *(net472 tests aborted: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_688f12f89498832eb548696c5c6eb87a