### PR TITLE
Keep ImagePlayground release versions aligned

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -173,8 +173,8 @@ Build-Module -ModuleName 'ImagePlayground' -RunMode $RunMode {
 
     New-ConfigurationBuild @newConfigurationBuildSplat #-DotSourceLibraries -DotSourceClasses -MergeModuleOnBuild -Enable -SignModule -DeleteTargetModuleBeforeBuild -CertificateThumbprint '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703' -MergeFunctionsFromApprovedModules
 
-    New-ConfigurationProjectBuild -Name 'ImagePlayground' -ConfigPath 'Build\project.build.json' -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub
-    New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource ProjectBuild -PrimaryProject 'ImagePlayground' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
+    New-ConfigurationProjectBuild -Name 'ImagePlayground' -ConfigPath 'Build\project.build.json' -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget
+    New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource ProjectBuild -PrimaryProject 'ImagePlayground' -SynchronizeModuleVersion -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
 
     $newConfigurationArtefactSplat = @{
         Type                = 'Unpacked'

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -36,7 +36,7 @@
   "TimeStampServer": "http://timestamp.digicert.com",
   "PublishSource": "https://api.nuget.org/v3/index.json",
   "PublishApiKeyFilePath": "C:\\Support\\Important\\NugetOrgEvotec.txt",
-  "SkipDuplicate": true,
+  "SkipDuplicate": false,
   "PublishFailFast": true,
   "GitHubAccessTokenFilePath": "C:\\Support\\Important\\GithubAPI.txt",
   "GitHubUsername": "EvotecIT",


### PR DESCRIPTION
## Summary

- opt the module release into explicit package/module version synchronization
- fail closed when a NuGet version is already occupied instead of treating it as a successful skip
- keep project packages inside the coordinated release and avoid creating a second project-level GitHub release

## Result

When the public package train is already at `3.2.2` and the module is at `3.2.1`, the next nonpublishing build resolves both ImagePlayground NuGets and the PowerShell module to `3.2.3`.

The shared fail-closed retry behavior is covered by EvotecIT/PSPublishModule#676. No package is published by this pull request.