### PR TITLE
fix(qrcode): validate pixel size parameter

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -47,6 +48,10 @@ public sealed class NewImageQrCodeCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCode - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -62,6 +63,10 @@ public sealed class NewImageQrCodeBezahlCodeCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeBezahlCode - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -54,6 +55,10 @@ public sealed class NewImageQrCodeBitcoinCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeBitcoin - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -42,6 +43,10 @@ public sealed class NewImageQrCodeGeoLocationCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeGeoLocation - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -54,6 +55,10 @@ public sealed class NewImageQrCodeGirocodeCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeGirocode - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -54,6 +55,10 @@ public sealed class NewImageQrCodeMoneroCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeMonero - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -38,6 +39,10 @@ public sealed class NewImageQrCodeOtpCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeOtp - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -38,6 +39,10 @@ public sealed class NewImageQrCodePhoneNumberCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodePhoneNumber - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -54,6 +55,10 @@ public sealed class NewImageQrCodeShadowSocksCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeShadowSocks - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -38,6 +39,10 @@ public sealed class NewImageQrCodeSkypeCallCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeSkypeCall - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -38,6 +39,10 @@ public sealed class NewImageQrCodeSlovenianUpnQrCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeSlovenianUpnQr - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -42,6 +43,10 @@ public sealed class NewImageQrCodeSmsCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeSms - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -38,6 +39,10 @@ public sealed class NewImageQrCodeSwissCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeSwiss - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
@@ -1,3 +1,4 @@
+using System;
 using ImagePlayground;
 using QRCoder;
 using System.IO;
@@ -43,6 +44,10 @@ public sealed class NewImageQrCodeWiFiCmdlet : PSCmdlet {
 
     /// <inheritdoc />
     protected override void ProcessRecord() {
+        if (PixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(PixelSize));
+        }
+
         if (string.IsNullOrWhiteSpace(FilePath)) {
             FilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Split('.')[0] + ".png");
             WriteWarning($"New-ImageQRCodeWiFi - No file path specified, saving to {FilePath}");

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -25,6 +25,10 @@ public class QrCode {
     /// <param name="backgroundColor">Background color of the QR code.</param>
     /// <param name="pixelSize">Pixel size for each QR module.</param>
     public static void Generate(string content, string filePath, bool transparent = false, QRCodeGenerator.ECCLevel eccLevel = QRCodeGenerator.ECCLevel.Q, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
+        if (pixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(pixelSize));
+        }
+
         string fullPath = Helpers.ResolvePath(filePath);
 
         FileInfo fileInfo = new FileInfo(fullPath);
@@ -67,6 +71,10 @@ public class QrCode {
     /// <param name="backgroundColor">Background color of the QR code.</param>
     /// <param name="pixelSize">Pixel size for each QR module.</param>
     public static void Generate(string content, string filePath, string logoPath, bool transparent = false, QRCodeGenerator.ECCLevel eccLevel = QRCodeGenerator.ECCLevel.Q, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
+        if (pixelSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(pixelSize));
+        }
+
         string fullPath = Helpers.ResolvePath(filePath);
         string fullLogoPath = Helpers.ResolvePath(logoPath);
 

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Net;
 using Xunit;
@@ -144,5 +145,13 @@ public partial class ImagePlayground {
 
         byte[] logoBytes = File.ReadAllBytes(filePath);
         Assert.NotEqual(baseBytes, logoBytes);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void Test_QRCode_InvalidPixelSize(int pixelSize) {
+        string filePath = Path.Combine(_directoryWithImages, "QRCodeInvalid.png");
+        Assert.Throws<ArgumentOutOfRangeException>(() => QrCode.Generate("https://evotec.xyz", filePath, false, QRCodeGenerator.ECCLevel.Q, null, null, pixelSize));
     }
 }

--- a/Tests/New-ImageQRCode.Tests.ps1
+++ b/Tests/New-ImageQRCode.Tests.ps1
@@ -52,5 +52,9 @@ Describe 'New-ImageQRCode' {
 
     }
 
+    It 'throws on invalid pixel size' {
+        { New-ImageQRCode -Content 'https://evotec.xyz' -FilePath (Join-Path $TestDir 'qr_invalid.png') -PixelSize 0 } | Should -Throw
+    }
+
 }
 

--- a/Tests/New-ImageQRCodeAdditional.Tests.ps1
+++ b/Tests/New-ImageQRCodeAdditional.Tests.ps1
@@ -28,4 +28,16 @@ describe 'New-ImageQRCode additional cmdlets' {
         Test-Path $file | Should -BeTrue
         (Get-ImageQRCode -FilePath $file).Message | Should -Match 'bitcoin:'
     }
+
+    It 'throws on invalid pixel size for Sms' {
+        { New-ImageQRCodeSms -Number '+1234567890' -Message 'Hello' -FilePath (Join-Path $TestDir 'sms_invalid.png') -PixelSize 0 } | Should -Throw
+    }
+
+    It 'throws on invalid pixel size for GeoLocation' {
+        { New-ImageQRCodeGeoLocation -Latitude '52.1' -Longitude '21.0' -FilePath (Join-Path $TestDir 'geo_invalid.png') -PixelSize 0 } | Should -Throw
+    }
+
+    It 'throws on invalid pixel size for Bitcoin' {
+        { New-ImageQRCodeBitcoin -Currency Bitcoin -Address '1BoatSLRHtKNngkdXEeobR76b53LETtpyT' -Amount 0.01 -FilePath (Join-Path $TestDir 'btc_invalid.png') -PixelSize 0 } | Should -Throw
+    }
 }

--- a/Tests/New-ImageQRCodeWiFi.Tests.ps1
+++ b/Tests/New-ImageQRCodeWiFi.Tests.ps1
@@ -50,5 +50,9 @@ Describe 'New-ImageQRCodeWiFi password quoting' {
         Test-Path $file | Should -BeTrue
         (Get-ImageQRCode -FilePath $file).Message | Should -Be 'WIFI:T:WPA;S:Test;P:pass123;;'
     }
+
+    It 'throws on invalid pixel size' {
+        { New-ImageQRCodeWiFi -SSID 'Test' -Password '12345678' -FilePath (Join-Path $TestDrive 'wifi_invalid.png') -PixelSize 0 } | Should -Throw
+    }
 }
 

--- a/Tests/New-ImageQRContact.Tests.ps1
+++ b/Tests/New-ImageQRContact.Tests.ps1
@@ -14,4 +14,8 @@ Describe 'New-ImageQRContact' {
         Test-Path $file | Should -BeTrue
         (Get-ImageQRCode -FilePath $file).Message | Should -Match 'BEGIN:VCARD'
     }
+
+    It 'throws on invalid pixel size' {
+        { New-ImageQRContact -FilePath (Join-Path $TestDir 'contact_invalid.png') -Firstname 'John' -Lastname 'Doe' -PixelSize 0 } | Should -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `pixelSize` is positive in QR code generation helpers and cmdlets
- add unit and Pester tests covering invalid `pixelSize`

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0 --no-build`
- `pwsh ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_689b5a480454832eb1e7692f26b1d914