### PR TITLE
feat: add cancellation tokens to async image ops

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -168,10 +168,10 @@ public class BarCode {
     /// </summary>
     /// <param name="filePath">Path to the barcode image.</param>
     /// <returns>A task containing the decoded barcode result.</returns>
-    public static async Task<BarcodeResult<Rgba32>> ReadAsync(string filePath) {
+    public static async Task<BarcodeResult<Rgba32>> ReadAsync(string filePath, CancellationToken cancellationToken = default) {
         string fullPath = Helpers.ResolvePath(filePath);
 
-        using Image<Rgba32> barcodeImage = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fullPath).ConfigureAwait(false);
+        using Image<Rgba32> barcodeImage = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fullPath, cancellationToken).ConfigureAwait(false);
         BarcodeReader.ImageSharp.BarcodeReader<Rgba32> reader = new(types: new[] { ZXing.BarcodeFormat.All_1D, ZXing.BarcodeFormat.DATA_MATRIX, ZXing.BarcodeFormat.PDF_417 });
         BarcodeResult<Rgba32> response = reader.Decode(barcodeImage);
         response.Image?.Dispose();

--- a/Sources/ImagePlayground.Core/ImageHelper.Rotate.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Rotate.cs
@@ -41,28 +41,24 @@ public partial class ImageHelper {
     /// <summary>
     /// Asynchronously rotates an image using a <see cref="RotateMode"/>.
     /// </summary>
-    public static async Task RotateAsync(string filePath, string outFilePath, RotateMode rotateMode) {
+    public static async Task RotateAsync(string filePath, string outFilePath, RotateMode rotateMode, CancellationToken cancellationToken = default) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(Path.GetDirectoryName(outFullPath)!);
-        await Task.Run(() => {
-            using var img = Image.Load(fullPath);
-            img.Rotate(rotateMode);
-            img.Save(outFullPath);
-        }).ConfigureAwait(false);
+        using SixLabors.ImageSharp.Image img = await SixLabors.ImageSharp.Image.LoadAsync(fullPath, cancellationToken).ConfigureAwait(false);
+        img.Mutate(x => x.Rotate(rotateMode));
+        await img.SaveAsync(outFullPath, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Asynchronously rotates an image by an arbitrary number of <paramref name="degrees"/>.
     /// </summary>
-    public static async Task RotateAsync(string filePath, string outFilePath, float degrees) {
+    public static async Task RotateAsync(string filePath, string outFilePath, float degrees, CancellationToken cancellationToken = default) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(Path.GetDirectoryName(outFullPath)!);
-        await Task.Run(() => {
-            using var img = Image.Load(fullPath);
-            img.Rotate(degrees);
-            img.Save(outFullPath);
-        }).ConfigureAwait(false);
+        using SixLabors.ImageSharp.Image img = await SixLabors.ImageSharp.Image.LoadAsync(fullPath, cancellationToken).ConfigureAwait(false);
+        img.Mutate(x => x.Rotate(degrees));
+        await img.SaveAsync(outFullPath, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -94,17 +94,15 @@ public partial class ImageHelper {
     /// <example>
     ///   <code>await ImageHelper.ResizeAsync("in.jpg", "out.jpg", 400, 300);</code>
     /// </example>
-    public static async Task ResizeAsync(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null) {
+    public static async Task ResizeAsync(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null, CancellationToken cancellationToken = default) {
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
-        await Task.Run(() => {
-            using var inStream = System.IO.File.OpenRead(fullPath);
-            using SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream);
-            Resize(image, width, height, keepAspectRatio, sampler);
-            image.Save(outFullPath);
-        }).ConfigureAwait(false);
+        using var inStream = System.IO.File.OpenRead(fullPath);
+        using SixLabors.ImageSharp.Image image = await SixLabors.ImageSharp.Image.LoadAsync(inStream, cancellationToken).ConfigureAwait(false);
+        Resize(image, width, height, keepAspectRatio, sampler);
+        await image.SaveAsync(outFullPath, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -195,7 +193,7 @@ public partial class ImageHelper {
     /// <example>
     ///   <code>await ImageHelper.ResizeAsync("in.jpg", "out.jpg", 75);</code>
     /// </example>
-    public static async Task ResizeAsync(string filePath, string outFilePath, int percentage) {
+    public static async Task ResizeAsync(string filePath, string outFilePath, int percentage, CancellationToken cancellationToken = default) {
         if (percentage <= 0) {
             throw new ArgumentOutOfRangeException(nameof(percentage));
         }
@@ -204,14 +202,12 @@ public partial class ImageHelper {
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
 
-        await Task.Run(() => {
-            using var inStream = System.IO.File.OpenRead(fullPath);
-            using SixLabors.ImageSharp.Image image = SixLabors.ImageSharp.Image.Load(inStream);
-            int width = image.Width * percentage / 100;
-            int height = image.Height * percentage / 100;
-            Resize(image, width, height, false);
-            image.Save(outFullPath);
-        }).ConfigureAwait(false);
+        using var inStream = System.IO.File.OpenRead(fullPath);
+        using SixLabors.ImageSharp.Image image = await SixLabors.ImageSharp.Image.LoadAsync(inStream, cancellationToken).ConfigureAwait(false);
+        int width = image.Width * percentage / 100;
+        int height = image.Height * percentage / 100;
+        Resize(image, width, height, false);
+        await image.SaveAsync(outFullPath, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Sources/ImagePlayground.Examples/Example.BarCode.cs
+++ b/Sources/ImagePlayground.Examples/Example.BarCode.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ImagePlayground.Examples;
@@ -69,10 +70,10 @@ internal partial class Example {
     /// Reads a barcode asynchronously.
     /// </summary>
     /// <param name="folderPath">Directory containing the barcode image.</param>
-    public static async Task ReadBarcodeAsyncSample(string folderPath) {
+    public static async Task ReadBarcodeAsyncSample(string folderPath, CancellationToken cancellationToken = default) {
         Console.WriteLine("[*] Reading Barcode asynchronously:");
         string filePath = System.IO.Path.Combine(folderPath, "BarcodeEAN13.png");
-        var read = await BarCode.ReadAsync(filePath).ConfigureAwait(false);
+        var read = await BarCode.ReadAsync(filePath, cancellationToken).ConfigureAwait(false);
         Console.WriteLine(read.Message);
     }
 }

--- a/Sources/ImagePlayground.Tests/AsyncMethodsCancellation.cs
+++ b/Sources/ImagePlayground.Tests/AsyncMethodsCancellation.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for cancellation in async image operations.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public async Task Test_ResizeAsync_Cancelled() {
+        string src = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+        string dest = Path.Combine(_directoryWithTests, "logo_async_cancel.png");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ImageHelper.ResizeAsync(src, dest, 40, 40, cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task Test_RotateAsync_Cancelled() {
+        string src = Path.Combine(_directoryWithImages, "PrzemyslawKlysAndKulkozaurr.jpg");
+        string dest = Path.Combine(_directoryWithTests, "rotate_async_cancel.jpg");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ImageHelper.RotateAsync(src, dest, 90, cts.Token));
+    }
+}
+

--- a/Sources/ImagePlayground.Tests/BarCodeCancellation.cs
+++ b/Sources/ImagePlayground.Tests/BarCodeCancellation.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ImagePlayground.Tests;
+
+/// <summary>
+/// Tests for cancellation in barcode reading.
+/// </summary>
+public partial class ImagePlayground {
+    [Fact]
+    public async Task Test_BarCodeReadAsync_Cancelled() {
+        string filePath = Path.Combine(_directoryWithImages, "BarcodeEAN13.png");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => BarCode.ReadAsync(filePath, cts.Token));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add optional CancellationToken parameters to async resize/rotate helpers and barcode reader
- wire tokens through ImageSharp operations
- add unit tests ensuring operations honor cancellation

## Testing
- `dotnet test Sources/ImagePlayground.sln` *(fails: ImagePlayground.Tests.ImagePlayground.Test_CleanupTempFiles_Idempotent, ImagePlayground.Tests.ImagePlayground.Test_ResolvePath_DownloadsUrlAsync)*
- `dotnet test Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj -f net8.0 --filter "Test_ResizeAsync_Cancelled|Test_RotateAsync_Cancelled|Test_BarCodeReadAsync_Cancelled"`


------
https://chatgpt.com/codex/tasks/task_e_689b8d36beb0832e8deebc4461706650