### PR TITLE
Use minimal ImagePlayground type surface

### DIFF
--- a/.github/workflows/test_powershell.yml
+++ b/.github/workflows/test_powershell.yml
@@ -17,7 +17,6 @@ on:
 env:
   DOTNET_VERSION: '8.x'
   BUILD_CONFIGURATION: 'Debug'
-  PSPUBLISHMODULE_REF: '105a24cf399ce8c7a3a7a269427ef2bfbc3b5d64'
 
 jobs:
   refresh-psd1:
@@ -30,13 +29,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
 
-      - name: Checkout PSPublishModule
-        uses: actions/checkout@v4
-        with:
-          repository: EvotecIT/PSPublishModule
-          ref: ${{ env.PSPUBLISHMODULE_REF }}
-          path: .dependencies/PSPublishModule
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -46,16 +38,10 @@ jobs:
         shell: pwsh
         run: |
           Install-Module Pester -Force -Scope CurrentUser -AllowClobber
-
-      - name: Build PSPublishModule
-        shell: pwsh
-        run: .\Build\Build-Module.ps1
-        working-directory: .dependencies/PSPublishModule
+          Install-Module PSPublishModule -Force -Scope CurrentUser -AllowClobber
 
       - name: Refresh module manifest
-        env:
-          RefreshPSD1Only: 'true'
-        run: .\Build\Build-Module.ps1
+        run: .\Build\Build-Module.ps1 -RunMode Manifest
         shell: pwsh
 
       - name: Commit refreshed PSD1
@@ -83,13 +69,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout PSPublishModule
-        uses: actions/checkout@v4
-        with:
-          repository: EvotecIT/PSPublishModule
-          ref: ${{ env.PSPUBLISHMODULE_REF }}
-          path: .dependencies/PSPublishModule
-
       - name: Download manifest
         uses: actions/download-artifact@v4
         with:
@@ -105,15 +84,11 @@ jobs:
         shell: pwsh
         run: |
           Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
-
-      - name: Build PSPublishModule
-        shell: pwsh
-        run: .\Build\Build-Module.ps1
-        working-directory: .dependencies/PSPublishModule
+          Install-Module -Name PSPublishModule -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 
       - name: Build module layout
         shell: pwsh
