### PR TITLE
Add background color support for charts

### DIFF
--- a/Examples/Charts.Background.ps1
+++ b/Examples/Charts.Background.ps1
@@ -1,0 +1,9 @@
+Import-Module $PSScriptRoot\..\ImagePlayground.psd1 -Force
+
+New-ImageChart {
+    New-ImageChartBar -Value 5 -Label "C#"
+    New-ImageChartBar -Value 12 -Label "C++"
+    New-ImageChartBar -Value 10 -Label "PowerShell"
+} -Show -FilePath $PSScriptRoot\Samples\ChartsBackground.png -Width 500 -Height 500 -Background ([SixLabors.ImageSharp.Color]::LightGray)
+
+New-SpectreImage -FilePath $PSScriptRoot\Samples\ChartsBackground.png -MaxWidth 500

--- a/Sources/ImagePlayground.Chart/Charts.cs
+++ b/Sources/ImagePlayground.Chart/Charts.cs
@@ -21,7 +21,8 @@ public static class Charts {
         string? yTitle = null,
         bool showGrid = false,
         ChartTheme theme = ChartTheme.Default,
-        IEnumerable<ChartAnnotation>? annotations = null) {
+        IEnumerable<ChartAnnotation>? annotations = null,
+        ImageColor? background = null) {
         if (definitions is null) throw new ArgumentNullException(nameof(definitions));
         var list = definitions.ToList();
         if (list.Count == 0) throw new ArgumentException("No chart definitions provided", nameof(definitions));
@@ -34,6 +35,13 @@ public static class Charts {
                 case ChartTheme.Light:
                     new ScottPlot.PlotStyles.Light().Apply(plot);
                     break;
+            }
+
+            if (background.HasValue) {
+                var px = background.Value.ToPixel<Rgba32>();
+                var color = new ScottPlot.Color(px.R, px.G, px.B, px.A);
+                plot.FigureBackground.Color = color;
+                plot.DataBackground.Color = color;
             }
             var type = list[0].Type;
             if (list.Any(d => d.Type != type))

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -65,6 +65,10 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
     [Parameter]
     public ChartTheme Theme { get; set; } = ChartTheme.Default;
 
+    /// <summary>Chart background color.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color? Background { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var list = new List<ChartDefinition>();
@@ -100,7 +104,7 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        Charts.Generate(list, output, Width, Height, null, XTitle, YTitle, ShowGrid.IsPresent, Theme, annotations);
+        Charts.Generate(list, output, Width, Height, null, XTitle, YTitle, ShowGrid.IsPresent, Theme, annotations, Background);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.Tests/ChartsAdditional.cs
+++ b/Sources/ImagePlayground.Tests/ChartsAdditional.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using ImagePlayground;
+using SixLabors.ImageSharp;
 
 namespace ImagePlayground.Tests;
 
@@ -43,5 +44,17 @@ public partial class ImagePlayground {
         Charts.Generate(defs, file, 200, 150, null, null, null, false, ChartTheme.Light);
         Assert.True(File.Exists(file));
         using var streamLight = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+    }
+
+    [Fact]
+    public void Test_GenerateBarChart_WithBackground() {
+        string file = Path.Combine(_directoryWithTests, "chart_background.png");
+        if (File.Exists(file)) File.Delete(file);
+        var defs = new List<ChartDefinition> {
+                new ChartBar("A", new List<double> {1,2})
+            };
+        Charts.Generate(defs, file, 200, 150, null, null, null, false, ChartTheme.Default, null, Color.Aqua);
+        Assert.True(File.Exists(file));
+        using var streamBg = File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }
 }

--- a/Tests/New-ImageChart.Tests.ps1
+++ b/Tests/New-ImageChart.Tests.ps1
@@ -49,6 +49,20 @@ Describe 'New-ImageChart' {
         Test-Path -Path $file | Should -BeTrue
     }
 
+    It 'creates a bar chart with background color' -Skip:(-not $IsWindows) {
+        $file = Join-Path -Path $TestDir -ChildPath 'chart_background.png'
+        if (Test-Path -Path $file) {
+            Remove-Item -Path $file
+        }
+
+        New-ImageChart -ChartsDefinition {
+            New-ImageChartBar -Name 'Jan' -Value @(1,2)
+            New-ImageChartBar -Name 'Feb' -Value @(3,4)
+        } -FilePath $file -Width 200 -Height 150 -Background ([SixLabors.ImageSharp.Color]::Aqua)
+
+        Test-Path -Path $file | Should -BeTrue
+    }
+
     It 'creates a polar chart' -Skip:(-not $IsWindows) {
         $file = Join-Path -Path $TestDir -ChildPath 'chart_polar.png'
         if (Test-Path -Path $file) {


### PR DESCRIPTION
## Summary
- add optional background color to `Charts.Generate`
- expose `-Background` on `New-ImageChart` cmdlet
- document and test background color with new example script

## Testing
- `dotnet build Sources/ImagePlayground.sln -c Release`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -c Release --no-build -f net8.0`
- `pwsh -NoLogo -NoProfile ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6899ef00f6b8832eb07d58bcdc59a3de