### PR TITLE
Remove redundant XmlDoc2CmdletDoc dependency

### DIFF
--- a/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
+++ b/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
@@ -60,17 +60,8 @@
         <PackageReference Include="CodeGlyphX" Version="2.0.0" />
     </ItemGroup>
 
-    <ItemGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation. DLL itself
-        will be removed/hidden -->
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
     <PropertyGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation. -->
+        <!-- PowerForge enriches module help from the compiler XML documentation file. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
@@ -81,15 +72,6 @@
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <Reference Include="System.Net.Http" />
     </ItemGroup>
-
-    <Target Name="CopyDocumentationToPublishFolder" AfterTargets="GenerateDocumentationFile;Publish">
-        <!-- This is needed for XmlDoc2CmdletDoc to copy a PowerShell documentation file to Publish
-        folder -->
-        <ItemGroup>
-            <DocFiles Include="$(OutputPath)$(AssemblyName).dll-Help.xml" />
-        </ItemGroup>
-        <Copy SourceFiles="@(DocFiles)" DestinationFolder="$(PublishDir)" />
-    </Target>
 
     <ItemGroup>
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />


### PR DESCRIPTION
PowerForge already generates binary cmdlet Markdown and external MAML through this repository's existing documentation configuration and NETBinaryModuleDocumentation setting.

This removes the redundant MatejKafka.XmlDoc2CmdletDoc package and its package-specific dll-Help.xml copy target. Compiler XML generation remains enabled for PowerForge enrichment; no public API or cmdlet behavior changes.