### PR TITLE
fix: create barcode output directories

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -29,7 +29,7 @@ public class BarCode {
     /// <param name="filePath">Destination file path.</param>
     private static void SaveToFile(IBarcode barcode, string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
-
+        Helpers.CreateParentDirectory(fullPath);
         FileInfo fileInfo = new FileInfo(fullPath);
         string extension = fileInfo.Extension.ToLowerInvariant();
         ImageFormat imageFormatDetected = extension switch {
@@ -52,6 +52,7 @@ public class BarCode {
 
     private static void SaveToFile(Image<Rgba32> image, string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
+        Helpers.CreateParentDirectory(fullPath);
         FileInfo fileInfo = new FileInfo(fullPath);
         string extension = fileInfo.Extension.ToLowerInvariant();
 

--- a/Sources/ImagePlayground.Tests/Barcode.cs
+++ b/Sources/ImagePlayground.Tests/Barcode.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for BarCode output directory creation.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_BarCode_CreatesOutputDirectory_ForCode128() {
+        string destDir = Path.Combine(_directoryWithTests, "barcode_created");
+        string dest = Path.Combine(destDir, "barcode.png");
+        if (Directory.Exists(destDir)) {
+            Directory.Delete(destDir, true);
+        }
+
+        BarCode.GenerateCode128("123456", dest);
+
+        Assert.True(File.Exists(dest));
+    }
+
+    [Fact]
+    public void Test_BarCode_CreatesOutputDirectory_ForPdf417() {
+        string destDir = Path.Combine(_directoryWithTests, "barcode_pdf417_created");
+        string dest = Path.Combine(destDir, "barcode.png");
+        if (Directory.Exists(destDir)) {
+            Directory.Delete(destDir, true);
+        }
+
+        BarCode.GeneratePdf417("Pdf417Example", dest);
+
+        Assert.True(File.Exists(dest));
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure parent directories exist before saving barcodes
- add tests for barcode save directory creation

## Testing
- `dotnet test Sources/ImagePlayground.sln --framework net8.0`
- `dotnet test Sources/ImagePlayground.sln` *(fails: Could not find 'mono' host)*
- `dotnet build Sources/ImagePlayground.sln -f net472` *(fails: reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899afa2d820832ebbebde91020790f0