### PR TITLE
Upgrade ImagePlayground QR decoding to CodeGlyphX 2.0

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -131,6 +131,7 @@ Build-Module -ModuleName 'ImagePlayground' -RunMode $RunMode {
             'ChartForgeX.Topology.TopologyEdge'
             'ChartForgeX.Topology.TopologyGroup'
             'ChartForgeX.Topology.TopologyNode'
+            'CodeGlyphX.QrPixelDecodeOptions'
             'ImagePlayground.Image'
             'SixLabors.Fonts.HorizontalAlignment'
             'SixLabors.Fonts.VerticalAlignment'

--- a/Docs/Get-ImageQRCode.md
+++ b/Docs/Get-ImageQRCode.md
@@ -11,7 +11,7 @@ Reads QR code information from an image file.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-ImageQRCode [-FilePath] <string> [<CommonParameters>]
+Get-ImageQRCode [-FilePath] <string> [-DecodeOptions <QrPixelDecodeOptions>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -32,6 +32,22 @@ Get-ImageQRCode -FilePath qr.png
 
 
 ## PARAMETERS
+
+### -DecodeOptions
+When omitted, ImagePlayground uses bounded fast-upright and robust-transform passes. Use Stylized for QR art or other difficult images.
+
+```yaml
+Type: QrPixelDecodeOptions
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
 
 ### -FilePath
 The file must exist.

--- a/Sources/ImagePlayground.PowerShell/CmdletGetImageQRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletGetImageQRCode.cs
@@ -1,3 +1,4 @@
+using CodeGlyphX;
 using ImagePlayground;
 using System.IO;
 using System.Management.Automation;
@@ -22,10 +23,15 @@ public sealed class GetImageQrCodeCmdlet : AsyncImageCmdlet {
     [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 0)]
     public string FilePath { get; set; } = string.Empty;
 
+    /// <summary>CodeGlyphX recognition options used while decoding the QR image.</summary>
+    /// <para>When omitted, ImagePlayground uses bounded fast-upright and robust-transform passes. Use <see cref="QrPixelDecodeOptions.Stylized"/> for QR art or other difficult images.</para>
+    [Parameter]
+    public QrPixelDecodeOptions? DecodeOptions { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         var filePath = ResolveExistingFilePath(FilePath, "GetImageQRCodeFileNotFound", FilePath);
-        var result = await ImagePlayground.QrCode.ReadAsync(filePath, CancelToken).ConfigureAwait(false);
+        var result = await ImagePlayground.QrCode.ReadAsync(filePath, CancelToken, DecodeOptions).ConfigureAwait(false);
         WriteObject(result);
     }
 }

--- a/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
+++ b/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
@@ -37,19 +37,19 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(ChartForgeXProjectPath)' != ''">
-        <ProjectReference Include="$(ChartForgeXProjectPath)" />
+        <ProjectReference Include="$(ChartForgeXProjectPath)" GlobalPropertiesToRemove="Version;VersionPrefix;VersionSuffix;PackageVersion;AssemblyVersion;FileVersion;InformationalVersion" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(CodeGlyphXProjectPath)' != ''">
-        <ProjectReference Include="$(CodeGlyphXProjectPath)" />
+        <ProjectReference Include="$(CodeGlyphXProjectPath)" GlobalPropertiesToRemove="Version;VersionPrefix;VersionSuffix;PackageVersion;AssemblyVersion;FileVersion;InformationalVersion" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalChartForgeXProject)' == 'true' And '$(ChartForgeXProjectPath)' == ''">
-        <ProjectReference Include="..\..\..\ChartForgeX\ChartForgeX\ChartForgeX.csproj" />
+        <ProjectReference Include="..\..\..\ChartForgeX\ChartForgeX\ChartForgeX.csproj" GlobalPropertiesToRemove="Version;VersionPrefix;VersionSuffix;PackageVersion;AssemblyVersion;FileVersion;InformationalVersion" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalCodeGlyphXProject)' == 'true' And '$(CodeGlyphXProjectPath)' == ''">
-        <ProjectReference Include="..\..\..\CodeMatrix\CodeGlyphX\CodeGlyphX.csproj" />
+        <ProjectReference Include="..\..\..\CodeGlyphX\CodeGlyphX\CodeGlyphX.csproj" GlobalPropertiesToRemove="Version;VersionPrefix;VersionSuffix;PackageVersion;AssemblyVersion;FileVersion;InformationalVersion" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalChartForgeXProject)' != 'true' And '$(ChartForgeXProjectPath)' == ''">

--- a/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
+++ b/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
@@ -57,7 +57,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalCodeGlyphXProject)' != 'true' And '$(CodeGlyphXProjectPath)' == ''">
-        <PackageReference Include="CodeGlyphX" Version="1.6.0" />
+        <PackageReference Include="CodeGlyphX" Version="2.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/ImagePlayground.PowerShell/Internal/QrCodes/QRCode.Decoding.cs
+++ b/Sources/ImagePlayground.PowerShell/Internal/QrCodes/QRCode.Decoding.cs
@@ -1,0 +1,121 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CodeGlyphX;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using CodeGlyphXPixelFormat = CodeGlyphX.PixelFormat;
+
+namespace ImagePlayground;
+
+public partial class QrCode {
+    private const int DefaultDecodePassBudgetMilliseconds = 5000;
+    private const int DefaultDecodeMaxDimension = 1600;
+
+    /// <summary>
+    /// Reads a QR code image and returns the decoded payload.
+    /// </summary>
+    /// <para>
+    /// Uses a bounded two-stage CodeGlyphX decode: a fast upright pass followed by a robust transform pass.
+    /// Pass explicit <see cref="QrPixelDecodeOptions"/> to select a different speed, accuracy, or stylized-code profile.
+    /// </para>
+    /// <param name="filePath">Path to the QR code image.</param>
+    /// <returns>The CodeGlyphX decoded QR payload, or <see langword="null"/> when no QR code is found.</returns>
+    /// <example>
+    ///   <code>var result = QrCode.Read("code.png");</code>
+    /// </example>
+    public static QrDecoded? Read(string filePath) {
+        return Read(filePath, decodeOptions: null);
+    }
+
+    /// <summary>
+    /// Reads a QR code image with caller-selected CodeGlyphX decode options.
+    /// </summary>
+    /// <param name="filePath">Path to the QR code image.</param>
+    /// <param name="decodeOptions">
+    /// CodeGlyphX QR decode options. Pass <see langword="null"/> to use the bounded two-stage default.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token used to abort image loading and recognition.</param>
+    /// <returns>The CodeGlyphX decoded QR payload, or <see langword="null"/> when no QR code is found.</returns>
+    public static QrDecoded? Read(string filePath, QrPixelDecodeOptions? decodeOptions, CancellationToken cancellationToken = default) {
+        return ReadAsync(filePath, cancellationToken, decodeOptions).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Reads a QR code image and returns the decoded payload asynchronously.
+    /// </summary>
+    /// <param name="filePath">Path to the QR code image.</param>
+    /// <param name="cancellationToken">Cancellation token used to abort image loading and recognition.</param>
+    /// <returns>The CodeGlyphX decoded QR payload, or <see langword="null"/> when no QR code is found.</returns>
+    public static Task<QrDecoded?> ReadAsync(string filePath, CancellationToken cancellationToken = default) {
+        return ReadAsync(filePath, cancellationToken, decodeOptions: null);
+    }
+
+    /// <summary>
+    /// Reads a QR code image asynchronously with caller-selected CodeGlyphX decode options.
+    /// </summary>
+    /// <param name="filePath">Path to the QR code image.</param>
+    /// <param name="cancellationToken">Cancellation token used to abort image loading and recognition.</param>
+    /// <param name="decodeOptions">
+    /// CodeGlyphX QR decode options. Pass <see langword="null"/> to use the bounded two-stage default.
+    /// </param>
+    /// <returns>The CodeGlyphX decoded QR payload, or <see langword="null"/> when no QR code is found.</returns>
+    public static async Task<QrDecoded?> ReadAsync(string filePath, CancellationToken cancellationToken, QrPixelDecodeOptions? decodeOptions) {
+        cancellationToken.ThrowIfCancellationRequested();
+        string fullPath = Helpers.ResolvePath(filePath);
+        using Image<Rgba32> image = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fullPath, cancellationToken).ConfigureAwait(false);
+        byte[] pixels = new byte[image.Width * image.Height * 4];
+        image.CopyPixelDataTo(pixels);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        if (TryDecodePixels(pixels, image.Width, image.Height, decodeOptions, cancellationToken, out var decoded)) {
+            return decoded;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return null;
+    }
+
+    private static bool TryDecodePixels(
+        byte[] pixels,
+        int width,
+        int height,
+        QrPixelDecodeOptions? options,
+        CancellationToken cancellationToken,
+        out QrDecoded decoded) {
+        if (options is not null) {
+            return TryDecodePixelsCore(pixels, width, height, options, cancellationToken, out decoded);
+        }
+
+        QrPixelDecodeOptions upright = QrPixelDecodeOptions.Fast();
+        upright.BudgetMilliseconds = DefaultDecodePassBudgetMilliseconds;
+        upright.MaxDimension = DefaultDecodeMaxDimension;
+        upright.DisableTransforms = true;
+        if (TryDecodePixelsCore(pixels, width, height, upright, cancellationToken, out decoded)) {
+            return true;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        QrPixelDecodeOptions robust = QrPixelDecodeOptions.Robust();
+        robust.BudgetMilliseconds = DefaultDecodePassBudgetMilliseconds;
+        robust.MaxDimension = DefaultDecodeMaxDimension;
+        return TryDecodePixelsCore(pixels, width, height, robust, cancellationToken, out decoded);
+    }
+
+    private static bool TryDecodePixelsCore(
+        byte[] pixels,
+        int width,
+        int height,
+        QrPixelDecodeOptions options,
+        CancellationToken cancellationToken,
+        out QrDecoded decoded) {
+        return QrImageDecoder.TryDecode(
+            pixels,
+            width,
+            height,
+            width * 4,
+            CodeGlyphXPixelFormat.Rgba32,
+            options,
+            cancellationToken,
+            out decoded);
+    }
+}

--- a/Sources/ImagePlayground.PowerShell/Internal/QrCodes/QRCode.cs
+++ b/Sources/ImagePlayground.PowerShell/Internal/QrCodes/QRCode.cs
@@ -9,7 +9,6 @@ using CodeGlyphX.Payloads;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using CodeGlyphXPixelFormat = CodeGlyphX.PixelFormat;
 using CodeGlyphXRgba32 = CodeGlyphX.Rendering.Png.Rgba32;
 
 namespace ImagePlayground;
@@ -25,7 +24,7 @@ namespace ImagePlayground;
 /// CodeGlyphX <see cref="QrDecoded"/> contract when a QR code is found.
 /// </para>
 /// </summary>
-public class QrCode {
+public partial class QrCode {
     /// <summary>
     /// Creates a QR code image from a raw string value.
     /// </summary>
@@ -1403,131 +1402,4 @@ public class QrCode {
         await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Reads a QR code image and returns the decoded payload.
-    /// </summary>
-    /// <para>Returns the CodeGlyphX decoded payload when a QR code is found; otherwise, returns <see langword="null"/>.</para>
-    /// <param name="filePath">Path to the QR code image.</param>
-    /// <returns>The CodeGlyphX decoded QR payload, or <see langword="null"/> when no QR code is found.</returns>
-    /// <example>
-    ///   <code>var result = QrCode.Read("code.png");</code>
-    /// </example>
-    public static QrDecoded? Read(string filePath) {
-        return ReadAsync(filePath).GetAwaiter().GetResult();
-    }
-
-    /// <summary>
-    /// Reads a QR code image and returns the decoded payload asynchronously.
-    /// </summary>
-    /// <param name="filePath">Path to the QR code image.</param>
-    /// <param name="cancellationToken">Cancellation token used to abort image loading or fallback reads.</param>
-    /// <returns>The CodeGlyphX decoded QR payload, or <see langword="null"/> when no QR code is found.</returns>
-    public static async Task<QrDecoded?> ReadAsync(string filePath, CancellationToken cancellationToken = default) {
-        cancellationToken.ThrowIfCancellationRequested();
-        string fullPath = Helpers.ResolvePath(filePath);
-        #if NET8_0_OR_GREATER
-        using Image<Rgba32> image = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fullPath, cancellationToken).ConfigureAwait(false);
-        byte[] pixels = new byte[image.Width * image.Height * 4];
-        image.CopyPixelDataTo(pixels);
-
-        cancellationToken.ThrowIfCancellationRequested();
-        if (TryDecodePixels(pixels, image.Width, image.Height, out var decoded)) {
-            return decoded;
-        }
-
-        var composited = CompositeOnWhite(image);
-        if (composited is not null && TryDecodePixels(composited, image.Width, image.Height, out decoded)) {
-            return decoded;
-        }
-
-        return await TryDecodeImageFallbackAsync(fullPath, cancellationToken).ConfigureAwait(false);
-        #else
-        return await TryDecodeImageFallbackAsync(fullPath, cancellationToken).ConfigureAwait(false);
-        #endif
-
-    }
-
-    private static async Task<QrDecoded?> TryDecodeImageFallbackAsync(string fullPath, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-        byte[] imageBytes = await AsyncFile.ReadAllBytesAsync(fullPath, cancellationToken).ConfigureAwait(false);
-        if (QrImageDecoder.TryDecodeImage(imageBytes, out var decoded)) {
-            return decoded;
-        }
-
-        var aggressiveOptions = new QrPixelDecodeOptions {
-            Profile = QrDecodeProfile.Robust,
-            AggressiveSampling = true,
-            StylizedSampling = true
-        };
-
-        cancellationToken.ThrowIfCancellationRequested();
-        if (QrImageDecoder.TryDecodeImage(imageBytes, aggressiveOptions, out decoded)) {
-            return decoded;
-        }
-
-        using FileStream stream = File.OpenRead(fullPath);
-        if (QrImageDecoder.TryDecodeImage(stream, out decoded)) {
-            return decoded;
-        }
-
-        cancellationToken.ThrowIfCancellationRequested();
-        stream.Position = 0;
-        return QrImageDecoder.TryDecodeImage(stream, aggressiveOptions, out decoded) ? decoded : null;
-    }
-
-    #if NET8_0_OR_GREATER
-    private static bool TryDecodePixels(byte[] pixels, int width, int height, out QrDecoded decoded) {
-        if (QrImageDecoder.TryDecode(pixels, width, height, width * 4, CodeGlyphXPixelFormat.Rgba32, out decoded)) {
-            return true;
-        }
-
-        var aggressiveOptions = new QrPixelDecodeOptions {
-            Profile = QrDecodeProfile.Robust,
-            AggressiveSampling = true,
-            StylizedSampling = true
-        };
-        return QrImageDecoder.TryDecode(pixels, width, height, width * 4, CodeGlyphXPixelFormat.Rgba32, aggressiveOptions, out decoded);
-    }
-    #endif
-
-    private static byte[]? CompositeOnWhite(Image<Rgba32> image) {
-        byte[]? composited = null;
-        var index = 0;
-
-        for (var y = 0; y < image.Height; y++) {
-            for (var x = 0; x < image.Width; x++) {
-                Rgba32 pixel = image[x, y];
-                if (pixel.A == 255) {
-                    if (composited is not null) {
-                        composited[index] = pixel.R;
-                        composited[index + 1] = pixel.G;
-                        composited[index + 2] = pixel.B;
-                        composited[index + 3] = 255;
-                    }
-
-                    index += 4;
-                    continue;
-                }
-
-                composited ??= new byte[image.Width * image.Height * 4];
-                if (index > 0) {
-                    image.CopyPixelDataTo(composited);
-                }
-
-                byte alpha = pixel.A;
-                composited[index] = BlendChannel(pixel.R, alpha);
-                composited[index + 1] = BlendChannel(pixel.G, alpha);
-                composited[index + 2] = BlendChannel(pixel.B, alpha);
-                composited[index + 3] = 255;
-                index += 4;
-            }
-        }
-
-        return composited;
-    }
-
-    private static byte BlendChannel(byte foreground, byte alpha) {
-        const int background = 255;
-        return (byte)((foreground * alpha + background * (255 - alpha) + 127) / 255);
-    }
 }

--- a/Sources/ImagePlayground.Tests/QRCode.cs
+++ b/Sources/ImagePlayground.Tests/QRCode.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Xunit;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 using CodeGlyphX;
 using CodeGlyphX.Payloads;
 
@@ -158,6 +159,20 @@ public partial class ImagePlayground {
 
         byte[] logoBytes = File.ReadAllBytes(filePath);
         Assert.NotEqual(baseBytes, logoBytes);
+    }
+
+    [Fact]
+    public void Test_QRCode_ReadsRotatedImage() {
+        string filePath = Path.Combine(_directoryWithImages, "QRCodeRotated.png");
+        File.Delete(filePath);
+        QrCode.Generate("https://evotec.xyz/rotated", filePath);
+
+        using (Image<Rgba32> image = SixLabors.ImageSharp.Image.Load<Rgba32>(filePath)) {
+            image.Mutate(context => context.Rotate(90));
+            image.SaveAsPng(filePath);
+        }
+
+        AssertQrDecoded(filePath, "https://evotec.xyz/rotated");
     }
 
     [Theory]

--- a/Sources/ImagePlayground.Tests/QrCodeAsync.cs
+++ b/Sources/ImagePlayground.Tests/QrCodeAsync.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using CodeGlyphX;
 using Xunit;
 
 namespace ImagePlayground.Tests;
@@ -42,6 +44,30 @@ public partial class ImagePlayground {
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => QrCode.ReadAsync(filePath, cts.Token));
+    }
+
+    [Fact]
+    public async Task Test_QrCodeReadAsync_CancelsActiveRecognition() {
+        string filePath = Path.Combine(_directoryWithImages, "KulekWSluchawkach.jpg");
+        QrPixelDecodeOptions options = QrPixelDecodeOptions.Robust();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        var stopwatch = Stopwatch.StartNew();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => QrCode.ReadAsync(filePath, cts.Token, options));
+
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), $"Cancellation took {stopwatch.Elapsed}.");
+    }
+
+    [Fact]
+    public async Task Test_QrCodeReadAsync_NonQrImageReturnsNullWithinBudget() {
+        string filePath = Path.Combine(_directoryWithImages, "KulekWSluchawkach.jpg");
+        QrPixelDecodeOptions options = QrPixelDecodeOptions.Screen(250, 800);
+        var stopwatch = Stopwatch.StartNew();
+
+        QrDecoded? result = await QrCode.ReadAsync(filePath, CancellationToken.None, options);
+
+        Assert.Null(result);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), $"Budgeted recognition took {stopwatch.Elapsed}.");
     }
 
     [Fact]

--- a/Tests/New-ImageQRCodeSpecialized.Tests.ps1
+++ b/Tests/New-ImageQRCodeSpecialized.Tests.ps1
@@ -148,14 +148,34 @@ Describe 'New-ImageQRCode specialized cmdlets' {
 
     It 'uses packaged CodeGlyphX by default unless a local project is requested' {
         $propsPath = Join-Path -Path $PSScriptRoot -ChildPath '..\Directory.Build.props'
+        $projectPath = Join-Path -Path $PSScriptRoot -ChildPath '..\Sources\ImagePlayground.PowerShell\ImagePlayground.PowerShell.csproj'
         $props = Get-Content -Path $propsPath -Raw
         [xml] $propsXml = $props
+        [xml] $projectXml = Get-Content -Path $projectPath -Raw
         $localCodeGlyphXDefaults = @($propsXml.Project.PropertyGroup.UseLocalCodeGlyphXProject)
+        $localCodeGlyphXReferences = @($projectXml.Project.ItemGroup.ProjectReference | Where-Object Include -Like '*CodeGlyphX*')
 
         $localCodeGlyphXDefaults | Should -HaveCount 1
         $localCodeGlyphXDefaults[0].Condition | Should -Be "'`$(UseLocalCodeGlyphXProject)' == ''"
         $localCodeGlyphXDefaults[0].InnerText | Should -Be 'false'
-        $props | Should -Not -Match ([regex]::Escape('..\CodeMatrix\CodeGlyphX\CodeGlyphX.csproj'))
+        $localCodeGlyphXReferences | Should -HaveCount 2
+        $localCodeGlyphXReferences.Include | Should -Contain '$(CodeGlyphXProjectPath)'
+        $localCodeGlyphXReferences.Include | Should -Contain '..\..\..\CodeGlyphX\CodeGlyphX\CodeGlyphX.csproj'
+    }
+
+    It 'preserves versions of independently released local project dependencies' {
+        $projectPath = Join-Path -Path $PSScriptRoot -ChildPath '..\Sources\ImagePlayground.PowerShell\ImagePlayground.PowerShell.csproj'
+        [xml] $projectXml = Get-Content -Path $projectPath -Raw
+        $independentReferences = @($projectXml.Project.ItemGroup.ProjectReference | Where-Object Include -Match 'CodeGlyphX|ChartForgeX')
+        $expectedProperties = @('Version', 'VersionPrefix', 'VersionSuffix', 'PackageVersion', 'AssemblyVersion', 'FileVersion', 'InformationalVersion')
+
+        $independentReferences | Should -HaveCount 4
+        foreach ($reference in $independentReferences) {
+            $propertiesToRemove = @($reference.GlobalPropertiesToRemove -split ';')
+            foreach ($property in $expectedProperties) {
+                $propertiesToRemove | Should -Contain $property -Because "$($reference.Include) is released independently from ImagePlayground"
+            }
+        }
     }
 
     It 'requires Swiss QR reference text for QRR and SCOR' {


### PR DESCRIPTION
## Summary

- upgrades the packaged QR engine to public CodeGlyphX 2.0.0
- keeps independently released ChartForgeX and CodeGlyphX project references from inheriting ImagePlayground package and assembly versions
- fixes the local CodeGlyphX sibling-project path
- replaces duplicated multi-pass QR image handling with one ImageSharp-to-CodeGlyphX raw-pixel path
- adds bounded default decoding, active cancellation, rotated-code coverage, and caller-selected `QrPixelDecodeOptions`
- exposes `-DecodeOptions` and the `CodeGlyphX.QrPixelDecodeOptions` accelerator in the PowerShell module

## Architecture

ImagePlayground owns image loading and the friendly PowerShell command. CodeGlyphX owns QR pixel decoding. The adapter sends one normalized RGBA pixel buffer to the shared decoder and does not carry a second QR decoder or a compatibility shim.

## Release state

CodeGlyphX 2.0.0 is public on NuGet and is the normal package reference used by this branch. Local project references remain opt-in development paths and preserve the dependency project's own version metadata.