### PR TITLE
feat(core): detect charset in meta content attribute

### DIFF
--- a/Sources/ImagePlayground.Core/Helpers.Path.cs
+++ b/Sources/ImagePlayground.Core/Helpers.Path.cs
@@ -131,6 +131,12 @@ public static partial class Helpers {
             asciiContent,
             @"<meta[^>]+charset\s*=\s*[""']?([^""'>\s]+)",
             System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        if (!metaMatch.Success) {
+            metaMatch = System.Text.RegularExpressions.Regex.Match(
+                asciiContent,
+                @"<meta[^>]+content\s*=\s*[""'][^""']*charset\s*=\s*([^""'>\s]+)",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        }
 
         if (metaMatch.Success) {
             try {


### PR DESCRIPTION
## Summary
- extend GetStringWithProperEncodingAsync to parse charset from meta content
- cover big-endian BOM and meta content scenarios in tests

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj --framework net8.0`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj` *(fails: Failed to negotiate protocol, waiting for response timed out after 90 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_6899afcad1a4832eaa1568f662881e4d