### PR TITLE
docs: expand XML comments for QrCode and ImageHelper

### DIFF
--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -45,14 +45,21 @@ public partial class ImageHelper {
 
     /// <summary>
     /// Resizes an image to the specified width and height.
-    /// Following image formats are supported: GIF, JPEG, PNG, JFIF, GIF
+    /// Following image formats are supported: GIF, JPEG, PNG and JFIF.
     /// </summary>
-    /// <param name="filePath"></param>
-    /// <param name="outFilePath"></param>
-    /// <param name="width"></param>
-    /// <param name="height"></param>
-    /// <param name="keepAspectRatio"></param>
-    /// <param name="sampler"></param>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <param name="outFilePath">Path where the resized image will be saved.</param>
+    /// <param name="width">Desired width or <c>null</c> to calculate automatically.</param>
+    /// <param name="height">Desired height or <c>null</c> to calculate automatically.</param>
+    /// <param name="keepAspectRatio">Preserve the original aspect ratio if <c>true</c>.</param>
+    /// <param name="sampler">Optional resampling algorithm to use.</param>
+    /// <remarks>
+    /// When <paramref name="keepAspectRatio"/> is <c>true</c> and one dimension is unspecified,
+    /// the missing dimension is calculated to maintain the aspect ratio.
+    /// </remarks>
+    /// <example>
+    ///   <code>ImageHelper.Resize("input.png", "output.png", 200, 100);</code>
+    /// </example>
     public static void Resize(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
         if (width.HasValue && width.Value <= 0) {
             throw new ArgumentOutOfRangeException(nameof(width), "Width must be greater than 0.");
@@ -74,6 +81,19 @@ public partial class ImageHelper {
     /// <summary>
     /// Asynchronously resizes an image to the specified width and height.
     /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <param name="outFilePath">Path where the resized image will be saved.</param>
+    /// <param name="width">Desired width or <c>null</c> to calculate automatically.</param>
+    /// <param name="height">Desired height or <c>null</c> to calculate automatically.</param>
+    /// <param name="keepAspectRatio">Preserve the original aspect ratio if <c>true</c>.</param>
+    /// <param name="sampler">Optional resampling algorithm to use.</param>
+    /// <returns>A task that represents the asynchronous resize operation.</returns>
+    /// <remarks>
+    /// This method offloads the processing to a background task, which can improve responsiveness in UI applications.
+    /// </remarks>
+    /// <example>
+    ///   <code>await ImageHelper.ResizeAsync("in.jpg", "out.jpg", 400, 300);</code>
+    /// </example>
     public static async Task ResizeAsync(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
@@ -141,9 +161,12 @@ public partial class ImageHelper {
     /// <summary>
     /// Resizes an image to the specified percentage.
     /// </summary>
-    /// <param name="filePath"></param>
-    /// <param name="outFilePath"></param>
-    /// <param name="percentage"></param>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <param name="outFilePath">Path where the resized image will be saved.</param>
+    /// <param name="percentage">Scale factor expressed as a percentage.</param>
+    /// <example>
+    ///   <code>ImageHelper.Resize("in.png", "out.png", 50);</code>
+    /// </example>
     public static void Resize(string filePath, string outFilePath, int percentage) {
         if (percentage <= 0) {
             throw new ArgumentOutOfRangeException(nameof(percentage));
@@ -165,6 +188,13 @@ public partial class ImageHelper {
     /// <summary>
     /// Asynchronously resizes an image to the specified percentage.
     /// </summary>
+    /// <param name="filePath">Path to the source image.</param>
+    /// <param name="outFilePath">Path where the resized image will be saved.</param>
+    /// <param name="percentage">Scale factor expressed as a percentage.</param>
+    /// <returns>A task that represents the asynchronous resize operation.</returns>
+    /// <example>
+    ///   <code>await ImageHelper.ResizeAsync("in.jpg", "out.jpg", 75);</code>
+    /// </example>
     public static async Task ResizeAsync(string filePath, string outFilePath, int percentage) {
         if (percentage <= 0) {
             throw new ArgumentOutOfRangeException(nameof(percentage));

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -191,6 +191,34 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code containing contact information in vCard format.
     /// </summary>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="outputType">Format of the contact payload.</param>
+    /// <param name="firstname">Contact first name.</param>
+    /// <param name="lastname">Contact last name.</param>
+    /// <param name="nickname">Optional nickname.</param>
+    /// <param name="phone">Primary phone number.</param>
+    /// <param name="mobilePhone">Mobile phone number.</param>
+    /// <param name="workPhone">Work phone number.</param>
+    /// <param name="email">Email address.</param>
+    /// <param name="birthday">Birth date of the contact.</param>
+    /// <param name="website">Website URL.</param>
+    /// <param name="street">Street name.</param>
+    /// <param name="houseNumber">House number.</param>
+    /// <param name="city">City or town.</param>
+    /// <param name="zipCode">Postal code.</param>
+    /// <param name="country">Country name.</param>
+    /// <param name="note">Additional notes.</param>
+    /// <param name="stateRegion">State or region.</param>
+    /// <param name="addressOrder">Ordering of address components.</param>
+    /// <param name="org">Organization name.</param>
+    /// <param name="orgTitle">Organization title.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateContact("contact.png", PayloadGenerator.ContactData.ContactOutputType.MeCard, "John", "Doe");</code>
+    /// </example>
     public static void GenerateContact(string filePath, PayloadGenerator.ContactData.ContactOutputType outputType, string firstname, string lastname, string nickname = null, string phone = null, string mobilePhone = null, string workPhone = null, string email = null, DateTime? birthday = null, string website = null, string street = null, string houseNumber = null, string city = null, string zipCode = null, string country = null, string note = null, string stateRegion = null, PayloadGenerator.ContactData.AddressOrder addressOrder = PayloadGenerator.ContactData.AddressOrder.Default, string org = null, string orgTitle = null, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         PayloadGenerator.ContactData generator = new PayloadGenerator.ContactData(outputType, firstname, lastname, nickname, phone, mobilePhone, workPhone, email, birthday, website, street, houseNumber, city, zipCode, country, note, stateRegion, addressOrder, org, orgTitle);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -199,6 +227,18 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code that opens an email draft.
     /// </summary>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="email">Recipient email address.</param>
+    /// <param name="subject">Optional message subject.</param>
+    /// <param name="message">Optional message body.</param>
+    /// <param name="encoding">Mail encoding scheme.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateEmail("email.png", "user@example.com", "Hello", "Body");</code>
+    /// </example>
     public static void GenerateEmail(string filePath, string email, string subject = null, string message = null, PayloadGenerator.Mail.MailEncoding encoding = PayloadGenerator.Mail.MailEncoding.MAILTO, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         PayloadGenerator.Mail generator = new PayloadGenerator.Mail(email, subject, message, encoding);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -207,6 +247,17 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code that opens the messaging app with an MMS draft.
     /// </summary>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="phoneNumber">Recipient phone number.</param>
+    /// <param name="subject">Subject line for the MMS message.</param>
+    /// <param name="encoding">MMS encoding scheme.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateMMS("mms.png", "+123456789", "Hi");</code>
+    /// </example>
     public static void GenerateMMS(string filePath, string phoneNumber, string subject = "", PayloadGenerator.MMS.MMSEncoding encoding = PayloadGenerator.MMS.MMSEncoding.MMSTO, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = subject == "" ? new PayloadGenerator.MMS(phoneNumber, encoding) : new PayloadGenerator.MMS(phoneNumber, subject, encoding);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -215,6 +266,17 @@ public class QrCode {
     /// <summary>
     /// Creates a QR code that launches the SMS application.
     /// </summary>
+    /// <param name="number">Phone number to message.</param>
+    /// <param name="message">Optional message body.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="encoding">SMS encoding type.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateSms("+123456789", "Hello", "sms.png");</code>
+    /// </example>
     public static void GenerateSms(string number, string? message, string filePath, PayloadGenerator.SMS.SMSEncoding encoding = PayloadGenerator.SMS.SMSEncoding.SMS, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = string.IsNullOrEmpty(message)
             ? new PayloadGenerator.SMS(number, encoding)
@@ -225,6 +287,17 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code representing a geographic location.
     /// </summary>
+    /// <param name="latitude">Latitude coordinate.</param>
+    /// <param name="longitude">Longitude coordinate.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="encoding">Geolocation encoding scheme.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateGeoLocation("46.0569", "14.5058", "geo.png");</code>
+    /// </example>
     public static void GenerateGeoLocation(string latitude, string longitude, string filePath, PayloadGenerator.Geolocation.GeolocationEncoding encoding = PayloadGenerator.Geolocation.GeolocationEncoding.GEO, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.Geolocation(latitude, longitude, encoding);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -233,6 +306,24 @@ public class QrCode {
     /// <summary>
     /// Creates a Girocode compliant QR code for SEPA credit transfers.
     /// </summary>
+    /// <param name="iban">IBAN of the receiver.</param>
+    /// <param name="bic">BIC of the receiver.</param>
+    /// <param name="name">Name of the receiver.</param>
+    /// <param name="amount">Transfer amount.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="remittanceInformation">Remittance information.</param>
+    /// <param name="type">Type of remittance information.</param>
+    /// <param name="purposeOfCreditTransfer">Purpose of the credit transfer.</param>
+    /// <param name="messageToGirocodeUser">Message displayed to the user.</param>
+    /// <param name="version">Girocode version.</param>
+    /// <param name="encoding">Character encoding.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateGirocode("DE02120300000000202051", "BYLADEM1001", "ACME", 10m, "giro.png");</code>
+    /// </example>
     public static void GenerateGirocode(string iban, string bic, string name, decimal amount, string filePath, string? remittanceInformation = null, PayloadGenerator.Girocode.TypeOfRemittance type = PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, string? purposeOfCreditTransfer = null, string? messageToGirocodeUser = null, PayloadGenerator.Girocode.GirocodeVersion version = PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding encoding = PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.Girocode(iban, bic, name, amount, remittanceInformation ?? string.Empty, type, purposeOfCreditTransfer ?? string.Empty, messageToGirocodeUser ?? string.Empty, version, encoding);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -241,6 +332,19 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code for Bitcoin-like cryptocurrency payments.
     /// </summary>
+    /// <param name="currency">Cryptocurrency type.</param>
+    /// <param name="address">Destination address.</param>
+    /// <param name="amount">Optional transfer amount.</param>
+    /// <param name="label">Optional label.</param>
+    /// <param name="message">Optional message.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateBitcoinAddress(PayloadGenerator.BitcoinLikeCryptoCurrencyAddress.BitcoinLikeCryptoCurrencyType.Bitcoin, "addr", 0.5, null, null, "btc.png");</code>
+    /// </example>
     public static void GenerateBitcoinAddress(PayloadGenerator.BitcoinLikeCryptoCurrencyAddress.BitcoinLikeCryptoCurrencyType currency, string address, double? amount, string? label, string? message, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.BitcoinLikeCryptoCurrencyAddress(currency, address, amount, label, message);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -249,6 +353,19 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code for a Monero transfer.
     /// </summary>
+    /// <param name="address">Destination address.</param>
+    /// <param name="amount">Optional transfer amount.</param>
+    /// <param name="paymentId">Optional payment identifier.</param>
+    /// <param name="recipientName">Name of the recipient.</param>
+    /// <param name="description">Transaction description.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateMoneroTransaction("addr", 1.0f, null, null, null, "xmr.png");</code>
+    /// </example>
     public static void GenerateMoneroTransaction(string address, float? amount, string? paymentId, string? recipientName, string? description, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.MoneroTransaction(address, amount, paymentId, recipientName, description);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -257,6 +374,15 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code that initiates a phone call.
     /// </summary>
+    /// <param name="number">Phone number to call.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GeneratePhoneNumber("+123456789", "phone.png");</code>
+    /// </example>
     public static void GeneratePhoneNumber(string number, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.PhoneNumber(number);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -265,6 +391,15 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code that starts a Skype call.
     /// </summary>
+    /// <param name="username">Skype username.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateSkypeCall("user", "skype.png");</code>
+    /// </example>
     public static void GenerateSkypeCall(string username, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.SkypeCall(username);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -273,6 +408,19 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code containing Shadowsocks configuration settings.
     /// </summary>
+    /// <param name="hostname">Server hostname.</param>
+    /// <param name="port">Server port.</param>
+    /// <param name="password">Connection password.</param>
+    /// <param name="method">Encryption method.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="tag">Optional connection tag.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateShadowSocks("host", 8388, "pass", PayloadGenerator.ShadowSocksConfig.Method.AES_256_GCM, "ss.png");</code>
+    /// </example>
     public static void GenerateShadowSocks(string hostname, int port, string password, PayloadGenerator.ShadowSocksConfig.Method method, string filePath, string? tag = null, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.ShadowSocksConfig(hostname, port, password, method, tag);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -281,6 +429,15 @@ public class QrCode {
     /// <summary>
     /// Generates a QR code for configuring a one-time password generator.
     /// </summary>
+    /// <param name="otp">Payload with OTP configuration.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateOneTimePassword(otp, "otp.png");</code>
+    /// </example>
     public static void GenerateOneTimePassword(PayloadGenerator.OneTimePassword otp, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         Generate(otp.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
@@ -289,6 +446,15 @@ public class QrCode {
     /// <summary>
     /// Generates a Slovenian UPN QR payment code.
     /// </summary>
+    /// <param name="upn">Payload with Slovenian UPN payment details.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateSlovenianUpnQr(upn, "upn.png");</code>
+    /// </example>
     public static void GenerateSlovenianUpnQr(PayloadGenerator.SlovenianUpnQr upn, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         Generate(upn.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
@@ -296,6 +462,21 @@ public class QrCode {
     /// <summary>
     /// Generates a German BezahlCode payment QR code.
     /// </summary>
+    /// <param name="authority">Authority type.</param>
+    /// <param name="name">Creditor name.</param>
+    /// <param name="account">Account number.</param>
+    /// <param name="bnc">Bank number.</param>
+    /// <param name="iban">IBAN of the creditor.</param>
+    /// <param name="bic">BIC of the creditor.</param>
+    /// <param name="reason">Payment reason.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateBezahlCode(PayloadGenerator.BezahlCode.AuthorityType.Person, "John", "123", "10020030", "DE89...", "BICCODE", "Invoice", "bezahl.png");</code>
+    /// </example>
     public static void GenerateBezahlCode(PayloadGenerator.BezahlCode.AuthorityType authority, string name, string account, string bnc, string iban, string bic, string reason, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         var generator = new PayloadGenerator.BezahlCode(authority, name, account, bnc, iban, bic, reason);
         Generate(generator.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
@@ -304,6 +485,15 @@ public class QrCode {
     /// <summary>
     /// Generates a Swiss QR invoice code.
     /// </summary>
+    /// <param name="swiss">Swiss QR code payload.</param>
+    /// <param name="filePath">Destination image path.</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="foregroundColor">Foreground color of QR modules.</param>
+    /// <param name="backgroundColor">Background color of the QR code.</param>
+    /// <param name="pixelSize">Pixel size for each QR module.</param>
+    /// <example>
+    ///   <code>QrCode.GenerateSwissQrCode(swissPayload, "swiss.png");</code>
+    /// </example>
     public static void GenerateSwissQrCode(PayloadGenerator.SwissQrCode swiss, string filePath, bool transparent = false, Color? foregroundColor = null, Color? backgroundColor = null, int pixelSize = 20) {
         Generate(swiss.ToString(), filePath, transparent, QRCodeGenerator.ECCLevel.Q, foregroundColor, backgroundColor, pixelSize);
     }
@@ -311,6 +501,11 @@ public class QrCode {
     /// <summary>
     /// Reads a QR code image and returns the decoded payload.
     /// </summary>
+    /// <param name="filePath">Path to the QR code image.</param>
+    /// <returns>Decoded barcode result.</returns>
+    /// <example>
+    ///   <code>var result = QrCode.Read("code.png");</code>
+    /// </example>
     public static BarcodeResult<Rgba32> Read(string filePath) {
         string fullPath = Helpers.ResolvePath(filePath);
 
@@ -329,6 +524,9 @@ public class QrCode {
     /// <summary>
     /// Saves an ImageSharp image as an ICO file with multiple resolutions.
     /// </summary>
+    /// <param name="image">Image to save.</param>
+    /// <param name="filePath">Destination ICO file path.</param>
+    /// <param name="sizes">Icon sizes to include.</param>
     private static void SaveImageAsIcon(SixLabors.ImageSharp.Image image, string filePath, params int[] sizes) {
         if (sizes == null || sizes.Length == 0) {
             sizes = new[] { 16, 32, 48, 64, 128, 256 };


### PR DESCRIPTION
## Summary
- document resize helpers with detailed XML comments and examples
- add missing parameter docs for many QrCode helpers

## Testing
- `dotnet build Sources/ImagePlayground.sln` *(fails: warnings about null reference arguments but build completed)*

------
https://chatgpt.com/codex/tasks/task_e_689b77a24c54832ea238d1b3cab77345