### PR TITLE
fix(barcode): handle null decode result

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -175,7 +175,14 @@ public class BarCode {
 
         using Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
         BarcodeReader.ImageSharp.BarcodeReader<Rgba32> reader = new(types: new[] { ZXing.BarcodeFormat.All_1D, ZXing.BarcodeFormat.DATA_MATRIX, ZXing.BarcodeFormat.PDF_417 });
-        BarcodeResult<Rgba32> response = reader.Decode(barcodeImage);
+        BarcodeResult<Rgba32>? response = reader.Decode(barcodeImage);
+        if (response == null) {
+            return new BarcodeResult<Rgba32> {
+                Status = Status.Error,
+                Message = "Unable to decode barcode"
+            };
+        }
+
         response.Image?.Dispose();
         BarcodeResult<Rgba32> result = new() {
             Value = response.Value,

--- a/Sources/ImagePlayground.Tests/BarcodeRead.cs
+++ b/Sources/ImagePlayground.Tests/BarcodeRead.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using BarcodeReader.ImageSharp;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for reading barcodes.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_BarCodeRead_ReturnsError_ForInvalidImage() {
+        string filePath = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+        var result = BarCode.Read(filePath);
+        Assert.Equal(Status.NotFound, result.Status);
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle null barcode decode responses by returning an error result
- cover barcode read failure scenario with a test

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6899bb74310c832e9ee23f7759bd16ac