### PR TITLE
feat(qrcode): ✨ add color and pixel size options

### DIFF
--- a/Sources/ImagePlayground.Examples/Example.QRCode.cs
+++ b/Sources/ImagePlayground.Examples/Example.QRCode.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using QRCoder;
+using SixLabors.ImageSharp;
 
 namespace ImagePlayground.Examples;
 internal partial class Example {
@@ -41,6 +43,10 @@ internal partial class Example {
         read = QrCode.Read(filePath);
         Console.Write(read.Message);
         Console.WriteLine();
+
+        Console.WriteLine("[*] Creating QR code with custom colors");
+        filePath = System.IO.Path.Combine(folderPath, "QRCodeColored.png");
+        QrCode.Generate("https://evotec.xyz", filePath, false, QRCodeGenerator.ECCLevel.Q, Color.Red, Color.Yellow, 10);
     }
 
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
@@ -33,6 +33,18 @@ public sealed class NewImageQrCodeCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Transparent { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -41,7 +53,7 @@ public sealed class NewImageQrCodeCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.Generate(Content, output, Transparent.IsPresent);
+        ImagePlayground.QrCode.Generate(Content, output, Transparent.IsPresent, QRCodeGenerator.ECCLevel.Q, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
@@ -48,6 +48,18 @@ public sealed class NewImageQrCodeBezahlCodeCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -56,7 +68,7 @@ public sealed class NewImageQrCodeBezahlCodeCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateBezahlCode(Authority, Name, Account, Bnc, Iban, Bic, Reason, output);
+        ImagePlayground.QrCode.GenerateBezahlCode(Authority, Name, Account, Bnc, Iban, Bic, Reason, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
@@ -40,6 +40,18 @@ public sealed class NewImageQrCodeBitcoinCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -48,7 +60,7 @@ public sealed class NewImageQrCodeBitcoinCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateBitcoinAddress(Currency, Address, Amount, Label, Message, output);
+        ImagePlayground.QrCode.GenerateBitcoinAddress(Currency, Address, Amount, Label, Message, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
@@ -28,6 +28,18 @@ public sealed class NewImageQrCodeGeoLocationCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -36,7 +48,7 @@ public sealed class NewImageQrCodeGeoLocationCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateGeoLocation(Latitude, Longitude, output);
+        ImagePlayground.QrCode.GenerateGeoLocation(Latitude, Longitude, output, PayloadGenerator.Geolocation.GeolocationEncoding.GEO, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
@@ -40,6 +40,18 @@ public sealed class NewImageQrCodeGirocodeCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -48,7 +60,7 @@ public sealed class NewImageQrCodeGirocodeCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateGirocode(Iban, Bic, Name, Amount, output, RemittanceInformation, PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, null, null, PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, false);
+        ImagePlayground.QrCode.GenerateGirocode(Iban, Bic, Name, Amount, output, RemittanceInformation, PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, null, null, PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
@@ -40,6 +40,18 @@ public sealed class NewImageQrCodeMoneroCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -48,7 +60,7 @@ public sealed class NewImageQrCodeMoneroCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateMoneroTransaction(Address, Amount, PaymentId, RecipientName, Description, output);
+        ImagePlayground.QrCode.GenerateMoneroTransaction(Address, Amount, PaymentId, RecipientName, Description, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
@@ -24,6 +24,18 @@ public sealed class NewImageQrCodeOtpCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -32,7 +44,7 @@ public sealed class NewImageQrCodeOtpCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateOneTimePassword(Payload, output);
+        ImagePlayground.QrCode.GenerateOneTimePassword(Payload, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
@@ -24,6 +24,18 @@ public sealed class NewImageQrCodePhoneNumberCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -32,7 +44,7 @@ public sealed class NewImageQrCodePhoneNumberCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GeneratePhoneNumber(Number, output);
+        ImagePlayground.QrCode.GeneratePhoneNumber(Number, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
@@ -40,6 +40,18 @@ public sealed class NewImageQrCodeShadowSocksCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -48,7 +60,7 @@ public sealed class NewImageQrCodeShadowSocksCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateShadowSocks(Host, Port, Password, Method, output, Tag);
+        ImagePlayground.QrCode.GenerateShadowSocks(Host, Port, Password, Method, output, Tag, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
@@ -24,6 +24,18 @@ public sealed class NewImageQrCodeSkypeCallCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -32,7 +44,7 @@ public sealed class NewImageQrCodeSkypeCallCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateSkypeCall(UserName, output);
+        ImagePlayground.QrCode.GenerateSkypeCall(UserName, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
@@ -24,6 +24,18 @@ public sealed class NewImageQrCodeSlovenianUpnQrCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -32,7 +44,7 @@ public sealed class NewImageQrCodeSlovenianUpnQrCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateSlovenianUpnQr(Payload, output);
+        ImagePlayground.QrCode.GenerateSlovenianUpnQr(Payload, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
@@ -28,6 +28,18 @@ public sealed class NewImageQrCodeSmsCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -36,7 +48,7 @@ public sealed class NewImageQrCodeSmsCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateSms(Number, Message, output, PayloadGenerator.SMS.SMSEncoding.SMS, false);
+        ImagePlayground.QrCode.GenerateSms(Number, Message, output, PayloadGenerator.SMS.SMSEncoding.SMS, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
@@ -24,6 +24,18 @@ public sealed class NewImageQrCodeSwissCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -32,7 +44,7 @@ public sealed class NewImageQrCodeSwissCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateSwissQrCode(Payload, output);
+        ImagePlayground.QrCode.GenerateSwissQrCode(Payload, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
@@ -29,6 +29,18 @@ public sealed class NewImageQrCodeWiFiCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -37,7 +49,7 @@ public sealed class NewImageQrCodeWiFiCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateWiFi(SSID, Password, output, false);
+        ImagePlayground.QrCode.GenerateWiFi(SSID, Password, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
@@ -100,6 +100,18 @@ public sealed class NewImageQrContactCmdlet : PSCmdlet {
     [Parameter]
     public SwitchParameter Show { get; set; }
 
+    /// <summary>Foreground color of QR modules.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color ForegroundColor { get; set; } = SixLabors.ImageSharp.Color.Black;
+
+    /// <summary>Background color of the QR code.</summary>
+    [Parameter]
+    public SixLabors.ImageSharp.Color BackgroundColor { get; set; } = SixLabors.ImageSharp.Color.White;
+
+    /// <summary>Pixel size for each QR module.</summary>
+    [Parameter]
+    public int PixelSize { get; set; } = 20;
+
     /// <inheritdoc />
     protected override void ProcessRecord() {
         if (string.IsNullOrWhiteSpace(FilePath)) {
@@ -108,7 +120,7 @@ public sealed class NewImageQrContactCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateContact(output, OutputType, Firstname ?? string.Empty, Lastname ?? string.Empty, Nickname, Phone, MobilePhone, WorkPhone, Email, Birthday, Website, Street, HouseNumber, City, ZipCode, Country, Note, StateRegion, AddressOrder, Org, OrgTitle, false);
+        ImagePlayground.QrCode.GenerateContact(output, OutputType, Firstname ?? string.Empty, Lastname ?? string.Empty, Nickname, Phone, MobilePhone, WorkPhone, Email, Birthday, Website, Street, HouseNumber, City, ZipCode, Country, Note, StateRegion, AddressOrder, Org, OrgTitle, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
             ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -21,7 +21,10 @@ public class QrCode {
     /// <param name="filePath">Path where the QR image will be saved.</param>
     /// <param name="transparent">Whether the background should be transparent.</param>
     /// <param name="eccLevel">Error correction level.</param>
-    public static void Generate(string content, string filePath, bool transparent = false, QRCodeGenerator.ECCLevel eccLevel = QRCodeGenerator.ECCLevel.Q) {
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    public static void Generate(string content, string filePath, bool transparent = false, QRCodeGenerator.ECCLevel eccLevel = QRCodeGenerator.ECCLevel.Q, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
 
         FileInfo fileInfo = new FileInfo(fullPath);
@@ -29,8 +32,9 @@ public class QrCode {
         using (QRCodeGenerator qrGenerator = new QRCodeGenerator()) {
             using (QRCodeData qrCodeData = qrGenerator.CreateQrCode(content, eccLevel)) {
                 using (QRCoder.QRCode qrCode = new QRCoder.QRCode(qrCodeData)) {
-                    Color lightColor = transparent ? Color.Transparent : Color.White;
-                    using (var qrCodeImage = qrCode.GetGraphic(20, Color.Black, lightColor, true)) {
+                    Color dark = foregroundColor ?? Color.Black;
+                    Color light = transparent ? Color.Transparent : (backgroundColor ?? Color.White);
+                    using (var qrCodeImage = qrCode.GetGraphic(pixelSize, dark, light, true)) {
                         switch (fileInfo.Extension.ToLowerInvariant()) {
                             case ".png":
                                 qrCodeImage.SaveAsPng(fullPath);
@@ -59,7 +63,10 @@ public class QrCode {
     /// <param name="logoPath">Path to the logo image to overlay.</param>
     /// <param name="transparent">Whether the background should be transparent.</param>
     /// <param name="eccLevel">Error correction level.</param>
-    public static void Generate(string content, string filePath, string logoPath, bool transparent = false, QRCodeGenerator.ECCLevel eccLevel = QRCodeGenerator.ECCLevel.Q) {
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    public static void Generate(string content, string filePath, string logoPath, bool transparent = false, QRCodeGenerator.ECCLevel eccLevel = QRCodeGenerator.ECCLevel.Q, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         string fullPath = Helpers.ResolvePath(filePath);
         string fullLogoPath = Helpers.ResolvePath(logoPath);
 
@@ -68,9 +75,10 @@ public class QrCode {
         using (QRCodeGenerator qrGenerator = new QRCodeGenerator()) {
             using (QRCodeData qrCodeData = qrGenerator.CreateQrCode(content, eccLevel)) {
                 using (QRCoder.QRCode qrCode = new QRCoder.QRCode(qrCodeData)) {
-                    Color lightColor = transparent ? Color.Transparent : Color.White;
-                    using (var qrCodeImage = qrCode.GetGraphic(20, Color.Black, lightColor, true)) {
-                        using (Image<Rgba32> logo = SixLabors.ImageSharp.Image.Load<Rgba32>(fullLogoPath)) {
+                    Color dark = foregroundColor ?? Color.Black;
+                    Color light = transparent ? Color.Transparent : (backgroundColor ?? Color.White);
+                    using (var qrCodeImage = qrCode.GetGraphic(pixelSize, dark, light, true)) {
+                        using (SixLabors.ImageSharp.Image<Rgba32> logo = SixLabors.ImageSharp.Image.Load<Rgba32>(fullLogoPath)) {
                             int logoSize = qrCodeImage.Width / 5;
                             logo.Mutate(x => x.Resize(new ResizeOptions {
                                 Mode = ResizeMode.Max,
@@ -102,10 +110,13 @@ public class QrCode {
     /// <param name="password">Wireless password.</param>
     /// <param name="filePath">Destination image path.</param>
     /// <param name="transparent">Whether the QR code should have transparent background.</param>
-    public static void GenerateWiFi(string ssid, string password, string filePath, bool transparent = false) {
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    public static void GenerateWiFi(string ssid, string password, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         string encodedPassword = WebUtility.UrlEncode(password);
         PayloadGenerator.WiFi generator = new PayloadGenerator.WiFi(ssid, encodedPassword, PayloadGenerator.WiFi.Authentication.WPA, false, false);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
@@ -114,9 +125,12 @@ public class QrCode {
     /// <param name="message">Message text to pre-fill.</param>
     /// <param name="filePath">Destination path for the QR image.</param>
     /// <param name="transparent">Whether the QR code should have transparent background.</param>
-    public static void GenerateWhatsAppMessage(string message, string filePath, bool transparent = false) {
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    public static void GenerateWhatsAppMessage(string message, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         PayloadGenerator.WhatsAppMessage generator = new PayloadGenerator.WhatsAppMessage(message);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
     /// <summary>
     /// Generates a QR code representing a hyperlink.
@@ -124,9 +138,12 @@ public class QrCode {
     /// <param name="url">URL to encode.</param>
     /// <param name="filePath">Destination path for the QR image.</param>
     /// <param name="transparent">Whether the QR code should have transparent background.</param>
-    public static void GenerateUrl(string url, string filePath, bool transparent = false) {
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    public static void GenerateUrl(string url, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         PayloadGenerator.Url generator = new PayloadGenerator.Url(url);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
     /// <summary>
     /// Generates a QR code that opens a bookmark in the browser.
@@ -135,9 +152,12 @@ public class QrCode {
     /// <param name="bookmarkName">Bookmark display name.</param>
     /// <param name="filePath">Destination image path.</param>
     /// <param name="transparent">Whether the QR code should have transparent background.</param>
-    public static void GenerateBookmark(string bookmarkUrl, string bookmarkName, string filePath, bool transparent = false) {
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    public static void GenerateBookmark(string bookmarkUrl, string bookmarkName, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         PayloadGenerator.Bookmark generator = new PayloadGenerator.Bookmark(bookmarkUrl, bookmarkName);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
@@ -152,129 +172,132 @@ public class QrCode {
     /// <param name="allDayEvent">Specifies whether the event spans the full day.</param>
     /// <param name="calendarEventEncoding">Calendar encoding.</param>
     /// <param name="transparent">Whether the QR code should have transparent background.</param>
-    public static void GenerateCalendarEvent(string calendarEntry, string calendarMessage, string calendarGeoLocation, DateTime calendarFrom, DateTime calendarTo, string filePath, bool allDayEvent, PayloadGenerator.CalendarEvent.EventEncoding calendarEventEncoding = PayloadGenerator.CalendarEvent.EventEncoding.iCalComplete, bool transparent = false) {
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    public static void GenerateCalendarEvent(string calendarEntry, string calendarMessage, string calendarGeoLocation, DateTime calendarFrom, DateTime calendarTo, string filePath, bool allDayEvent, PayloadGenerator.CalendarEvent.EventEncoding calendarEventEncoding = PayloadGenerator.CalendarEvent.EventEncoding.iCalComplete, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         PayloadGenerator.CalendarEvent generator = new PayloadGenerator.CalendarEvent(calendarEntry, calendarMessage, calendarGeoLocation, calendarFrom, calendarTo, allDayEvent, calendarEventEncoding);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code containing contact information in vCard format.
     /// </summary>
-    public static void GenerateContact(string filePath, PayloadGenerator.ContactData.ContactOutputType outputType, string firstname, string lastname, string nickname = null, string phone = null, string mobilePhone = null, string workPhone = null, string email = null, DateTime? birthday = null, string website = null, string street = null, string houseNumber = null, string city = null, string zipCode = null, string country = null, string note = null, string stateRegion = null, PayloadGenerator.ContactData.AddressOrder addressOrder = PayloadGenerator.ContactData.AddressOrder.Default, string org = null, string orgTitle = null, bool transparent = false) {
+    public static void GenerateContact(string filePath, PayloadGenerator.ContactData.ContactOutputType outputType, string firstname, string lastname, string nickname = null, string phone = null, string mobilePhone = null, string workPhone = null, string email = null, DateTime? birthday = null, string website = null, string street = null, string houseNumber = null, string city = null, string zipCode = null, string country = null, string note = null, string stateRegion = null, PayloadGenerator.ContactData.AddressOrder addressOrder = PayloadGenerator.ContactData.AddressOrder.Default, string org = null, string orgTitle = null, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         PayloadGenerator.ContactData generator = new PayloadGenerator.ContactData(outputType, firstname, lastname, nickname, phone, mobilePhone, workPhone, email, birthday, website, street, houseNumber, city, zipCode, country, note, stateRegion, addressOrder, org, orgTitle);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code that opens an email draft.
     /// </summary>
-    public static void GenerateEmail(string filePath, string email, string subject = null, string message = null, PayloadGenerator.Mail.MailEncoding encoding = PayloadGenerator.Mail.MailEncoding.MAILTO, bool transparent = false) {
+    public static void GenerateEmail(string filePath, string email, string subject = null, string message = null, PayloadGenerator.Mail.MailEncoding encoding = PayloadGenerator.Mail.MailEncoding.MAILTO, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         PayloadGenerator.Mail generator = new PayloadGenerator.Mail(email, subject, message, encoding);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code that opens the messaging app with an MMS draft.
     /// </summary>
-    public static void GenerateMMS(string filePath, string phoneNumber, string subject = "", PayloadGenerator.MMS.MMSEncoding encoding = PayloadGenerator.MMS.MMSEncoding.MMSTO, bool transparent = false) {
+    public static void GenerateMMS(string filePath, string phoneNumber, string subject = "", PayloadGenerator.MMS.MMSEncoding encoding = PayloadGenerator.MMS.MMSEncoding.MMSTO, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = subject == "" ? new PayloadGenerator.MMS(phoneNumber, encoding) : new PayloadGenerator.MMS(phoneNumber, subject, encoding);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Creates a QR code that launches the SMS application.
     /// </summary>
-    public static void GenerateSms(string number, string? message, string filePath, PayloadGenerator.SMS.SMSEncoding encoding = PayloadGenerator.SMS.SMSEncoding.SMS, bool transparent = false) {
+    public static void GenerateSms(string number, string? message, string filePath, PayloadGenerator.SMS.SMSEncoding encoding = PayloadGenerator.SMS.SMSEncoding.SMS, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = string.IsNullOrEmpty(message)
             ? new PayloadGenerator.SMS(number, encoding)
             : new PayloadGenerator.SMS(number, message!, encoding);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code representing a geographic location.
     /// </summary>
-    public static void GenerateGeoLocation(string latitude, string longitude, string filePath, PayloadGenerator.Geolocation.GeolocationEncoding encoding = PayloadGenerator.Geolocation.GeolocationEncoding.GEO, bool transparent = false) {
+    public static void GenerateGeoLocation(string latitude, string longitude, string filePath, PayloadGenerator.Geolocation.GeolocationEncoding encoding = PayloadGenerator.Geolocation.GeolocationEncoding.GEO, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.Geolocation(latitude, longitude, encoding);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Creates a Girocode compliant QR code for SEPA credit transfers.
     /// </summary>
-    public static void GenerateGirocode(string iban, string bic, string name, decimal amount, string filePath, string? remittanceInformation = null, PayloadGenerator.Girocode.TypeOfRemittance type = PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, string? purposeOfCreditTransfer = null, string? messageToGirocodeUser = null, PayloadGenerator.Girocode.GirocodeVersion version = PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding encoding = PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, bool transparent = false) {
+    public static void GenerateGirocode(string iban, string bic, string name, decimal amount, string filePath, string? remittanceInformation = null, PayloadGenerator.Girocode.TypeOfRemittance type = PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, string? purposeOfCreditTransfer = null, string? messageToGirocodeUser = null, PayloadGenerator.Girocode.GirocodeVersion version = PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding encoding = PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.Girocode(iban, bic, name, amount, remittanceInformation ?? string.Empty, type, purposeOfCreditTransfer ?? string.Empty, messageToGirocodeUser ?? string.Empty, version, encoding);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code for Bitcoin-like cryptocurrency payments.
     /// </summary>
-    public static void GenerateBitcoinAddress(PayloadGenerator.BitcoinLikeCryptoCurrencyAddress.BitcoinLikeCryptoCurrencyType currency, string address, double? amount, string? label, string? message, string filePath, bool transparent = false) {
+    public static void GenerateBitcoinAddress(PayloadGenerator.BitcoinLikeCryptoCurrencyAddress.BitcoinLikeCryptoCurrencyType currency, string address, double? amount, string? label, string? message, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.BitcoinLikeCryptoCurrencyAddress(currency, address, amount, label, message);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code for a Monero transfer.
     /// </summary>
-    public static void GenerateMoneroTransaction(string address, float? amount, string? paymentId, string? recipientName, string? description, string filePath, bool transparent = false) {
+    public static void GenerateMoneroTransaction(string address, float? amount, string? paymentId, string? recipientName, string? description, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.MoneroTransaction(address, amount, paymentId, recipientName, description);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code that initiates a phone call.
     /// </summary>
-    public static void GeneratePhoneNumber(string number, string filePath, bool transparent = false) {
+    public static void GeneratePhoneNumber(string number, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.PhoneNumber(number);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code that starts a Skype call.
     /// </summary>
-    public static void GenerateSkypeCall(string username, string filePath, bool transparent = false) {
+    public static void GenerateSkypeCall(string username, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.SkypeCall(username);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code containing Shadowsocks configuration settings.
     /// </summary>
-    public static void GenerateShadowSocks(string hostname, int port, string password, PayloadGenerator.ShadowSocksConfig.Method method, string filePath, string? tag = null, bool transparent = false) {
+    public static void GenerateShadowSocks(string hostname, int port, string password, PayloadGenerator.ShadowSocksConfig.Method method, string filePath, string? tag = null, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.ShadowSocksConfig(hostname, port, password, method, tag);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a QR code for configuring a one-time password generator.
     /// </summary>
-    public static void GenerateOneTimePassword(PayloadGenerator.OneTimePassword otp, string filePath, bool transparent = false) {
-        Generate(otp.ToString(), filePath, transparent);
+    public static void GenerateOneTimePassword(PayloadGenerator.OneTimePassword otp, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
+        Generate(otp.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
 
     /// <summary>
     /// Generates a Slovenian UPN QR payment code.
     /// </summary>
-    public static void GenerateSlovenianUpnQr(PayloadGenerator.SlovenianUpnQr upn, string filePath, bool transparent = false) {
-        Generate(upn.ToString(), filePath, transparent);
+    public static void GenerateSlovenianUpnQr(PayloadGenerator.SlovenianUpnQr upn, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
+        Generate(upn.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a German BezahlCode payment QR code.
     /// </summary>
-    public static void GenerateBezahlCode(PayloadGenerator.BezahlCode.AuthorityType authority, string name, string account, string bnc, string iban, string bic, string reason, string filePath, bool transparent = false) {
+    public static void GenerateBezahlCode(PayloadGenerator.BezahlCode.AuthorityType authority, string name, string account, string bnc, string iban, string bic, string reason, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.BezahlCode(authority, name, account, bnc, iban, bic, reason);
-        Generate(generator.ToString(), filePath, transparent);
+        Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>
     /// Generates a Swiss QR invoice code.
     /// </summary>
-    public static void GenerateSwissQrCode(PayloadGenerator.SwissQrCode swiss, string filePath, bool transparent = false) {
-        Generate(swiss.ToString(), filePath, transparent);
+    public static void GenerateSwissQrCode(PayloadGenerator.SwissQrCode swiss, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
+        Generate(swiss.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
 
     /// <summary>

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -3,6 +3,7 @@ using System.Net;
 using Xunit;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using QRCoder;
 
 
 namespace ImagePlayground.Tests;
@@ -24,6 +25,22 @@ public partial class ImagePlayground {
 
         var read = QrCode.Read(filePath);
         Assert.True(read.Message == "https://evotec.xyz");
+    }
+
+    [Fact]
+    public void Test_QRCode_CustomColors() {
+
+        string filePath = System.IO.Path.Combine(_directoryWithImages, "QRCodeColors.png");
+        File.Delete(filePath);
+        QrCode.Generate("https://evotec.xyz", filePath, false, QRCodeGenerator.ECCLevel.Q, Color.Red, Color.Yellow, 10);
+
+        Assert.True(File.Exists(filePath) == true);
+
+        using SixLabors.ImageSharp.Image<Rgba32> img = SixLabors.ImageSharp.Image.Load<Rgba32>(filePath);
+        Assert.Equal(Color.Yellow.ToPixel<Rgba32>(), img[0, 0]);
+
+        var read = QrCode.Read(filePath);
+        Assert.Equal("https://evotec.xyz", read.Message);
     }
 
     [Fact]

--- a/Tests/New-ImageQRCode.Tests.ps1
+++ b/Tests/New-ImageQRCode.Tests.ps1
@@ -26,6 +26,20 @@ Describe 'New-ImageQRCode' {
 
     }
 
+    It 'creates QR code with custom colors' {
+
+        $file = Join-Path $TestDir 'qr_custom.png'
+
+        if (Test-Path $file) { Remove-Item $file }
+
+        New-ImageQRCode -Content 'https://evotec.xyz' -FilePath $file -ForegroundColor Red -BackgroundColor Yellow -PixelSize 10
+
+        Test-Path $file | Should -BeTrue
+
+        (Get-ImageQRCode -FilePath $file).Message | Should -Be 'https://evotec.xyz'
+
+    }
+
     It 'creates QR code icon' {
 
         $file = Join-Path $TestDir 'qr.ico'

--- a/Tests/New-ImageQRCodeWiFi.Tests.ps1
+++ b/Tests/New-ImageQRCodeWiFi.Tests.ps1
@@ -43,5 +43,12 @@ Describe 'New-ImageQRCodeWiFi password quoting' {
         $result = Get-ImageQRCode -FilePath $file
         $result.Message | Should -Be 'WIFI:T:WPA;S:Test;P:pass%3B123!;;'
     }
+
+    It 'supports custom colors' {
+        $file = Join-Path $TestDrive 'wifi_colors.png'
+        New-ImageQRCodeWiFi -SSID 'Test' -Password 'pass123' -FilePath $file -ForegroundColor Blue -BackgroundColor White -PixelSize 15
+        Test-Path $file | Should -BeTrue
+        (Get-ImageQRCode -FilePath $file).Message | Should -Be 'WIFI:T:WPA;S:Test;P:pass123;;'
+    }
 }
 


### PR DESCRIPTION
## Summary
- allow specifying foreground/background colors and pixel size when generating QR codes
- expose new color and size options across QR-related PowerShell cmdlets
- cover new customization options with examples and tests

## Testing
- `dotnet test Sources/ImagePlayground.sln`
- `pwsh -NoLogo -NoProfile -File ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6899ef05f4d8832ea3bf950b94c81eaa