-        run: .\Build\Build-Module.ps1
+        run: .\Build\Build-Module.ps1 -RunMode Build
 
       - name: Upload packaged module
         uses: actions/upload-artifact@v4

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -117,6 +117,7 @@ Build-Module -ModuleName 'ImagePlayground' -RunMode $RunMode {
             'ChartForgeX'
             'CodeGlyphX'
             'ImagePlayground'
+            'ImagePlayground.PowerShell'
             'SixLabors.Fonts'
             'SixLabors.ImageSharp'
         )

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -118,8 +118,6 @@ Build-Module -ModuleName 'ImagePlayground' -RunMode $RunMode {
             'CodeGlyphX'
             'ImagePlayground'
             'ImagePlayground.PowerShell'
-            'SixLabors.Fonts'
-            'SixLabors.ImageSharp'
         )
         NETAssemblyTypeAccelerators       = @(
             'ChartForgeX.Core.Chart'
@@ -136,11 +134,16 @@ Build-Module -ModuleName 'ImagePlayground' -RunMode $RunMode {
             'CodeGlyphX.Payloads.SwissQrCodePayload+Iban'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Reference'
             'ImagePlayground.Image'
+            'SixLabors.Fonts.HorizontalAlignment'
+            'SixLabors.Fonts.VerticalAlignment'
             'SixLabors.ImageSharp.Color'
             'SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag'
             'SixLabors.ImageSharp.PointF'
             'SixLabors.ImageSharp.Rational'
             'SixLabors.ImageSharp.Rectangle'
+            'SixLabors.ImageSharp.Processing.FlipMode'
+            'SixLabors.ImageSharp.Processing.GrayscaleMode'
+            'SixLabors.ImageSharp.Processing.RotateMode'
         )
         NETBinaryModuleDocumentation      = $true
         #NETExcludeMainLibrary             = $true

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,6 +1,6 @@
 param(
     [ValidateSet('Manifest', 'Build', 'Publish')]
-    [string] $ConfigurationGateMode = 'Build',
+    [string] $RunMode = 'Build',
 
     [string] $PowerShellGalleryApiKeyPath = 'C:\Support\Important\PowerShellGalleryAPI.txt',
 
@@ -9,7 +9,7 @@ param(
 
 Import-Module PSPublishModule -Force -ErrorAction Stop
 
-Build-Module -ModuleName 'ImagePlayground' {
+Build-Module -ModuleName 'ImagePlayground' -RunMode $RunMode {
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
         # Minimum version of the Windows PowerShell engine required by this module
@@ -112,79 +112,32 @@ Build-Module -ModuleName 'ImagePlayground' {
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0', 'net472'
         NETAssemblyLoadContext            = $true
-        NETAssemblyTypeAcceleratorMode    = 'AllowList'
+        NETAssemblyTypeAcceleratorMode    = 'Enums'
+        NETAssemblyTypeAcceleratorAssemblies = @(
+            'ChartForgeX'
+            'CodeGlyphX'
+            'ImagePlayground'
+            'SixLabors.Fonts'
+            'SixLabors.ImageSharp'
+        )
         NETAssemblyTypeAccelerators       = @(
             'ChartForgeX.Core.Chart'
             'ChartForgeX.Primitives.ChartColor'
             'ChartForgeX.Primitives.ChartPoint'
-            'ChartForgeX.Topology.TopologyCanvasSurfaceStyle'
             'ChartForgeX.Topology.TopologyChart'
-            'ChartForgeX.Topology.TopologyDirection'
             'ChartForgeX.Topology.TopologyEdge'
-            'ChartForgeX.Topology.TopologyEdgeEmphasis'
-            'ChartForgeX.Topology.TopologyEdgeKind'
-            'ChartForgeX.Topology.TopologyEdgeLineStyle'
-            'ChartForgeX.Topology.TopologyEdgePort'
-            'ChartForgeX.Topology.TopologyEdgeRouting'
             'ChartForgeX.Topology.TopologyGroup'
-            'ChartForgeX.Topology.TopologyGroupLayoutPolicy'
-            'ChartForgeX.Topology.TopologyHealthStatus'
-            'ChartForgeX.Topology.TopologyLayoutDirection'
-            'ChartForgeX.Topology.TopologyLayoutMode'
             'ChartForgeX.Topology.TopologyNode'
-            'ChartForgeX.Topology.TopologyNodeDisplayMode'
-            'ChartForgeX.Topology.TopologyNodeKind'
-            'ChartForgeX.Topology.TopologyVisualStyle'
-            'CodeGlyphX.BarcodeType'
-            'CodeGlyphX.OtpAlgorithm'
-            'CodeGlyphX.OtpAuthType'
-            'CodeGlyphX.Payloads.QrBezahlAuthorityType'
-            'CodeGlyphX.Payloads.QrBezahlPeriodicUnit'
-            'CodeGlyphX.Payloads.QrBitcoinLikeType'
-            'CodeGlyphX.Payloads.QrCalendarEncoding'
-            'CodeGlyphX.Payloads.QrContactAddressOrder'
-            'CodeGlyphX.Payloads.QrContactAddressType'
-            'CodeGlyphX.Payloads.QrContactOutputType'
-            'CodeGlyphX.Payloads.QrGeolocationEncoding'
-            'CodeGlyphX.Payloads.QrGirocodeEncoding'
-            'CodeGlyphX.Payloads.QrGirocodeRemittanceType'
-            'CodeGlyphX.Payloads.QrGirocodeVersion'
-            'CodeGlyphX.Payloads.QrMailEncoding'
-            'CodeGlyphX.Payloads.QrMmsEncoding'
-            'CodeGlyphX.Payloads.QrShadowSocksMethod'
-            'CodeGlyphX.Payloads.QrSmsEncoding'
             'CodeGlyphX.Payloads.SlovenianUpnQrPayload'
             'CodeGlyphX.Payloads.SwissQrCodePayload'
             'CodeGlyphX.Payloads.SwissQrCodePayload+AdditionalInformation'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Contact'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Iban'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Reference'
-            'CodeGlyphX.QrErrorCorrectionLevel'
-            'CodeGlyphX.QrTextEncoding'
-            'CodeGlyphX.SwissQrAddressType'
-            'CodeGlyphX.SwissQrCurrency'
-            'CodeGlyphX.SwissQrIbanType'
-            'CodeGlyphX.SwissQrReferenceType'
-            'ImagePlayground.ChartBarOptions'
-            'ImagePlayground.ChartHeatmapColorScale'
-            'ImagePlayground.ChartLegendPosition'
-            'ImagePlayground.ChartMarkerShape'
-            'ImagePlayground.ChartPictorialSymbol'
-            'ImagePlayground.ChartPieLabelContent'
-            'ImagePlayground.ChartRenderOptions'
-            'ImagePlayground.ChartTheme'
             'ImagePlayground.Image'
-            'ImagePlayground.ImagePlacement'
-            'ImagePlayground.Sampler'
-            'ImagePlayground.Status'
-            'ImagePlayground.WatermarkPlacement'
-            'SixLabors.Fonts.HorizontalAlignment'
-            'SixLabors.Fonts.VerticalAlignment'
             'SixLabors.ImageSharp.Color'
             'SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag'
             'SixLabors.ImageSharp.PointF'
-            'SixLabors.ImageSharp.Processing.FlipMode'
-            'SixLabors.ImageSharp.Processing.RotateMode'
             'SixLabors.ImageSharp.Rational'
             'SixLabors.ImageSharp.Rectangle'
         )
@@ -198,7 +151,6 @@ Build-Module -ModuleName 'ImagePlayground' {
         #SeparateFileLibraries             = $true
         DeleteTargetModuleBeforeBuild     = $true
         MergeLibraryDebugging             = $false
-        RefreshPSD1Only                   = $false
         NETHandleRuntimes                 = $true
     }
 
@@ -239,5 +191,4 @@ Build-Module -ModuleName 'ImagePlayground' {
     New-ConfigurationPublish -Type PowerShellGallery -FilePath $PowerShellGalleryApiKeyPath -Enabled:$false -UseAsDependencyVersionSource
     New-ConfigurationPublish -Type GitHub -FilePath $GitHubApiKeyPath -UserName 'EvotecIT' -Enabled:$false -RepositoryName 'ImagePlayground' -OverwriteTagName 'ImagePlayground-PowerShellModule.<TagModuleVersionWithPreRelease>'
 
-    New-ConfigurationGate -Mode $ConfigurationGateMode
 } -ExitCode

--- a/Tests/New-ImageQRCodeSpecialized.Tests.ps1
+++ b/Tests/New-ImageQRCodeSpecialized.Tests.ps1
@@ -136,7 +136,7 @@ Describe 'New-ImageQRCode specialized cmdlets' {
         $parameters.Keys | Should -Not -Contain 'ReferenceTextType'
     }
 
-    It 'exposes Swiss QR payload value-object accelerators for static helpers' {
+    It 'exposes Swiss QR payload value-object accelerators and public enums for static helpers' {
         $expectedAccelerators = @(
             'CodeGlyphX.Payloads.SwissQrCodePayload'
             'CodeGlyphX.Payloads.SwissQrCodePayload+AdditionalInformation'
@@ -144,7 +144,7 @@ Describe 'New-ImageQRCode specialized cmdlets' {
             'CodeGlyphX.Payloads.SwissQrCodePayload+Iban'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Reference'
         )
-        $legacyAccelerators = @(
+        $expectedEnumAccelerators = @(
             'CodeGlyphX.Payloads.SwissQrCodePayload+Iban+IbanType'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Reference+ReferenceType'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Reference+ReferenceTextType'
@@ -157,9 +157,8 @@ Describe 'New-ImageQRCode specialized cmdlets' {
                 $buildScript | Should -Match ([regex]::Escape($accelerator))
             }
 
-            foreach ($accelerator in $legacyAccelerators) {
-                $buildScript | Should -Not -Match ([regex]::Escape($accelerator))
-            }
+            $buildScript | Should -Match ([regex]::Escape("NETAssemblyTypeAcceleratorMode    = 'Enums'"))
+            $buildScript | Should -Match ([regex]::Escape("'CodeGlyphX'"))
 
             return
         }
@@ -170,8 +169,8 @@ Describe 'New-ImageQRCode specialized cmdlets' {
             $typeAccelerators.ContainsKey($accelerator) | Should -BeTrue
         }
 
-        foreach ($accelerator in $legacyAccelerators) {
-            $typeAccelerators.ContainsKey($accelerator) | Should -BeFalse
+        foreach ($accelerator in $expectedEnumAccelerators) {
+            $typeAccelerators.ContainsKey($accelerator) | Should -BeTrue
         }
     }
 

--- a/Tests/New-ImageQRCodeSpecialized.Tests.ps1
+++ b/Tests/New-ImageQRCodeSpecialized.Tests.ps1
@@ -145,9 +145,8 @@ Describe 'New-ImageQRCode specialized cmdlets' {
             'CodeGlyphX.Payloads.SwissQrCodePayload+Reference'
         )
         $expectedEnumAccelerators = @(
-            'CodeGlyphX.Payloads.SwissQrCodePayload+Iban+IbanType'
-            'CodeGlyphX.Payloads.SwissQrCodePayload+Reference+ReferenceType'
-            'CodeGlyphX.Payloads.SwissQrCodePayload+Reference+ReferenceTextType'
+            'CodeGlyphX.SwissQrIbanType'
+            'CodeGlyphX.SwissQrReferenceType'
         )
         $moduleScriptPath = Join-Path -Path (Get-Module -Name ImagePlayground).ModuleBase -ChildPath 'ImagePlayground.psm1'
         $moduleScript = Get-Content -Path $moduleScriptPath -Raw


### PR DESCRIPTION
## Summary
- switch the build wrapper to shared `-RunMode` instead of local gate/env behavior
- remove the PSPublishModule commit checkout from CI so consumers use the published shared module
- replace the large type accelerator allow-list with enum discovery plus a narrow set of useful value objects/classes
- keep Swiss/Slovenian QR payload objects, topology objects, ImageSharp structs, `ExifTag`, and the small ImageSharp/SixLabors enum surface that public commands use
- include `ImagePlayground.PowerShell` in enum discovery so cmdlet-facing chart enums remain available

## Notes
- PSPublishModule 3.0.40 is published and the workflow now passes without pinning or checkout workarounds.
- SixLabors assemblies are not included as assembly-wide enum sources; only the specific public helper types used by the module are explicit accelerators.

## Validation
- `Build/Build-Module.ps1 -RunMode Manifest` with PSPublishModule 3.0.40
- `Build/Build-Module.ps1 -RunMode Build` with PSPublishModule 3.0.40
- focused Pester: Swiss QR payload/value-object accelerator test
- GitHub Actions: .NET matrix, manifest refresh, packaged build, and PowerShell packaged tests passed