### PR TITLE
fix: handle hex color extraction safely

### DIFF
--- a/Sources/ImagePlayground.Core/Helpers.cs
+++ b/Sources/ImagePlayground.Core/Helpers.cs
@@ -28,7 +28,15 @@ public static partial class Helpers {
     /// <param name="c">Color value to convert.</param>
     /// <returns>Hex string without alpha component.</returns>
     public static string ToHexColor(this SixLabors.ImageSharp.Color c) {
-        return c.ToHex().Remove(6);
+        string hex = c.ToHex();
+        if (hex.Length < 6) {
+            return hex;
+        }
+#if NETSTANDARD2_0 || NET472
+        return hex.Substring(0, 6);
+#else
+        return hex[..6];
+#endif
     }
 
     /// <summary>
@@ -101,4 +109,4 @@ public static partial class Helpers {
         //file is not locked
         return false;
     }
-}
+}

--- a/Sources/ImagePlayground.Tests/HelpersColor.cs
+++ b/Sources/ImagePlayground.Tests/HelpersColor.cs
@@ -1,0 +1,16 @@
+using SixLabors.ImageSharp;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for HelpersColor.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_ToHexColor_RemovesAlpha() {
+        Color color = Color.ParseHex("11223344");
+        string result = Helpers.ToHexColor(color);
+        Assert.Equal("112233", result);
+    }
+}


### PR DESCRIPTION
## Summary
- guard ToHexColor against short values
- add unit test for ToHexColor removing alpha

## Testing
- `dotnet test Sources/ImagePlayground.sln` *(failed: run started but aborted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6899af9a0408832e80160ee1d843b65c