### PR TITLE
feat(core): honor cancellation tokens in async helpers

### DIFF
--- a/Sources/ImagePlayground.BarCode/BarCode.cs
+++ b/Sources/ImagePlayground.BarCode/BarCode.cs
@@ -169,6 +169,7 @@ public class BarCode {
     /// <param name="filePath">Path to the barcode image.</param>
     /// <returns>A task containing the decoded barcode result.</returns>
     public static async Task<BarcodeResult<Rgba32>> ReadAsync(string filePath, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         string fullPath = Helpers.ResolvePath(filePath);
 
         using Image<Rgba32> barcodeImage = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fullPath, cancellationToken).ConfigureAwait(false);

--- a/Sources/ImagePlayground.Core/ImageHelper.Rotate.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.Rotate.cs
@@ -42,6 +42,7 @@ public partial class ImageHelper {
     /// Asynchronously rotates an image using a <see cref="RotateMode"/>.
     /// </summary>
     public static async Task RotateAsync(string filePath, string outFilePath, RotateMode rotateMode, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(Path.GetDirectoryName(outFullPath)!);
@@ -54,6 +55,7 @@ public partial class ImageHelper {
     /// Asynchronously rotates an image by an arbitrary number of <paramref name="degrees"/>.
     /// </summary>
     public static async Task RotateAsync(string filePath, string outFilePath, float degrees, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(Path.GetDirectoryName(outFullPath)!);

--- a/Sources/ImagePlayground.Core/ImageHelper.cs
+++ b/Sources/ImagePlayground.Core/ImageHelper.cs
@@ -95,6 +95,7 @@ public partial class ImageHelper {
     ///   <code>await ImageHelper.ResizeAsync("in.jpg", "out.jpg", 400, 300);</code>
     /// </example>
     public static async Task ResizeAsync(string filePath, string outFilePath, int? width, int? height, bool keepAspectRatio = true, Sampler? sampler = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);
@@ -198,6 +199,7 @@ public partial class ImageHelper {
             throw new ArgumentOutOfRangeException(nameof(percentage));
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         string fullPath = Helpers.ResolvePath(filePath);
         string outFullPath = Helpers.ResolvePath(outFilePath);
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outFullPath)!);

--- a/Sources/ImagePlayground.Tests/AsyncMethodsCancellation.cs
+++ b/Sources/ImagePlayground.Tests/AsyncMethodsCancellation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using SixLabors.ImageSharp.Processing;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -28,6 +29,26 @@ public partial class ImagePlayground {
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ImageHelper.RotateAsync(src, dest, 90, cts.Token));
+    }
+
+    [Fact]
+    public async Task Test_RotateAsync_Mode_Cancelled() {
+        string src = Path.Combine(_directoryWithImages, "PrzemyslawKlysAndKulkozaurr.jpg");
+        string dest = Path.Combine(_directoryWithTests, "rotate_mode_async_cancel.jpg");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ImageHelper.RotateAsync(src, dest, RotateMode.Rotate90, cts.Token));
+    }
+
+    [Fact]
+    public async Task Test_ResizeAsync_Percentage_Cancelled() {
+        string src = Path.Combine(_directoryWithImages, "LogoEvotec.png");
+        string dest = Path.Combine(_directoryWithTests, "logo_async_percentage_cancel.png");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ImageHelper.ResizeAsync(src, dest, 50, cts.Token));
     }
 }
 


### PR DESCRIPTION
## Summary
- honor cancellation tokens in image resize/rotate helpers
- propagate cancellation checks in barcode reading
- cover cancellation scenarios with extra tests

## Testing
- `dotnet restore Sources/ImagePlayground.sln`
- `dotnet test Sources/ImagePlayground.sln` *(fails: Could not find 'mono' host)*
- `dotnet test Sources/ImagePlayground.sln -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689c3af438e4832e991f375c64cb2495