### PR TITLE
fix(qrcode): ensure QR saves handle directories

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
@@ -57,11 +57,10 @@ public sealed class NewImageQrCodeCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCode - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.Generate(Content, output, Transparent.IsPresent, QRCodeGenerator.ECCLevel.Q, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.Generate(Content, FilePath, Transparent.IsPresent, QRCodeGenerator.ECCLevel.Q, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
@@ -72,11 +72,10 @@ public sealed class NewImageQrCodeBezahlCodeCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeBezahlCode - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateBezahlCode(Authority, Name, Account, Bnc, Iban, Bic, Reason, output, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateBezahlCode(Authority, Name, Account, Bnc, Iban, Bic, Reason, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
@@ -64,11 +64,10 @@ public sealed class NewImageQrCodeBitcoinCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeBitcoin - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateBitcoinAddress(Currency, Address, Amount, Label, Message, output, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateBitcoinAddress(Currency, Address, Amount, Label, Message, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
@@ -52,11 +52,10 @@ public sealed class NewImageQrCodeGeoLocationCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeGeoLocation - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateGeoLocation(Latitude, Longitude, output, PayloadGenerator.Geolocation.GeolocationEncoding.GEO, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateGeoLocation(Latitude, Longitude, FilePath, PayloadGenerator.Geolocation.GeolocationEncoding.GEO, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
@@ -64,11 +64,10 @@ public sealed class NewImageQrCodeGirocodeCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeGirocode - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateGirocode(Iban, Bic, Name, Amount, output, RemittanceInformation, PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, null, null, PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateGirocode(Iban, Bic, Name, Amount, FilePath, RemittanceInformation, PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, null, null, PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
@@ -64,11 +64,10 @@ public sealed class NewImageQrCodeMoneroCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeMonero - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateMoneroTransaction(Address, Amount, PaymentId, RecipientName, Description, output, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateMoneroTransaction(Address, Amount, PaymentId, RecipientName, Description, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
@@ -48,11 +48,10 @@ public sealed class NewImageQrCodeOtpCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeOtp - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateOneTimePassword(Payload, output, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateOneTimePassword(Payload, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
@@ -48,11 +48,10 @@ public sealed class NewImageQrCodePhoneNumberCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodePhoneNumber - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GeneratePhoneNumber(Number, output, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GeneratePhoneNumber(Number, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
@@ -64,11 +64,10 @@ public sealed class NewImageQrCodeShadowSocksCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeShadowSocks - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateShadowSocks(Host, Port, Password, Method, output, Tag, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateShadowSocks(Host, Port, Password, Method, FilePath, Tag, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
@@ -48,11 +48,10 @@ public sealed class NewImageQrCodeSkypeCallCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeSkypeCall - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateSkypeCall(UserName, output, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateSkypeCall(UserName, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
@@ -48,11 +48,10 @@ public sealed class NewImageQrCodeSlovenianUpnQrCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeSlovenianUpnQr - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateSlovenianUpnQr(Payload, output, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateSlovenianUpnQr(Payload, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
@@ -52,11 +52,10 @@ public sealed class NewImageQrCodeSmsCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeSms - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateSms(Number, Message, output, PayloadGenerator.SMS.SMSEncoding.SMS, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateSms(Number, Message, FilePath, PayloadGenerator.SMS.SMSEncoding.SMS, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
@@ -48,11 +48,10 @@ public sealed class NewImageQrCodeSwissCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeSwiss - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateSwissQrCode(Payload, output, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateSwissQrCode(Payload, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
@@ -53,11 +53,10 @@ public sealed class NewImageQrCodeWiFiCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeWiFi - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateWiFi(SSID, Password, output, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateWiFi(SSID, Password, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
@@ -119,11 +119,10 @@ public sealed class NewImageQrContactCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRContact - No file path specified, saving to {FilePath}");
         }
 
-        var output = Helpers.ResolvePath(FilePath);
-        ImagePlayground.QrCode.GenerateContact(output, OutputType, Firstname ?? string.Empty, Lastname ?? string.Empty, Nickname, Phone, MobilePhone, WorkPhone, Email, Birthday, Website, Street, HouseNumber, City, ZipCode, Country, Note, StateRegion, AddressOrder, Org, OrgTitle, false, ForegroundColor, BackgroundColor, PixelSize);
+        ImagePlayground.QrCode.GenerateContact(FilePath, OutputType, Firstname ?? string.Empty, Lastname ?? string.Empty, Nickname, Phone, MobilePhone, WorkPhone, Email, Birthday, Website, Street, HouseNumber, City, ZipCode, Country, Note, StateRegion, AddressOrder, Org, OrgTitle, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(output, true);
+            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
         }
     }
 }

--- a/Sources/ImagePlayground.QRCode/QRCode.cs
+++ b/Sources/ImagePlayground.QRCode/QRCode.cs
@@ -39,6 +39,7 @@ public class QrCode {
                     Color dark = foregroundColor ?? Color.Black;
                     Color light = transparent ? Color.Transparent : (backgroundColor ?? Color.White);
                     using (var qrCodeImage = qrCode.GetGraphic(pixelSize, dark, light, true)) {
+                        Helpers.CreateParentDirectory(fullPath);
                         switch (fileInfo.Extension.ToLowerInvariant()) {
                             case ".png":
                                 qrCodeImage.SaveAsPng(fullPath);
@@ -97,6 +98,7 @@ public class QrCode {
                             qrCodeImage.Mutate(ctx => ctx.DrawImage(logo, new Point(posX, posY), 1f));
                         }
 
+                        Helpers.CreateParentDirectory(fullPath);
                         string extension = fileInfo.Extension.ToLowerInvariant();
                         Action saveAction = extension switch {
                             ".png" => () => qrCodeImage.SaveAsPng(fullPath),
@@ -528,6 +530,7 @@ public class QrCode {
     /// <param name="filePath">Destination ICO file path.</param>
     /// <param name="sizes">Icon sizes to include.</param>
     private static void SaveImageAsIcon(SixLabors.ImageSharp.Image image, string filePath, params int[] sizes) {
+        Helpers.CreateParentDirectory(filePath);
         if (sizes == null || sizes.Length == 0) {
             sizes = new[] { 16, 32, 48, 64, 128, 256 };
         }

--- a/Tests/New-ImageQRCode.Tests.ps1
+++ b/Tests/New-ImageQRCode.Tests.ps1
@@ -26,6 +26,22 @@ Describe 'New-ImageQRCode' {
 
     }
 
+    It 'creates QR code in current directory' {
+
+        $file = 'qr_current.png'
+
+        if (Test-Path -Path $file) { Remove-Item -Path $file }
+
+        New-ImageQRCode -Content 'https://evotec.xyz' -FilePath $file
+
+        Test-Path -Path $file | Should -BeTrue
+
+        (Get-ImageQRCode -FilePath $file).Message | Should -Be 'https://evotec.xyz'
+
+        Remove-Item -Path $file
+
+    }
+
     It 'creates QR code with custom colors' {
 
         $file = Join-Path $TestDir 'qr_custom.png'


### PR DESCRIPTION
## Summary
- ensure QR saves create destination directories
- simplify QR cmdlets to rely on internal path resolution
- cover saving QR to current directory with a new Pester test

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh ./ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_689b8d417a9c832eb9bd9f527c05530d