### PR TITLE
fix(core): 🐛 handle relative output paths in ConvertTo

### DIFF
--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -29,7 +29,7 @@ public partial class ImageHelper {
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
         using (var inStream = System.IO.File.OpenRead(fullPath))
         using (SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream)) {
-            FileInfo fileInfo = new FileInfo(outFilePath);
+            FileInfo fileInfo = new FileInfo(outFullPath);
             if (fileInfo.Extension == ".ico") {
                 if (System.IO.Path.GetExtension(fullPath).Equals(".ico", StringComparison.OrdinalIgnoreCase)) {
                     System.IO.File.Copy(fullPath, outFullPath, true);

--- a/Sources/ImagePlayground.Tests/ConvertToRelativePath.cs
+++ b/Sources/ImagePlayground.Tests/ConvertToRelativePath.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for relative output paths in ConvertTo.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public void Test_ConvertTo_RelativeOutputPath_CreatesFile() {
+        string src = Path.Combine(_directoryWithImages, "QRCode1.png");
+        string relativeDir = Path.Combine("Tests", "relative");
+        string relativePath = Path.Combine(relativeDir, "converted.jpg");
+        if (File.Exists(relativePath)) File.Delete(relativePath);
+        if (Directory.Exists(relativeDir)) Directory.Delete(relativeDir, true);
+
+        ImageHelper.ConvertTo(src, relativePath);
+        string expectedFullPath = Path.GetFullPath(relativePath);
+        Assert.True(File.Exists(expectedFullPath));
+    }
+}


### PR DESCRIPTION
## Summary
- use resolved output path when creating FileInfo in `ConvertTo`
- test handling of relative output paths

## Testing
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0`
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net472` *(fails: Failed to negotiate protocol, waiting for response timed out after 90 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_689b5a2689b8832e9578dc09dc1657c5