### PR TITLE
fix(core): ensure ConvertTo uses resolved output path

### DIFF
--- a/Examples/Images.ConvertToNoDirectory.ps1
+++ b/Examples/Images.ConvertToNoDirectory.ps1
@@ -1,0 +1,5 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+Push-Location $PSScriptRoot
+ConvertTo-Image -FilePath .\Samples\LogoEvotec.png -OutputPath LogoEvotec.jpg
+Pop-Location

--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.IO;
-using System.Threading.Tasks;
-using SixLabors.ImageSharp;
+﻿using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
+using System;
+using System.IO;
+using System.Threading.Tasks;
 using Color = SixLabors.ImageSharp.Color;
 
 namespace ImagePlayground;
@@ -26,10 +26,10 @@ public partial class ImageHelper {
     public static void ConvertTo(string filePath, string outFilePath, int? quality = null, int? compressionLevel = null) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
-        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
+        Helpers.CreateParentDirectory(outFullPath);
         using (var inStream = System.IO.File.OpenRead(fullPath))
         using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
-            FileInfo fileInfo = new FileInfo(outFilePath);
+            FileInfo fileInfo = new FileInfo(outFullPath);
             if (fileInfo.Extension == ".ico") {
                 if (System.IO.Path.GetExtension(fullPath).Equals(".ico", StringComparison.OrdinalIgnoreCase)) {
                     System.IO.File.Copy(fullPath, outFullPath, true);

--- a/Tests/ConvertTo-Image.Tests.ps1
+++ b/Tests/ConvertTo-Image.Tests.ps1
@@ -14,6 +14,15 @@ Describe 'ConvertTo-Image' {
         Test-Path $dest | Should -BeTrue
     }
 
+    It 'converts when output path has no directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dest = 'qr_nodir.jpg'
+        if (Test-Path $dest) { Remove-Item $dest }
+        ConvertTo-Image -FilePath $src -OutputPath $dest
+        Test-Path $dest | Should -BeTrue
+        Remove-Item $dest
+    }
+
     It 'copies icon when converting icon to icon' {
         $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.ico'
         $dest = Join-Path $TestDir 'qr_copy.ico'


### PR DESCRIPTION
## Summary
- ensure ConvertTo creates parent directory and uses resolved output path
- add regression test for output path without directory
- document relative output usage in new example script

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script './Tests/ConvertTo-Image.Tests.ps1'"`

------
https://chatgpt.com/codex/tasks/task_e_6899af893dfc832e9e29612f9dc22006