### PR TITLE
fix(powershell): add exclusive parameter sets for New-ImageChart

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -11,12 +11,15 @@ namespace ImagePlayground.PowerShell;
 /// </example>
 [Cmdlet(VerbsCommon.New, "ImageChart")]
 public sealed class NewImageChartCmdlet : PSCmdlet {
+    private const string ScriptBlockSet = "ScriptBlock";
+    private const string DefinitionSet = "Definition";
+
     /// <summary>ScriptBlock producing chart definitions.</summary>
-    [Parameter(Position = 0)]
+    [Parameter(Position = 0, Mandatory = true, ParameterSetName = ScriptBlockSet)]
     public ScriptBlock? ChartsDefinition { get; set; }
 
     /// <summary>Chart definitions provided directly.</summary>
-    [Parameter(ValueFromPipeline = true)]
+    [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = DefinitionSet)]
     public ChartDefinition[]? Definition { get; set; }
 
     /// <summary>ScriptBlock producing annotations.</summary>
@@ -46,7 +49,8 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
     public string? YTitle { get; set; }
 
     /// <summary>Output file path.</summary>
-    [Parameter(ValueFromPipeline = true, Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = ScriptBlockSet)]
+    [Parameter(Mandatory = true, ParameterSetName = DefinitionSet)]
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>Open the image after creation.</summary>

--- a/Tests/New-ImageChart.Tests.ps1
+++ b/Tests/New-ImageChart.Tests.ps1
@@ -1,54 +1,96 @@
 Describe 'New-ImageChart' {
     BeforeAll {
-        Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
-        $TestDir = Join-Path $PSScriptRoot 'Artifacts'
-        if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
+        Import-Module -Name "$PSScriptRoot/../ImagePlayground.psd1" -Force
+        $TestDir = Join-Path -Path $PSScriptRoot -ChildPath 'Artifacts'
+        if (-not (Test-Path -Path $TestDir)) {
+            New-Item -Path $TestDir -ItemType Directory | Out-Null
+        }
     }
 
     It 'creates a bar chart' -Skip:(-not $IsWindows) {
-        $file = Join-Path $TestDir 'chart.png'
-        if (Test-Path $file) { Remove-Item $file }
+        $file = Join-Path -Path $TestDir -ChildPath 'chart.png'
+        if (Test-Path -Path $file) {
+            Remove-Item -Path $file
+        }
 
         New-ImageChart -ChartsDefinition {
             New-ImageChartBar -Name 'Jan' -Value @(1,2)
             New-ImageChartBar -Name 'Feb' -Value @(3,4)
         } -FilePath $file -Width 200 -Height 150
 
-        Test-Path $file | Should -BeTrue
+        Test-Path -Path $file | Should -BeTrue
     }
 
     It 'creates a bar chart with axis titles' -Skip:(-not $IsWindows) {
-        $file = Join-Path $TestDir 'chart_titles.png'
-        if (Test-Path $file) { Remove-Item $file }
+        $file = Join-Path -Path $TestDir -ChildPath 'chart_titles.png'
+        if (Test-Path -Path $file) {
+            Remove-Item -Path $file
+        }
 
         New-ImageChart -ChartsDefinition {
             New-ImageChartBar -Name 'Jan' -Value @(1,2)
             New-ImageChartBar -Name 'Feb' -Value @(3,4)
         } -FilePath $file -Width 200 -Height 150 -XTitle 'X' -YTitle 'Y'
 
-        Test-Path $file | Should -BeTrue
+        Test-Path -Path $file | Should -BeTrue
     }
 
     It 'creates a bar chart with grid lines' -Skip:(-not $IsWindows) {
-        $file = Join-Path $TestDir 'chart_grid.png'
-        if (Test-Path $file) { Remove-Item $file }
+        $file = Join-Path -Path $TestDir -ChildPath 'chart_grid.png'
+        if (Test-Path -Path $file) {
+            Remove-Item -Path $file
+        }
 
         New-ImageChart -ChartsDefinition {
             New-ImageChartBar -Name 'Jan' -Value @(1,2)
             New-ImageChartBar -Name 'Feb' -Value @(3,4)
         } -FilePath $file -Width 200 -Height 150 -ShowGrid
 
-        Test-Path $file | Should -BeTrue
+        Test-Path -Path $file | Should -BeTrue
     }
 
     It 'creates a polar chart' -Skip:(-not $IsWindows) {
-        $file = Join-Path $TestDir 'chart_polar.png'
-        if (Test-Path $file) { Remove-Item $file }
+        $file = Join-Path -Path $TestDir -ChildPath 'chart_polar.png'
+        if (Test-Path -Path $file) {
+            Remove-Item -Path $file
+        }
 
         New-ImageChart -ChartsDefinition {
             New-ImageChartPolar -Name 'S1' -Angle @(0,1) -Value @(1,2)
         } -FilePath $file -Width 200 -Height 150
 
-        Test-Path $file | Should -BeTrue
+        Test-Path -Path $file | Should -BeTrue
+    }
+
+    It 'creates a bar chart from definitions' -Skip:(-not $IsWindows) {
+        $file = Join-Path -Path $TestDir -ChildPath 'chart_defs.png'
+        if (Test-Path -Path $file) {
+            Remove-Item -Path $file
+        }
+
+        $defs = @(
+            New-ImageChartBar -Name 'Jan' -Value @(1,2)
+            New-ImageChartBar -Name 'Feb' -Value @(3,4)
+        )
+
+        New-ImageChart -Definition $defs -FilePath $file -Width 200 -Height 150
+
+        Test-Path -Path $file | Should -BeTrue
+    }
+
+    It 'creates a bar chart from pipeline input' -Skip:(-not $IsWindows) {
+        $file = Join-Path -Path $TestDir -ChildPath 'chart_pipe.png'
+        if (Test-Path -Path $file) {
+            Remove-Item -Path $file
+        }
+
+        $defs = @(
+            New-ImageChartBar -Name 'Jan' -Value @(1,2)
+            New-ImageChartBar -Name 'Feb' -Value @(3,4)
+        )
+
+        $defs | New-ImageChart -FilePath $file -Width 200 -Height 150
+
+        Test-Path -Path $file | Should -BeTrue
     }
 }


### PR DESCRIPTION
## Summary
- ensure New-ImageChart uses distinct parameter sets for scriptblock vs object definitions, preventing ambiguous input
- expand New-ImageChart tests with named parameters and coverage for definition and pipeline input

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope CurrentUser; Import-Module -Name ./ImagePlayground.psd1 -Force; Invoke-Pester -Script ./Tests/New-ImageChart.Tests.ps1"`


------
https://chatgpt.com/codex/tasks/task_e_6899bb974334832ebbe8d8abc5aeed7b