### PR TITLE
fix: update watermark placement examples

### DIFF
--- a/Examples/Images.Manipulation.ps1
+++ b/Examples/Images.Manipulation.ps1
@@ -17,9 +17,9 @@ Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\PrzemyslawKlysAndK
 
 # Add watermark
 $Image = Get-Image -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg
-$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png",[ImagePlayground.Image+WatermarkPlacement]::Middle, 0.5, 0.5)
+$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png",[ImagePlayground.WatermarkPlacement]::Middle, 0.5, 0.5)
 # Add watermark with rotation 90 degrees
-$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png",[ImagePlayground.Image+WatermarkPlacement]::TopLeft, 1, 18, 90)
+$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png",[ImagePlayground.WatermarkPlacement]::TopLeft, 1, 18, 90)
 # Resize 200% in the same image
 $Image.Resize(200)
 # Rotate 30 degrees in the same image

--- a/Examples/Images.QRCodeWithImage.ps1
+++ b/Examples/Images.QRCodeWithImage.ps1
@@ -4,7 +4,7 @@ New-ImageQRCode -Content 'https://evotec.xyz' -FilePath "$PSScriptRoot\Samples\Q
 
 # Add watermark
 $Image = Get-Image -FilePath "$PSScriptRoot\Samples\QRCode.png"
-# void WatermarkImage(string filePath, ImagePlayground.Image+WatermarkPlacement placement, float opacity = 1, float padding = 18, int rotate = 0, SixLabors.ImageSharp.Processing.FlipMode flipMode = SixLabors.ImageSharp.Processing.FlipMode.None, int watermarkPercentage = 20)
-$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.Image+WatermarkPlacement]::TopLeft, 1, 0.5, 0, [SixLabors.ImageSharp.Processing.FlipMode]::None, 50)
+# void WatermarkImage(string filePath, ImagePlayground.WatermarkPlacement placement, float opacity = 1, float padding = 18, int rotate = 0, SixLabors.ImageSharp.Processing.FlipMode flipMode = SixLabors.ImageSharp.Processing.FlipMode.None, int watermarkPercentage = 20)
+$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.WatermarkPlacement]::TopLeft, 1, 0.5, 0, [SixLabors.ImageSharp.Processing.FlipMode]::None, 50)
 # Add watermark with rotation 90 degrees
 Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\QRCodeWithImage.jpg

--- a/Examples/Images.Watermark.ps1
+++ b/Examples/Images.Watermark.ps1
@@ -2,14 +2,14 @@
 
 # Add watermark
 $Image = Get-Image -FilePath $PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg
-# void WatermarkImage(string filePath, ImagePlayground.Image+WatermarkPlacement placement, float opacity = 1, float padding = 18, int rotate = 0, SixLabors.ImageSharp.Processing.FlipMode flipMode = SixLabors.ImageSharp.Processing.FlipMode.None, int watermarkPercentage = 20)
-$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.Image+WatermarkPlacement]::Middle, 0.5, 0.5)
+# void WatermarkImage(string filePath, ImagePlayground.WatermarkPlacement placement, float opacity = 1, float padding = 18, int rotate = 0, SixLabors.ImageSharp.Processing.FlipMode flipMode = SixLabors.ImageSharp.Processing.FlipMode.None, int watermarkPercentage = 20)
+$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.WatermarkPlacement]::Middle, 0.5, 0.5)
 # Add watermark with rotation 90 degrees
-$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.Image+WatermarkPlacement]::TopLeft, 1, 18, 90)
+$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.WatermarkPlacement]::TopLeft, 1, 18, 90)
 # Add watermark with text
 # There are 2 methods to add watermark with text
 #void Watermark(string text, float x, float y, SixLabors.ImageSharp.Color color, float fontSize = 16, string fontFamilyName = "Arial", float padding = 18)
-#void Watermark(string text, ImagePlayground.Image+WatermarkPlacement placement, SixLabors.ImageSharp.Color color, float fontSize = 16, string fontFamilyName = "Arial", float padding = 18)
-$Image.Watermark("Evotec", [ImagePlayground.Image+WatermarkPlacement]::TopRight, [SixLabors.ImageSharp.Color]::Blue, 50, "Calibri")
+#void Watermark(string text, ImagePlayground.WatermarkPlacement placement, SixLabors.ImageSharp.Color color, float fontSize = 16, string fontFamilyName = "Arial", float padding = 18)
+$Image.Watermark("Evotec", [ImagePlayground.WatermarkPlacement]::TopRight, [SixLabors.ImageSharp.Color]::Blue, 50, "Calibri")
 
 Save-Image -Image $Image -Open -FilePath $PSScriptRoot\Output\PrzemyslawKlysAndKulkozaurrWatermarkWithText.jpg

--- a/Examples/Images.Watermark1.ps1
+++ b/Examples/Images.Watermark1.ps1
@@ -2,10 +2,10 @@
 
 # Add watermark
 $Image = Get-Image -FilePath "$PSScriptRoot\Samples\PrzemyslawKlysAndKulkozaurr.jpg"
-# void WatermarkImage(string filePath, ImagePlayground.Image+WatermarkPlacement placement, float opacity = 1, float padding = 18, int rotate = 0, SixLabors.ImageSharp.Processing.FlipMode flipMode = SixLabors.ImageSharp.Processing.FlipMode.None, int watermarkPercentage = 20)
+# void WatermarkImage(string filePath, ImagePlayground.WatermarkPlacement placement, float opacity = 1, float padding = 18, int rotate = 0, SixLabors.ImageSharp.Processing.FlipMode flipMode = SixLabors.ImageSharp.Processing.FlipMode.None, int watermarkPercentage = 20)
 
 # place in the middle
-$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.Image+WatermarkPlacement]::Middle, 0.5, 0.5, 90, [SixLabors.ImageSharp.Processing.FlipMode]::Vertical, 100)
+$Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", [ImagePlayground.WatermarkPlacement]::Middle, 0.5, 0.5, 90, [SixLabors.ImageSharp.Processing.FlipMode]::Vertical, 100)
 
 # place with x,y
 $Image.WatermarkImage("$PSScriptRoot\Samples\LogoEvotec.png", 50, 100, 0.5, 0.5)


### PR DESCRIPTION
## Summary
- replace deprecated `Image+WatermarkPlacement` references with `WatermarkPlacement` in example scripts

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh ./ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6899a59c24f0832e930594868e2c682c