### PR TITLE
docs(core): add xml docs for base64 helper

### DIFF
--- a/Sources/ImagePlayground.Core/ImageHelper.Base64.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Base64.cs
@@ -2,8 +2,9 @@ using System;
 using System.IO;
 
 namespace ImagePlayground;
+
 /// <summary>
-/// Provides helper methods for image manipulation.
+/// Provides helper methods for converting images to and from Base64 strings.
 /// </summary>
 public partial class ImageHelper {
     /// <summary>
@@ -11,6 +12,9 @@ public partial class ImageHelper {
     /// </summary>
     /// <param name="filePath">Path to the source image.</param>
     /// <returns>Base64 encoded string.</returns>
+    /// <example>
+    /// <code>string base64 = ImageHelper.ConvertToBase64("input.png");</code>
+    /// </example>
     public static string ConvertToBase64(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
         using var stream = File.OpenRead(fullPath);
@@ -24,6 +28,9 @@ public partial class ImageHelper {
     /// </summary>
     /// <param name="base64">Base64 encoded image content.</param>
     /// <param name="outFilePath">Destination file path.</param>
+    /// <example>
+    /// <code>ImageHelper.ConvertFromBase64(base64String, "output.png");</code>
+    /// </example>
     public static void ConvertFromBase64(string base64, string outFilePath) {
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);


### PR DESCRIPTION
## Summary
- document Base64 helper methods with examples

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `dotnet test Sources/ImagePlayground.sln` *(fails: Could not find host & 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6899bb855338832eb9e69644b6c5beb8