### PR TITLE
feat(barcode): ✨ add async barcode reader

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -160,14 +160,14 @@ public class BarCode {
     }
 
     /// <summary>
-    /// Reads and decodes a barcode from an image.
+    /// Reads and decodes a barcode from an image asynchronously.
     /// </summary>
     /// <param name="filePath">Path to the barcode image.</param>
-    /// <returns>Decoded barcode result.</returns>
-    public static BarcodeResult<Rgba32> Read(string filePath) {
+    /// <returns>A task containing the decoded barcode result.</returns>
+    public static async Task<BarcodeResult<Rgba32>> ReadAsync(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
 
-        using Image<Rgba32> barcodeImage = SixLabors.ImageSharp.Image.Load<Rgba32>(fullPath);
+        using Image<Rgba32> barcodeImage = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fullPath).ConfigureAwait(false);
         BarcodeReader.ImageSharp.BarcodeReader<Rgba32> reader = new(types: new[] { ZXing.BarcodeFormat.All_1D, ZXing.BarcodeFormat.DATA_MATRIX, ZXing.BarcodeFormat.PDF_417 });
         BarcodeResult<Rgba32> response = reader.Decode(barcodeImage);
         response.Image?.Dispose();
@@ -177,5 +177,14 @@ public class BarCode {
             Message = response.Message
         };
         return result;
+    }
+
+    /// <summary>
+    /// Reads and decodes a barcode from an image.
+    /// </summary>
+    /// <param name="filePath">Path to the barcode image.</param>
+    /// <returns>Decoded barcode result.</returns>
+    public static BarcodeResult<Rgba32> Read(string filePath) {
+        return ReadAsync(filePath).GetAwaiter().GetResult();
     }
 }

--- a/Sources/ImagePlayground.Examples/Example.BarCode.cs
+++ b/Sources/ImagePlayground.Examples/Example.BarCode.cs
@@ -64,5 +64,16 @@ internal partial class Example {
         var read = BarCode.Read(filePath);
         Console.WriteLine(read.Message);
     }
+
+    /// <summary>
+    /// Reads a barcode asynchronously.
+    /// </summary>
+    /// <param name="folderPath">Directory containing the barcode image.</param>
+    public static async Task ReadBarcodeAsyncSample(string folderPath) {
+        Console.WriteLine("[*] Reading Barcode asynchronously:");
+        string filePath = System.IO.Path.Combine(folderPath, "BarcodeEAN13.png");
+        var read = await BarCode.ReadAsync(filePath).ConfigureAwait(false);
+        Console.WriteLine(read.Message);
+    }
 }
 

--- a/Sources/ImagePlayground.Tests/BarCodeDispose.cs
+++ b/Sources/ImagePlayground.Tests/BarCodeDispose.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace ImagePlayground.Tests;
@@ -11,6 +12,14 @@ public partial class ImagePlayground {
     public void Test_BarCodeRead_DoesNotLockFile() {
         string filePath = Path.Combine(_directoryWithImages, "BarcodeEAN13.png");
         var result = BarCode.Read(filePath);
+        Assert.True(result.Message == "9012341234571");
+        using var stream = File.Open(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+    }
+
+    [Fact]
+    public async Task Test_BarCodeReadAsync_DoesNotLockFile() {
+        string filePath = Path.Combine(_directoryWithImages, "BarcodeEAN13.png");
+        var result = await BarCode.ReadAsync(filePath);
         Assert.True(result.Message == "9012341234571");
         using var stream = File.Open(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
     }


### PR DESCRIPTION
## Summary
- add `ReadAsync` barcode reader using Image.LoadAsync and retain sync wrapper
- verify async read path via new xUnit test
- demonstrate async barcode reading in examples

## Testing
- `dotnet test Sources/ImagePlayground.sln` *(failed: Failed to negotiate protocol, waiting for response timed out after 90 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_689b43bd758c832ead9e41ca68f0694c