### PR TITLE
fix(core): 🐛 validate resize dimensions

### DIFF
--- a/Examples/Resize/InvalidDimensions.ps1
+++ b/Examples/Resize/InvalidDimensions.ps1
@@ -1,0 +1,8 @@
+Import-Module $PSScriptRoot/../ImagePlayground.psd1 -Force
+
+$source = Join-Path -Path $PSScriptRoot -ChildPath '../Samples/LogoEvotec.png'
+$destination = Join-Path -Path $PSScriptRoot -ChildPath '../Output/logo-invalid-dimension.png'
+
+# This call fails because width is zero
+Resize-Image -FilePath $source -OutputPath $destination -Width 0 -Height 10
+

--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -54,6 +54,12 @@ public partial class ImageHelper {
     /// <param name="keepAspectRatio"></param>
     /// <param name="sampler"></param>
     public static void Resize(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
+        if (width.HasValue && width.Value <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(width), "Width must be greater than 0.");
+        }
+        if (height.HasValue && height.Value <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(height), "Height must be greater than 0.");
+        }
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
@@ -91,6 +97,12 @@ public partial class ImageHelper {
     /// <param name="sampler">Optional resampler algorithm.</param>
     /// <returns>Resized image instance.</returns>
     public static SixLabors.ImageSharp.Image Resize(SixLabors.ImageSharp.Image image, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
+        if (width.HasValue && width.Value <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(width), "Width must be greater than 0.");
+        }
+        if (height.HasValue && height.Value <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(height), "Height must be greater than 0.");
+        }
         if (width == null && height == null) {
             return image;
         }

--- a/Tests/Resize-Image.Tests.ps1
+++ b/Tests/Resize-Image.Tests.ps1
@@ -81,6 +81,16 @@ Describe 'Resize-Image' {
         { Resize-Image -FilePath $src -OutputPath $dest -Width 10 -Height -5 } | Should -Throw
     }
 
+    It 'throws for non-positive dimensions via API' {
+        $src = Join-Path -Path $PSScriptRoot -ChildPath '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $img = [ImagePlayground.Image]::Load($src)
+        { [ImagePlayground.ImageHelper]::Resize($img, 0, 10) } | Should -Throw
+        { [ImagePlayground.ImageHelper]::Resize($img, 10, 0) } | Should -Throw
+        { [ImagePlayground.ImageHelper]::Resize($img, -5, 10) } | Should -Throw
+        { [ImagePlayground.ImageHelper]::Resize($img, 10, -5) } | Should -Throw
+        $img.Dispose()
+    }
+
     It 'throws for dimensions above maximum' {
         $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
         $dest = Join-Path $TestDir 'logo-too-large.png'


### PR DESCRIPTION
## Summary
- guard Resize overloads against non-positive width or height
- cover invalid dimension inputs with new Pester tests
- add failing Resize example script

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh -NoLogo -NoProfile -Command "./ImagePlayground.Tests.ps1"`


------
https://chatgpt.com/codex/tasks/task_e_6899af91dd60832eac753359ef57bfe5