### PR TITLE
fix(powershell): ensure Remove-ImageExif creates output directory

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
@@ -53,6 +53,7 @@ public sealed class RemoveImageExifCmdlet : PSCmdlet {
         }
 
         var output = string.IsNullOrWhiteSpace(FilePathOutput) ? filePath : Helpers.ResolvePath(FilePathOutput!);
+        Helpers.CreateParentDirectory(output);
         img.Save(output);
     }
 }

--- a/Tests/Remove-ImageExif.Tests.ps1
+++ b/Tests/Remove-ImageExif.Tests.ps1
@@ -34,5 +34,30 @@ Describe 'Remove-ImageExif' {
 
     }
 
+    It 'creates parent directory when output path provided' {
+
+        $dest = Join-Path $TestDir 'exif-source.jpg'
+        $output = Join-Path $TestDir 'nested/exif-output.jpg'
+
+        if (Test-Path $dest) { Remove-Item $dest }
+        if (Test-Path (Split-Path $output)) { Remove-Item (Split-Path $output) -Recurse }
+
+        $img = [ImagePlayground.Image]::new()
+
+        $img.Create($dest, 10, 10)
+
+        $img.SetExifValue([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software, 'ImagePlayground')
+
+        $img.Save()
+
+        $img.Dispose()
+
+        Remove-ImageExif -FilePath $dest -FilePathOutput $output -ExifTag ([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software)
+
+        Test-Path $output | Should -BeTrue
+        (Get-ImageExif -FilePath $output).Count | Should -Be 0
+
+    }
+
 }
 


### PR DESCRIPTION
## Summary
- ensure Remove-ImageExif creates parent directory when saving to a new path
- add regression test for Remove-ImageExif output path creation

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6899bb795168832e92f49cd8abb5e552