### PR TITLE
feat(powershell): add verbose logging to Remove-ImageExif

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletRemoveImageExif.cs
@@ -54,7 +54,9 @@ public sealed class RemoveImageExifCmdlet : PSCmdlet {
 
         var output = string.IsNullOrWhiteSpace(FilePathOutput) ? filePath : Helpers.ResolvePath(FilePathOutput!);
         Helpers.CreateParentDirectory(output);
+        WriteVerbose($"Saving image to {output}");
         img.Save(output);
+        WriteVerbose($"Saved image to {output}");
     }
 }
 

--- a/Tests/Remove-ImageExif.Tests.ps1
+++ b/Tests/Remove-ImageExif.Tests.ps1
@@ -28,7 +28,7 @@ Describe 'Remove-ImageExif' {
 
         $img.Dispose()
 
-        Remove-ImageExif -FilePath $dest -ExifTag ([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software)
+        Remove-ImageExif -FilePath $dest -ExifTag ([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software) -Verbose
 
         (Get-ImageExif -FilePath $dest).Count | Should -Be 0
 
@@ -52,7 +52,7 @@ Describe 'Remove-ImageExif' {
 
         $img.Dispose()
 
-        Remove-ImageExif -FilePath $dest -FilePathOutput $output -ExifTag ([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software)
+        Remove-ImageExif -FilePath $dest -FilePathOutput $output -ExifTag ([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software) -Verbose
 
         Test-Path $output | Should -BeTrue
         (Get-ImageExif -FilePath $output).Count | Should -Be 0

--- a/Tests/Set-ImageExif.Tests.ps1
+++ b/Tests/Set-ImageExif.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'Set-ImageExif' {
 
         (Get-ImageExif -FilePath $dest -Translate).Software | Should -Be 'Modified'
 
-        Remove-ImageExif -FilePath $dest -ExifTag ([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software)
+        Remove-ImageExif -FilePath $dest -ExifTag ([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software) -Verbose
 
         (Get-ImageExif -FilePath $dest).Count | Should -Be 0
 


### PR DESCRIPTION
## Summary
- add verbose logging around Remove-ImageExif save operations
- run Remove-ImageExif tests with `-Verbose`

## Testing
- `~/.dotnet/dotnet build Sources/ImagePlayground.sln`
- `pwsh ImagePlayground.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6899ef3158a0832ea1880e457d9dd617