### PR TITLE
refactor(core): remove redundant stream closing

### DIFF
--- a/Sources/ImagePlayground.Core/Helpers.cs
+++ b/Sources/ImagePlayground.Core/Helpers.cs
@@ -72,9 +72,7 @@ public static partial class Helpers {
     /// <returns><c>true</c> if the file cannot be opened exclusively.</returns>
     public static bool IsFileLocked(this FileInfo file) {
         try {
-            using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {
-                stream.Close();
-            }
+            using FileStream _ = file.Open(FileMode.Open, FileAccess.Read, FileShare.None);
         } catch (IOException) {
             //the file is unavailable because it is:
             //still being written to
@@ -95,9 +93,7 @@ public static partial class Helpers {
     public static bool IsFileLocked(this string fileName) {
         try {
             var file = new FileInfo(fileName);
-            using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {
-                stream.Close();
-            }
+            using FileStream _ = file.Open(FileMode.Open, FileAccess.Read, FileShare.None);
         } catch (IOException) {
             //the file is unavailable because it is:
             //still being written to


### PR DESCRIPTION
## Summary
- refactor stream lock detection helpers to rely on using statements

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0`
- `pwsh -NoLogo -NoProfile -File ./ImagePlayground.Tests.ps1`
- ⚠️ `dotnet test Sources/ImagePlayground.sln` *(failed: Failed to negotiate protocol, waiting for response timed out after 90 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_6899ef367b24832e85ce3952ebea20f0