### PR TITLE
Simplify dependency versioning

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -119,6 +119,8 @@ Build-Module -ModuleName 'ImagePlayground' -RunMode $RunMode {
             'ImagePlayground'
             'ImagePlayground.PowerShell'
         )
+        # Enums are registered from the assemblies above. This list is only for non-enum types
+        # that are intentionally part of the PowerShell scripting surface.
         NETAssemblyTypeAccelerators       = @(
             'ChartForgeX.Core.Chart'
             'ChartForgeX.Primitives.ChartColor'
@@ -127,12 +129,6 @@ Build-Module -ModuleName 'ImagePlayground' -RunMode $RunMode {
             'ChartForgeX.Topology.TopologyEdge'
             'ChartForgeX.Topology.TopologyGroup'
             'ChartForgeX.Topology.TopologyNode'
-            'CodeGlyphX.Payloads.SlovenianUpnQrPayload'
-            'CodeGlyphX.Payloads.SwissQrCodePayload'
-            'CodeGlyphX.Payloads.SwissQrCodePayload+AdditionalInformation'
-            'CodeGlyphX.Payloads.SwissQrCodePayload+Contact'
-            'CodeGlyphX.Payloads.SwissQrCodePayload+Iban'
-            'CodeGlyphX.Payloads.SwissQrCodePayload+Reference'
             'ImagePlayground.Image'
             'SixLabors.Fonts.HorizontalAlignment'
             'SixLabors.Fonts.VerticalAlignment'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,28 +3,6 @@
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <ImagePlaygroundPackageVersion>2.0.2</ImagePlaygroundPackageVersion>
-    <ImagePlaygroundPowerShellPackageVersion>2.0.0</ImagePlaygroundPowerShellPackageVersion>
-
-    <CodeuctivityImageSharpCompareVersion>2.0.182</CodeuctivityImageSharpCompareVersion>
-    <!-- Keep the ImageSharp stack on this license line unless the project owner explicitly approves a newer license. -->
-    <SixLaborsFontsVersion>1.0.1</SixLaborsFontsVersion>
-    <SixLaborsImageSharpVersion>2.1.13</SixLaborsImageSharpVersion>
-    <SixLaborsImageSharpDrawingVersion>1.0.0</SixLaborsImageSharpDrawingVersion>
-    <SystemDrawingCommonVersion>8.0.0</SystemDrawingCommonVersion>
-    <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
-    <SystemTextJsonVersion>8.0.6</SystemTextJsonVersion>
-    <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
-
-    <ChartForgeXVersion>0.1.8</ChartForgeXVersion>
-    <CodeGlyphXVersion>1.6.0</CodeGlyphXVersion>
-    <PowerShellStandardLibraryVersion>5.1.1</PowerShellStandardLibraryVersion>
-    <XmlDoc2CmdletDocVersion>0.7.0</XmlDoc2CmdletDocVersion>
-    <MicrosoftNETTestSdkVersion>17.14.1</MicrosoftNETTestSdkVersion>
-    <XunitVersion>2.9.3</XunitVersion>
-    <XunitRunnerVisualStudioVersion>3.1.5</XunitRunnerVisualStudioVersion>
-    <CoverletCollectorVersion>6.0.4</CoverletCollectorVersion>
-
     <UseLocalCodeGlyphXProject Condition="'$(UseLocalCodeGlyphXProject)' == '' and Exists('$(MSBuildThisFileDirectory)..\CodeMatrix\CodeGlyphX\CodeGlyphX.csproj')">true</UseLocalCodeGlyphXProject>
     <UseLocalCodeGlyphXProject Condition="'$(UseLocalCodeGlyphXProject)' == ''">false</UseLocalCodeGlyphXProject>
     <UseLocalChartForgeXProject Condition="'$(UseLocalChartForgeXProject)' == '' and Exists('$(MSBuildThisFileDirectory)..\ChartForgeX\ChartForgeX\ChartForgeX.csproj')">true</UseLocalChartForgeXProject>

--- a/Sources/ImagePlayground.Gdi/ImagePlayground.Gdi.csproj
+++ b/Sources/ImagePlayground.Gdi/ImagePlayground.Gdi.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>$(ImagePlaygroundPackageVersion)</VersionPrefix>
+    <VersionPrefix>2.0.3</VersionPrefix>
     <TargetFrameworks>net472;net8.0-windows;net10.0-windows</TargetFrameworks>
     <AssemblyName>ImagePlayground.Gdi</AssemblyName>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
+++ b/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <VersionPrefix>$(ImagePlaygroundPowerShellPackageVersion)</VersionPrefix>
+        <VersionPrefix>2.0.0</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
         <AssemblyName>ImagePlayground.PowerShell</AssemblyName>
         <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
@@ -52,17 +52,17 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalChartForgeXProject)' != 'true' And '$(ChartForgeXProjectPath)' == ''">
-        <PackageReference Include="ChartForgeX" Version="$(ChartForgeXVersion)" />
+        <PackageReference Include="ChartForgeX" Version="0.1.8" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalCodeGlyphXProject)' != 'true' And '$(CodeGlyphXProjectPath)' == ''">
-        <PackageReference Include="CodeGlyphX" Version="$(CodeGlyphXVersion)" />
+        <PackageReference Include="CodeGlyphX" Version="1.6.0" />
     </ItemGroup>
 
     <ItemGroup>
         <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation. DLL itself
         will be removed/hidden -->
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="$(XmlDoc2CmdletDocVersion)">
+        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -91,7 +91,7 @@
     </Target>
 
     <ItemGroup>
