### PR TITLE
fix(powershell): ensure output directories exist

### DIFF
--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageText.cs
@@ -98,6 +98,7 @@ public sealed class AddImageTextCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
         ImagePlayground.ImageHelper.AddText(
             filePath,
             output,

--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageTextBox.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageTextBox.cs
@@ -88,6 +88,7 @@ public sealed class AddImageTextBoxCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
         ImagePlayground.ImageHelper.AddTextBox(
             filePath,
             output,

--- a/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletAddImageWatermark.cs
@@ -82,6 +82,7 @@ public sealed class AddImageWatermarkCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
 
         if (Spacing != null) {
             if (Async.IsPresent) {

--- a/Sources/ImagePlayground.PowerShell/CmdletCompareImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletCompareImage.cs
@@ -38,6 +38,7 @@ public sealed class CompareImageCmdlet : PSCmdlet {
 
         if (!string.IsNullOrWhiteSpace(OutputPath)) {
             var output = Helpers.ResolvePath(OutputPath);
+            Helpers.CreateParentDirectory(output);
             ImagePlayground.ImageHelper.Compare(filePath, compare, output);
         } else {
             var result = ImagePlayground.ImageHelper.Compare(filePath, compare);

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertFromImageBase64.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertFromImageBase64.cs
@@ -31,6 +31,7 @@ public sealed class ConvertFromImageBase64Cmdlet : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
         ImageHelper.ConvertFromBase64(Base64, output);
         Helpers.Open(output, Open.IsPresent);
     }

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertToImage.cs
@@ -44,6 +44,7 @@ public sealed class ConvertToImageCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
         ImagePlayground.ImageHelper.ConvertTo(filePath, output, Quality, CompressionLevel);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletExportImageMetadata.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletExportImageMetadata.cs
@@ -37,6 +37,7 @@ public sealed class ExportImageMetadataCmdlet : PSCmdlet {
             WriteObject(json);
         } else {
             var output = Helpers.ResolvePath(OutputPath!);
+            Helpers.CreateParentDirectory(output);
             File.WriteAllText(output, json);
         }
     }

--- a/Sources/ImagePlayground.PowerShell/CmdletImportImageMetadata.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletImportImageMetadata.cs
@@ -42,6 +42,7 @@ public sealed class ImportImageMetadataCmdlet : PSCmdlet {
         }
 
         var output = string.IsNullOrWhiteSpace(OutputPath) ? filePath : Helpers.ResolvePath(OutputPath!);
+        Helpers.CreateParentDirectory(output);
         var options = new ImageHelper.ImportMetadataOptions(filePath, metaPath, output);
         ImageHelper.ImportMetadata(options);
     }

--- a/Sources/ImagePlayground.PowerShell/CmdletMergeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletMergeImage.cs
@@ -46,6 +46,7 @@ public sealed class MergeImageCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(FilePathOutput);
+        Helpers.CreateParentDirectory(output);
 
         ImagePlayground.ImageHelper.Combine(filePath, merge, output, ResizeToFit.IsPresent, Placement);
     }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageAvatar.cs
@@ -58,6 +58,7 @@ public sealed class NewImageAvatarCmdlet : PSCmdlet {
             OutputStream.Position = 0;
         } else {
             var output = Helpers.ResolvePath(OutputPath);
+            Helpers.CreateParentDirectory(output);
             ImagePlayground.ImageHelper.Avatar(filePath, output, Width, Height, CornerRadius);
             if (Open.IsPresent) {
                 ImagePlayground.Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageBarCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageBarCode.cs
@@ -25,6 +25,7 @@ public BarcodeType Type { get; set; }
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
         BarCode.Generate(Type, Value, output);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChart.cs
@@ -104,6 +104,7 @@ public sealed class NewImageChartCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
         Charts.Generate(list, output, Width, Height, null, XTitle, YTitle, ShowGrid.IsPresent, Theme, annotations, Background);
 
         if (Show.IsPresent) {

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageCrop.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageCrop.cs
@@ -75,6 +75,7 @@ public sealed class NewImageCropCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
 
         if (ParameterSetName == ParameterSetCircle) {
             ImageHelper.CropCircle(filePath, output, CenterX, CenterY, Radius);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageGif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageGif.cs
@@ -38,6 +38,7 @@ public sealed class NewImageGifCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
         Gif.Generate(checkedFrames, output, FrameDelay);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageGrid.cs
@@ -35,6 +35,7 @@ public sealed class NewImageGridCmdlet : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
         ImagePlayground.ImageHelper.Create(output, Width, Height, Color, Open.IsPresent);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageIcon.cs
@@ -40,6 +40,7 @@ public sealed class NewImageIconCmdlet : PSCmdlet {
         }
 
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
         using var img = ImagePlayground.Image.Load(filePath);
         img.SaveAsIcon(output, Size);
         if (Open.IsPresent) {

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageMosaic.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageMosaic.cs
@@ -49,6 +49,7 @@ public sealed class NewImageMosaicCmdlet : PSCmdlet {
             checkedFiles.Add(full);
         }
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
         ImageHelper.Mosaic(checkedFiles, output, Columns, Width, Height);
         if (Open.IsPresent) {
             Helpers.Open(output, true);

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCode.cs
@@ -57,10 +57,12 @@ public sealed class NewImageQrCodeCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCode - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.Generate(Content, FilePath, Transparent.IsPresent, QRCodeGenerator.ECCLevel.Q, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.Generate(Content, output, Transparent.IsPresent, QRCodeGenerator.ECCLevel.Q, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBezahlCode.cs
@@ -72,10 +72,12 @@ public sealed class NewImageQrCodeBezahlCodeCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeBezahlCode - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateBezahlCode(Authority, Name, Account, Bnc, Iban, Bic, Reason, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateBezahlCode(Authority, Name, Account, Bnc, Iban, Bic, Reason, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeBitcoin.cs
@@ -64,10 +64,12 @@ public sealed class NewImageQrCodeBitcoinCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeBitcoin - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateBitcoinAddress(Currency, Address, Amount, Label, Message, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateBitcoinAddress(Currency, Address, Amount, Label, Message, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGeoLocation.cs
@@ -52,10 +52,12 @@ public sealed class NewImageQrCodeGeoLocationCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeGeoLocation - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateGeoLocation(Latitude, Longitude, FilePath, PayloadGenerator.Geolocation.GeolocationEncoding.GEO, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateGeoLocation(Latitude, Longitude, output, PayloadGenerator.Geolocation.GeolocationEncoding.GEO, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeGirocode.cs
@@ -64,10 +64,12 @@ public sealed class NewImageQrCodeGirocodeCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeGirocode - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateGirocode(Iban, Bic, Name, Amount, FilePath, RemittanceInformation, PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, null, null, PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateGirocode(Iban, Bic, Name, Amount, output, RemittanceInformation, PayloadGenerator.Girocode.TypeOfRemittance.Unstructured, null, null, PayloadGenerator.Girocode.GirocodeVersion.Version1, PayloadGenerator.Girocode.GirocodeEncoding.ISO_8859_1, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeMonero.cs
@@ -64,10 +64,12 @@ public sealed class NewImageQrCodeMoneroCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeMonero - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateMoneroTransaction(Address, Amount, PaymentId, RecipientName, Description, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateMoneroTransaction(Address, Amount, PaymentId, RecipientName, Description, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeOtp.cs
@@ -48,10 +48,12 @@ public sealed class NewImageQrCodeOtpCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeOtp - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateOneTimePassword(Payload, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateOneTimePassword(Payload, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodePhoneNumber.cs
@@ -48,10 +48,12 @@ public sealed class NewImageQrCodePhoneNumberCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodePhoneNumber - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GeneratePhoneNumber(Number, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GeneratePhoneNumber(Number, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeShadowSocks.cs
@@ -64,10 +64,12 @@ public sealed class NewImageQrCodeShadowSocksCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeShadowSocks - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateShadowSocks(Host, Port, Password, Method, FilePath, Tag, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateShadowSocks(Host, Port, Password, Method, output, Tag, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSkypeCall.cs
@@ -48,10 +48,12 @@ public sealed class NewImageQrCodeSkypeCallCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeSkypeCall - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateSkypeCall(UserName, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateSkypeCall(UserName, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSlovenianUpnQr.cs
@@ -48,10 +48,12 @@ public sealed class NewImageQrCodeSlovenianUpnQrCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeSlovenianUpnQr - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateSlovenianUpnQr(Payload, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateSlovenianUpnQr(Payload, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSms.cs
@@ -52,10 +52,12 @@ public sealed class NewImageQrCodeSmsCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeSms - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateSms(Number, Message, FilePath, PayloadGenerator.SMS.SMSEncoding.SMS, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateSms(Number, Message, output, PayloadGenerator.SMS.SMSEncoding.SMS, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeSwiss.cs
@@ -48,10 +48,12 @@ public sealed class NewImageQrCodeSwissCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeSwiss - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateSwissQrCode(Payload, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateSwissQrCode(Payload, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRCodeWiFi.cs
@@ -53,10 +53,12 @@ public sealed class NewImageQrCodeWiFiCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRCodeWiFi - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateWiFi(SSID, Password, FilePath, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateWiFi(SSID, Password, output, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageQRContact.cs
@@ -119,10 +119,12 @@ public sealed class NewImageQrContactCmdlet : PSCmdlet {
             WriteWarning($"New-ImageQRContact - No file path specified, saving to {FilePath}");
         }
 
-        ImagePlayground.QrCode.GenerateContact(FilePath, OutputType, Firstname ?? string.Empty, Lastname ?? string.Empty, Nickname, Phone, MobilePhone, WorkPhone, Email, Birthday, Website, Street, HouseNumber, City, ZipCode, Country, Note, StateRegion, AddressOrder, Org, OrgTitle, false, ForegroundColor, BackgroundColor, PixelSize);
+        var output = Helpers.ResolvePath(FilePath);
+        Helpers.CreateParentDirectory(output);
+        ImagePlayground.QrCode.GenerateContact(output, OutputType, Firstname ?? string.Empty, Lastname ?? string.Empty, Nickname, Phone, MobilePhone, WorkPhone, Email, Birthday, Website, Street, HouseNumber, City, ZipCode, Country, Note, StateRegion, AddressOrder, Org, OrgTitle, false, ForegroundColor, BackgroundColor, PixelSize);
 
         if (Show.IsPresent) {
-            ImagePlayground.Helpers.Open(Helpers.ResolvePath(FilePath), true);
+            ImagePlayground.Helpers.Open(output, true);
         }
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageThumbnail.cs
@@ -45,6 +45,7 @@ public sealed class NewImageThumbnailCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(OutputDirectory);
+        Helpers.CreateParentDirectory(output);
         ImagePlayground.ImageHelper.GenerateThumbnails(dir, output, Width, Height, !DontRespectAspectRatio.IsPresent, Sampler);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletResizeImage.cs
@@ -63,6 +63,7 @@ public sealed class ResizeImageCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
 
         if (ParameterSetName == ParameterSetPercentage) {
             if (Async.IsPresent) {

--- a/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSaveImage.cs
@@ -42,6 +42,7 @@ public sealed class SaveImageCmdlet : PSCmdlet {
     protected override void ProcessRecord() {
         if (!string.IsNullOrWhiteSpace(FilePath)) {
             var output = Helpers.ResolvePath(FilePath);
+            Helpers.CreateParentDirectory(output);
             Image.Save(output, Open.IsPresent, Quality, CompressionLevel);
         } else if (AsStream.IsPresent) {
             WriteObject(Image.ToStream(Quality, CompressionLevel));

--- a/Sources/ImagePlayground.PowerShell/CmdletSetImageAdjust.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSetImageAdjust.cs
@@ -55,6 +55,7 @@ public sealed class SetImageAdjustCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
         if (Async.IsPresent) {
             ImageHelper.AdjustAsync(filePath, output, Brightness, Contrast, Lightness, Opacity, Saturation, Sepia).GetAwaiter().GetResult();
         } else {

--- a/Sources/ImagePlayground.PowerShell/CmdletSetImageBlur.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSetImageBlur.cs
@@ -37,6 +37,7 @@ public sealed class SetImageBlurCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
         if (Async.IsPresent) {
             ImagePlayground.ImageHelper.BlurAsync(filePath, output, Amount).GetAwaiter().GetResult();
         } else {

--- a/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSetImageExif.cs
@@ -47,6 +47,7 @@ public sealed class SetImageExifCmdlet : PSCmdlet {
         img.SetExifValue(ExifTag, Value);
 
         var output = string.IsNullOrWhiteSpace(FilePathOutput) ? filePath : Helpers.ResolvePath(FilePathOutput!);
+        Helpers.CreateParentDirectory(output);
         img.Save(output);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/CmdletSetImageRotation.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSetImageRotation.cs
@@ -53,6 +53,7 @@ public sealed class SetImageRotationCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
 
         if (ParameterSetName == ParameterSetDegrees) {
             if (Async.IsPresent) {

--- a/Sources/ImagePlayground.PowerShell/CmdletSetImageSharpen.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletSetImageSharpen.cs
@@ -37,6 +37,7 @@ public sealed class SetImageSharpenCmdlet : PSCmdlet {
             return;
         }
         var output = Helpers.ResolvePath(OutputPath);
+        Helpers.CreateParentDirectory(output);
         if (Async.IsPresent) {
             ImagePlayground.ImageHelper.SharpenAsync(filePath, output, Amount).GetAwaiter().GetResult();
         } else {

--- a/Tests/Add-ImageText.Tests.ps1
+++ b/Tests/Add-ImageText.Tests.ps1
@@ -71,5 +71,12 @@ Describe 'Add-ImageText' {
         { Add-ImageText -FilePath $src -OutputPath $dest -Text 'Test' -X 0 -Y -1 } | Should -Throw
     }
 
+    It 'creates output in non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'text.png'
+        Add-ImageText -FilePath $src -OutputPath $dest -Text 'Test' -X 1 -Y 1 -Color ([SixLabors.ImageSharp.Color]::Red)
+        Test-Path $dest | Should -BeTrue
+    }
 }
 

--- a/Tests/Add-ImageTextBox.Tests.ps1
+++ b/Tests/Add-ImageTextBox.Tests.ps1
@@ -20,4 +20,12 @@ Describe 'Add-ImageTextBox' {
         Add-ImageTextBox -FilePath $src -OutputPath $dest -Text 'Long text to wrap properly' -X 1 -Y 1 -Width 50 -Color ([SixLabors.ImageSharp.Color]::Blue)
         Test-Path $dest | Should -BeTrue
     }
+
+    It 'adds textbox to non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'textbox.png'
+        Add-ImageTextBox -FilePath $src -OutputPath $dest -Text 'Test Wrap' -X 1 -Y 1 -Width 100 -Color ([SixLabors.ImageSharp.Color]::Red)
+        Test-Path $dest | Should -BeTrue
+    }
 }

--- a/Tests/Compare-Image.Tests.ps1
+++ b/Tests/Compare-Image.Tests.ps1
@@ -48,5 +48,16 @@ Describe 'Compare-Image' {
 
     }
 
+    It 'saves mask to non-existent directory' {
+        $img1 = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $modified = Join-Path $TestDir 'qr_mod2.png'
+        if (Test-Path $modified) { Remove-Item $modified }
+        Add-ImageText -FilePath $img1 -OutputPath $modified -Text 'Diff' -X 1 -Y 1 -Color ([SixLabors.ImageSharp.Color]::Red)
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'diff.png'
+        Compare-Image -FilePath $img1 -FilePathToCompare $modified -OutputPath $dest
+        Test-Path $dest | Should -BeTrue
+    }
+
 }
 

--- a/Tests/ConvertFrom-ImageBase64.Tests.ps1
+++ b/Tests/ConvertFrom-ImageBase64.Tests.ps1
@@ -12,4 +12,13 @@ describe 'ConvertFrom-ImageBase64' {
         ConvertFrom-ImageBase64 -Base64 $b64 -OutputPath $dest
         Test-Path $dest | Should -BeTrue
     }
+
+    It 'creates image in non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $b64 = ConvertTo-ImageBase64 -FilePath $src
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'fromb64.png'
+        ConvertFrom-ImageBase64 -Base64 $b64 -OutputPath $dest
+        Test-Path $dest | Should -BeTrue
+    }
 }

--- a/Tests/ConvertTo-Image.Tests.ps1
+++ b/Tests/ConvertTo-Image.Tests.ps1
@@ -28,4 +28,12 @@ Describe 'ConvertTo-Image' {
         $dest = Join-Path $TestDir 'invalid.ico'
         { ConvertTo-Image -FilePath $src -OutputPath $dest } | Should -Throw
     }
+
+    It 'converts image to non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'qr.jpg'
+        ConvertTo-Image -FilePath $src -OutputPath $dest -Quality 80
+        Test-Path $dest | Should -BeTrue
+    }
 }

--- a/Tests/Export-ImageMetadata.Tests.ps1
+++ b/Tests/Export-ImageMetadata.Tests.ps1
@@ -1,0 +1,14 @@
+describe 'Export-ImageMetadata' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
+        $TestDir = Join-Path $PSScriptRoot 'Artifacts'
+        if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
+    }
+    It 'exports metadata to non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'meta.json'
+        Export-ImageMetadata -FilePath $src -OutputPath $dest
+        Test-Path $dest | Should -BeTrue
+    }
+}

--- a/Tests/Import-ImageMetadata.Tests.ps1
+++ b/Tests/Import-ImageMetadata.Tests.ps1
@@ -1,0 +1,16 @@
+describe 'Import-ImageMetadata' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
+        $TestDir = Join-Path $PSScriptRoot 'Artifacts'
+        if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
+    }
+    It 'imports metadata to non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $meta = Join-Path $TestDir 'meta.json'
+        Export-ImageMetadata -FilePath $src -OutputPath $meta
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'logo.png'
+        Import-ImageMetadata -FilePath $src -MetadataPath $meta -OutputPath $dest
+        Test-Path $dest | Should -BeTrue
+    }
+}

--- a/Tests/Merge-Image.Tests.ps1
+++ b/Tests/Merge-Image.Tests.ps1
@@ -48,5 +48,14 @@ Describe 'Merge-Image' {
 
     }
 
+    It 'merges images into non-existent directory' {
+        $src1 = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $src2 = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'merged.png'
+        Merge-Image -FilePath $src1 -FilePathToMerge $src2 -FilePathOutput $dest
+        Test-Path $dest | Should -BeTrue
+    }
+
 }
 

--- a/Tests/New-ImageAvatar.Tests.ps1
+++ b/Tests/New-ImageAvatar.Tests.ps1
@@ -1,0 +1,14 @@
+describe 'New-ImageAvatar' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ImagePlayground.psd1" -Force
+        $TestDir = Join-Path $PSScriptRoot 'Artifacts'
+        if (-not (Test-Path $TestDir)) { New-Item -Path $TestDir -ItemType Directory | Out-Null }
+    }
+    It 'creates avatar in non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'avatar.png'
+        New-ImageAvatar -FilePath $src -OutputPath $dest -Width 32 -Height 32
+        Test-Path $dest | Should -BeTrue
+    }
+}

--- a/Tests/New-ImageBarCode.Tests.ps1
+++ b/Tests/New-ImageBarCode.Tests.ps1
@@ -44,4 +44,11 @@ Describe 'New-ImageBarCode' {
         (Get-ImageBarCode -FilePath $file).Message | Should -Be 'Pdf417Example'
     }
 
+    It 'creates barcode in non-existent directory' {
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $file = Join-Path $dir 'barcode.png'
+        New-ImageBarCode -Type EAN -Value '9012341234571' -FilePath $file
+        Test-Path $file | Should -BeTrue
+    }
+
 }

--- a/Tests/New-ImageChart.Tests.ps1
+++ b/Tests/New-ImageChart.Tests.ps1
@@ -107,4 +107,14 @@ Describe 'New-ImageChart' {
 
         Test-Path -Path $file | Should -BeTrue
     }
+
+    It 'creates chart in non-existent directory' -Skip:(-not $IsWindows) {
+        $defs = @(
+            New-ImageChartBar -Name 'Jan' -Value @(1,2)
+        )
+        $dir = Join-Path -Path $TestDir -ChildPath ([guid]::NewGuid())
+        $file = Join-Path -Path $dir -ChildPath 'chart.png'
+        New-ImageChart -Definition $defs -FilePath $file -Width 200 -Height 150
+        Test-Path -Path $file | Should -BeTrue
+    }
 }

--- a/Tests/New-ImageGif.Tests.ps1
+++ b/Tests/New-ImageGif.Tests.ps1
@@ -18,5 +18,15 @@ Describe 'New-ImageGif' {
         New-ImageGif -Frames $frames -FilePath $dest -FrameDelay 50
         Test-Path $dest | Should -BeTrue
     }
+
+    It 'creates gif in non-existent directory' {
+        $frames = @(
+            Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        )
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'anim.gif'
+        New-ImageGif -Frames $frames -FilePath $dest -FrameDelay 50
+        Test-Path $dest | Should -BeTrue
+    }
 }
 

--- a/Tests/New-ImageGrid.Tests.ps1
+++ b/Tests/New-ImageGrid.Tests.ps1
@@ -33,5 +33,12 @@ Describe 'New-ImageGrid' {
 
     }
 
+    It 'creates grid in non-existent directory' {
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'grid.png'
+        New-ImageGrid -FilePath $dest -Width 50 -Height 50
+        Test-Path $dest | Should -BeTrue
+    }
+
 }
 

--- a/Tests/New-ImageIcon.Tests.ps1
+++ b/Tests/New-ImageIcon.Tests.ps1
@@ -14,4 +14,12 @@ Describe 'New-ImageIcon' {
         New-ImageIcon -FilePath $src -OutputPath $dest -Size @(16,32)
         Test-Path $dest | Should -BeTrue
     }
+
+    It 'creates icon in non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'icon.ico'
+        New-ImageIcon -FilePath $src -OutputPath $dest -Size @(16,32)
+        Test-Path $dest | Should -BeTrue
+    }
 }

--- a/Tests/New-ImageMosaic.Tests.ps1
+++ b/Tests/New-ImageMosaic.Tests.ps1
@@ -31,4 +31,15 @@ Describe 'New-ImageMosaic' {
 
     }
 
+    It 'creates mosaic in non-existent directory' {
+        $src1 = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $src2 = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/QRCode1.png'
+        $src3 = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/BarcodeEAN7.png'
+        $src4 = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/BarcodeEAN13.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'mosaic.png'
+        New-ImageMosaic -FilePaths @($src1,$src2,$src3,$src4) -OutputPath $dest -Columns 2 -Width 100 -Height 100
+        Test-Path $dest | Should -BeTrue
+    }
+
 }

--- a/Tests/New-ImageQRCode.Tests.ps1
+++ b/Tests/New-ImageQRCode.Tests.ps1
@@ -72,5 +72,12 @@ Describe 'New-ImageQRCode' {
         { New-ImageQRCode -Content 'https://evotec.xyz' -FilePath (Join-Path $TestDir 'qr_invalid.png') -PixelSize 0 } | Should -Throw
     }
 
+    It 'creates QR code in non-existent directory' {
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $file = Join-Path $dir 'qr.png'
+        New-ImageQRCode -Content 'https://evotec.xyz' -FilePath $file
+        Test-Path $file | Should -BeTrue
+    }
+
 }
 

--- a/Tests/New-ImageQRCodeAdditional.Tests.ps1
+++ b/Tests/New-ImageQRCodeAdditional.Tests.ps1
@@ -29,6 +29,13 @@ describe 'New-ImageQRCode additional cmdlets' {
         (Get-ImageQRCode -FilePath $file).Message | Should -Match 'bitcoin:'
     }
 
+    It 'creates SMS QR code in non-existent directory' {
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $file = Join-Path $dir 'sms.png'
+        New-ImageQRCodeSms -Number '+1234567890' -Message 'Hello' -FilePath $file
+        Test-Path $file | Should -BeTrue
+    }
+
     It 'throws on invalid pixel size for Sms' {
         { New-ImageQRCodeSms -Number '+1234567890' -Message 'Hello' -FilePath (Join-Path $TestDir 'sms_invalid.png') -PixelSize 0 } | Should -Throw
     }

--- a/Tests/New-ImageQRCodeWiFi.Tests.ps1
+++ b/Tests/New-ImageQRCodeWiFi.Tests.ps1
@@ -51,6 +51,13 @@ Describe 'New-ImageQRCodeWiFi password quoting' {
         (Get-ImageQRCode -FilePath $file).Message | Should -Be 'WIFI:T:WPA;S:Test;P:pass123;;'
     }
 
+    It 'creates WiFi QR in non-existent directory' {
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $file = Join-Path $dir 'wifi.png'
+        New-ImageQRCodeWiFi -SSID 'Test' -Password 'pass123' -FilePath $file
+        Test-Path $file | Should -BeTrue
+    }
+
     It 'throws on invalid pixel size' {
         { New-ImageQRCodeWiFi -SSID 'Test' -Password '12345678' -FilePath (Join-Path $TestDrive 'wifi_invalid.png') -PixelSize 0 } | Should -Throw
     }

--- a/Tests/New-ImageQRContact.Tests.ps1
+++ b/Tests/New-ImageQRContact.Tests.ps1
@@ -15,6 +15,13 @@ Describe 'New-ImageQRContact' {
         (Get-ImageQRCode -FilePath $file).Message | Should -Match 'BEGIN:VCARD'
     }
 
+    It 'creates contact QR in non-existent directory' {
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $file = Join-Path $dir 'contact.png'
+        New-ImageQRContact -FilePath $file -Firstname 'John' -Lastname 'Doe'
+        Test-Path $file | Should -BeTrue
+    }
+
     It 'throws on invalid pixel size' {
         { New-ImageQRContact -FilePath (Join-Path $TestDir 'contact_invalid.png') -Firstname 'John' -Lastname 'Doe' -PixelSize 0 } | Should -Throw
     }

--- a/Tests/Resize-Image.Tests.ps1
+++ b/Tests/Resize-Image.Tests.ps1
@@ -30,6 +30,14 @@ Describe 'Resize-Image' {
 
     }
 
+    It 'resizes to non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'logo-small.png'
+        Resize-Image -FilePath $src -OutputPath $dest -Width 50 -Height 50
+        Test-Path $dest | Should -BeTrue
+    }
+
     It 'resizes an image asynchronously' {
         $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
         $dest = Join-Path $TestDir 'logo-small-async.png'

--- a/Tests/Set-ImageAdjust.Tests.ps1
+++ b/Tests/Set-ImageAdjust.Tests.ps1
@@ -29,4 +29,12 @@ Describe 'Set-ImageAdjust' {
         $img.Dispose()
         $orig.Dispose()
     }
+
+    It 'adjusts image in non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'logo-adjust.png'
+        Set-ImageAdjust -FilePath $src -OutputPath $dest -Brightness 1.2 -Contrast 1.1
+        Test-Path $dest | Should -BeTrue
+    }
 }

--- a/Tests/Set-ImageBlur.Tests.ps1
+++ b/Tests/Set-ImageBlur.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Set-ImageBlur' {
 
     It 'blurs an image asynchronously' {
         $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
-        $dest = Join-Path $TestDir 'logo-blur-async.png'
+       $dest = Join-Path $TestDir 'logo-blur-async.png'
         Set-ImageBlur -FilePath $src -OutputPath $dest -Amount 5 -Async
         $orig = [ImagePlayground.Image]::Load($src)
         $img = [ImagePlayground.Image]::Load($dest)
@@ -31,5 +31,13 @@ Describe 'Set-ImageBlur' {
         $img.Height | Should -Be $orig.Height
         $img.Dispose()
         $orig.Dispose()
+    }
+
+    It 'blurs to non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'logo-blur.png'
+        Set-ImageBlur -FilePath $src -OutputPath $dest -Amount 5
+        Test-Path $dest | Should -BeTrue
     }
 }

--- a/Tests/Set-ImageExif.Tests.ps1
+++ b/Tests/Set-ImageExif.Tests.ps1
@@ -38,6 +38,14 @@ Describe 'Set-ImageExif' {
 
     }
 
+    It 'sets exif in non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'exif-edit.jpg'
+        Set-ImageExif -FilePath $src -FilePathOutput $dest -ExifTag ([SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag]::Software) -Value 'Modified'
+        Test-Path $dest | Should -BeTrue
+    }
+
     It 'throws when value type mismatches tag' {
 
         $dest = Join-Path $TestDir 'exif-type-error.jpg'

--- a/Tests/Set-ImageRotation.Tests.ps1
+++ b/Tests/Set-ImageRotation.Tests.ps1
@@ -45,4 +45,12 @@ Describe 'Set-ImageRotation' {
         $img.Dispose()
         $orig.Dispose()
     }
+
+    It 'rotates into non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/PrzemyslawKlysAndKulkozaurr.jpg'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'rotate.jpg'
+        Set-ImageRotation -FilePath $src -OutputPath $dest -Degrees 90
+        Test-Path $dest | Should -BeTrue
+    }
 }

--- a/Tests/Set-ImageSharpen.Tests.ps1
+++ b/Tests/Set-ImageSharpen.Tests.ps1
@@ -32,4 +32,12 @@ Describe 'Set-ImageSharpen' {
         $img.Dispose()
         $orig.Dispose()
     }
+
+    It 'sharpens into non-existent directory' {
+        $src = Join-Path $PSScriptRoot '../Sources/ImagePlayground.Tests/Images/LogoEvotec.png'
+        $dir = Join-Path $TestDir ([guid]::NewGuid())
+        $dest = Join-Path $dir 'logo-sharp.png'
+        Set-ImageSharpen -FilePath $src -OutputPath $dest -Amount 2
+        Test-Path $dest | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- ensure cmdlets create parent directories before writing files
- add Pester coverage for outputs in non-existent directories

## Testing
- `dotnet build Sources/ImagePlayground.sln`
- `pwsh ./ImagePlayground.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_689b99004c98832ebc81a14ec3b5131b