### PR TITLE
Handle unsupported barcode types

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System;
+using System.IO;
 using Barcoder;
 using Barcoder.Code128;
 using Barcoder.Code39;
@@ -156,7 +157,10 @@ public class BarCode {
             BarcodeType.PDF417 => () => GeneratePdf417(content, filePath),
             _ => null
         };
-        generator?.Invoke();
+        if (generator is null) {
+            throw new ArgumentOutOfRangeException(nameof(barcodeType), barcodeType, "Unsupported barcode type.");
+        }
+        generator();
     }
 
     /// <summary>

--- a/Sources/ImagePlayground.Tests/BarCodeInvalid.cs
+++ b/Sources/ImagePlayground.Tests/BarCodeInvalid.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for invalid BarCode generation.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_BarCode_Generate_InvalidType_Throws() {
+        string filePath = Path.Combine(_directoryWithTests, "barcode_invalid.png");
+        Assert.Throws<ArgumentOutOfRangeException>(() => BarCode.Generate((BarcodeType)999, "invalid", filePath));
+    }
+}
+


### PR DESCRIPTION
## Summary
- throw `ArgumentOutOfRangeException` when `BarCode.Generate` receives an unsupported type
- cover unsupported barcode type with a negative unit test

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj` *(fails: Could not find 'mono' host)*
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689b5a2c2d04832ea81651a8716ebceb