-        <PackageReference Include="PowerShellStandard.Library" Version="$(PowerShellStandardLibraryVersion)" PrivateAssets="all" />
+        <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj
+++ b/Sources/ImagePlayground.Tests/ImagePlayground.Tests.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVersion)">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioVersion)">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Sources/ImagePlayground/ImagePlayground.csproj
+++ b/Sources/ImagePlayground/ImagePlayground.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>$(ImagePlaygroundPackageVersion)</VersionPrefix>
+    <VersionPrefix>2.0.3</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net472;net8.0;net10.0</TargetFrameworks>
     <AssemblyName>ImagePlayground</AssemblyName>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
@@ -13,13 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="$(CodeuctivityImageSharpCompareVersion)" />
-    <PackageReference Include="SixLabors.Fonts" Version="$(SixLaborsFontsVersion)" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="$(SixLaborsImageSharpVersion)" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="$(SixLaborsImageSharpDrawingVersion)" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="2.0.182" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/New-ImageQRCodeSpecialized.Tests.ps1
+++ b/Tests/New-ImageQRCodeSpecialized.Tests.ps1
@@ -136,24 +136,25 @@ Describe 'New-ImageQRCode specialized cmdlets' {
         $parameters.Keys | Should -Not -Contain 'ReferenceTextType'
     }
 
-    It 'exposes Swiss QR payload value-object accelerators and public enums for static helpers' {
-        $expectedAccelerators = @(
+    It 'exposes CodeGlyphX enums without publishing QR payload value-object accelerators' {
+        $expectedEnumAccelerators = @(
+            'CodeGlyphX.SwissQrIbanType'
+            'CodeGlyphX.SwissQrReferenceType'
+        )
+        $unexpectedAccelerators = @(
+            'CodeGlyphX.Payloads.SlovenianUpnQrPayload'
             'CodeGlyphX.Payloads.SwissQrCodePayload'
             'CodeGlyphX.Payloads.SwissQrCodePayload+AdditionalInformation'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Contact'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Iban'
             'CodeGlyphX.Payloads.SwissQrCodePayload+Reference'
         )
-        $expectedEnumAccelerators = @(
-            'CodeGlyphX.SwissQrIbanType'
-            'CodeGlyphX.SwissQrReferenceType'
-        )
         $moduleScriptPath = Join-Path -Path (Get-Module -Name ImagePlayground).ModuleBase -ChildPath 'ImagePlayground.psm1'
         $moduleScript = Get-Content -Path $moduleScriptPath -Raw
         if ($PSEdition -ne 'Core' -or $moduleScript -notmatch 'RegisterPowerForgeAssemblyTypeAccelerators') {
             $buildScript = Get-Content -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\Build\Build-Module.ps1') -Raw
-            foreach ($accelerator in $expectedAccelerators) {
-                $buildScript | Should -Match ([regex]::Escape($accelerator))
+            foreach ($accelerator in $unexpectedAccelerators) {
+                $buildScript | Should -Not -Match ([regex]::Escape($accelerator))
             }
 
             $buildScript | Should -Match ([regex]::Escape("NETAssemblyTypeAcceleratorMode    = 'Enums'"))
@@ -164,12 +165,12 @@ Describe 'New-ImageQRCode specialized cmdlets' {
 
         $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
 
-        foreach ($accelerator in $expectedAccelerators) {
+        foreach ($accelerator in $expectedEnumAccelerators) {
             $typeAccelerators.ContainsKey($accelerator) | Should -BeTrue
         }
 
-        foreach ($accelerator in $expectedEnumAccelerators) {
-            $typeAccelerators.ContainsKey($accelerator) | Should -BeTrue
+        foreach ($accelerator in $unexpectedAccelerators) {
+            $typeAccelerators.ContainsKey($accelerator) | Should -BeFalse
         }
     }
 


### PR DESCRIPTION
## Summary
- replace custom package version properties with literal NuGet versions in each consuming project
- keep release/package version ownership in the project files instead of `Directory.Build.props`
- narrow the PowerShell type accelerator surface so enum discovery remains automatic while QR payload internals are not exposed as accelerators

## Validation
- `dotnet restore .\Sources\ImagePlayground.sln /p:UseLocalCodeGlyphXProject=false /p:UseLocalChartForgeXProject=false`
- `dotnet build .\Sources\ImagePlayground.sln --no-restore /p:UseLocalCodeGlyphXProject=false /p:UseLocalChartForgeXProject=false`
- `git diff --check`

## Notes
The default local build still picks up the sibling CodeGlyphX checkout when present. That local checkout does not currently expose the Swiss QR enum API expected by ImagePlayground, so the validation above uses the published package path.