### PR TITLE
Expose per-subtree organization layouts

### DIFF
--- a/Docs/New-ImageOrganizationChart.md
+++ b/Docs/New-ImageOrganizationChart.md
@@ -11,16 +11,16 @@ Creates an organization or team chart.
 ## SYNTAX
 ### Definition (Default)
 ```powershell
-New-ImageOrganizationChart [-MemberDefinition] <scriptblock> -TeamLabel <string> -FilePath <string> [-TeamId <string>] [-Subtitle <string>] [-Width <int>] [-Height <int>] [-Direction <TopologyLayoutDirection>] [-NodeDisplayMode <TopologyNodeDisplayMode>] [-MinLevel <int>] [-MaxLevel <int>] [-NoTeamNode] [-NoAncestorContext] [-ShowLegend] [-Theme <string>] [-Transparent] [-Show] [-PassThru] [<CommonParameters>]
+New-ImageOrganizationChart [-MemberDefinition] <scriptblock> -TeamLabel <string> -FilePath <string> [-TeamId <string>] [-Subtitle <string>] [-Width <int>] [-Height <int>] [-Direction <TopologyLayoutDirection>] [-LayoutPolicy <TopologyHierarchyLayoutPolicy>] [-NodeDisplayMode <TopologyNodeDisplayMode>] [-MinLevel <int>] [-MaxLevel <int>] [-NoTeamNode] [-NoAncestorContext] [-ShowLegend] [-Theme <string>] [-Transparent] [-Show] [-PassThru] [<CommonParameters>]
 ```
 
 ### Member
 ```powershell
-New-ImageOrganizationChart -Member <TopologyTeamMember[]> -TeamLabel <string> -FilePath <string> [-TeamId <string>] [-Subtitle <string>] [-Width <int>] [-Height <int>] [-Direction <TopologyLayoutDirection>] [-NodeDisplayMode <TopologyNodeDisplayMode>] [-MinLevel <int>] [-MaxLevel <int>] [-NoTeamNode] [-NoAncestorContext] [-ShowLegend] [-Theme <string>] [-Transparent] [-Show] [-PassThru] [<CommonParameters>]
+New-ImageOrganizationChart -Member <TopologyTeamMember[]> -TeamLabel <string> -FilePath <string> [-TeamId <string>] [-Subtitle <string>] [-Width <int>] [-Height <int>] [-Direction <TopologyLayoutDirection>] [-LayoutPolicy <TopologyHierarchyLayoutPolicy>] [-NodeDisplayMode <TopologyNodeDisplayMode>] [-MinLevel <int>] [-MaxLevel <int>] [-NoTeamNode] [-NoAncestorContext] [-ShowLegend] [-Theme <string>] [-Transparent] [-Show] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Maps PowerShell-authored team members into the shared ChartForgeX hierarchy engine, including compact child buckets and orthogonal parent-child routing.
+Maps PowerShell-authored team members into the shared ChartForgeX hierarchy engine, including inherited standard, compact, and vertical subtree layouts.
 
 ## EXAMPLES
 
@@ -72,6 +72,22 @@ Type: Int32
 Parameter Sets: Definition, Member
 Aliases: None
 Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LayoutPolicy
+Default sibling layout inherited by organization members that do not specify their own policy.
+
+```yaml
+Type: TopologyHierarchyLayoutPolicy
+Parameter Sets: Definition, Member
+Aliases: None
+Possible values: Auto, Standard, Compact, Vertical
 
 Required: False
 Position: named

--- a/Docs/New-ImageOrganizationMember.md
+++ b/Docs/New-ImageOrganizationMember.md
@@ -11,7 +11,7 @@ Creates one member for an organization or team chart.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-ImageOrganizationMember [-Id] <string> [-Name] <string> [[-Role] <string>] [-ParentId <string>] [-Level <int>] [-Status <TopologyHealthStatus>] [-IconId <string>] [-Metadata <hashtable>] [<CommonParameters>]
+New-ImageOrganizationMember [-Id] <string> [-Name] <string> [[-Role] <string>] [-ParentId <string>] [-Level <int>] [-Status <TopologyHealthStatus>] [-LayoutPolicy <TopologyHierarchyLayoutPolicy>] [-IconId <string>] [-Metadata <hashtable>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -54,6 +54,22 @@ Possible values:
 
 Required: True
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LayoutPolicy
+Sibling layout applied to this member's direct reports and inherited by its subtree.
+
+```yaml
+Type: TopologyHierarchyLayoutPolicy
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Auto, Standard, Compact, Vertical
+
+Required: False
+Position: named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Examples/Organization.Engineering.ps1
+++ b/Examples/Organization.Engineering.ps1
@@ -1,9 +1,13 @@
 Import-Module "$PSScriptRoot\..\ImagePlayground.psd1" -Force
 
-New-ImageOrganizationChart -TeamId engineering -TeamLabel 'Engineering' -MemberDefinition {
-    New-ImageOrganizationMember -Id director -Name 'Avery Stone' -Role 'Director of Engineering' -Status Healthy
-    New-ImageOrganizationMember -Id platform -Name 'Morgan Lee' -Role 'Platform Lead' -ParentId director -Status Healthy
-    New-ImageOrganizationMember -Id product -Name 'Sam Park' -Role 'Product Lead' -ParentId director -Status Healthy
+New-ImageOrganizationChart -TeamId engineering -TeamLabel 'Engineering' -LayoutPolicy Auto -MemberDefinition {
+    New-ImageOrganizationMember -Id director -Name 'Avery Stone' -Role 'Director of Engineering' -Status Healthy -LayoutPolicy Standard
+    New-ImageOrganizationMember -Id platform -Name 'Morgan Lee' -Role 'Platform Lead' -ParentId director -Status Healthy -LayoutPolicy Compact
+    New-ImageOrganizationMember -Id product -Name 'Sam Park' -Role 'Product Lead' -ParentId director -Status Healthy -LayoutPolicy Vertical
     New-ImageOrganizationMember -Id runtime -Name 'Alex Kim' -Role 'Runtime Engineer' -ParentId platform -Status Warning
+    New-ImageOrganizationMember -Id tooling -Name 'Jordan Bell' -Role 'Tooling Engineer' -ParentId platform -Status Healthy
+    New-ImageOrganizationMember -Id reliability -Name 'Casey Ward' -Role 'Reliability Engineer' -ParentId platform -Status Healthy
+    New-ImageOrganizationMember -Id applications -Name 'Robin Shaw' -Role 'Applications Engineer' -ParentId platform -Status Healthy
     New-ImageOrganizationMember -Id ux -Name 'Taylor Reed' -Role 'Product Designer' -ParentId product -Status Healthy
+    New-ImageOrganizationMember -Id research -Name 'Cameron Hall' -Role 'UX Researcher' -ParentId product -Status Healthy
 } -FilePath "$PSScriptRoot\organization-engineering.svg" -Width 1100 -Height 620

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageOrganizationChart.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageOrganizationChart.cs
@@ -7,7 +7,7 @@ using System.Management.Automation;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates an organization or team chart.</summary>
-/// <para>Maps PowerShell-authored team members into the shared ChartForgeX hierarchy engine, including compact child buckets and orthogonal parent-child routing.</para>
+/// <para>Maps PowerShell-authored team members into the shared ChartForgeX hierarchy engine, including inherited standard, compact, and vertical subtree layouts.</para>
 /// <example>
 ///   <summary>Create an engineering organization chart</summary>
 ///   <prefix>PS&gt; </prefix>
@@ -53,6 +53,10 @@ public sealed class NewImageOrganizationChartCmdlet : PSCmdlet {
     /// <summary>Layered organization-chart direction.</summary>
     [Parameter]
     public TopologyLayoutDirection Direction { get; set; } = TopologyLayoutDirection.TopToBottom;
+
+    /// <summary>Default sibling layout inherited by organization members that do not specify their own policy.</summary>
+    [Parameter]
+    public TopologyHierarchyLayoutPolicy LayoutPolicy { get; set; } = TopologyHierarchyLayoutPolicy.Auto;
 
     /// <summary>Organization member presentation mode.</summary>
     [Parameter]
@@ -127,6 +131,7 @@ public sealed class NewImageOrganizationChartCmdlet : PSCmdlet {
             IncludeTeamNode = !NoTeamNode.IsPresent,
             IncludeAncestorContext = !NoAncestorContext.IsPresent,
             LayoutDirection = Direction,
+            LayoutPolicy = LayoutPolicy,
             NodeDisplayMode = NodeDisplayMode
         };
         if (MyInvocation.BoundParameters.ContainsKey(nameof(MinLevel))) teamOptions.MinLevel = MinLevel;

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageOrganizationMember.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageOrganizationMember.cs
@@ -38,6 +38,10 @@ public sealed class NewImageOrganizationMemberCmdlet : PSCmdlet {
     [Parameter]
     public TopologyHealthStatus Status { get; set; } = TopologyHealthStatus.Unknown;
 
+    /// <summary>Sibling layout applied to this member's direct reports and inherited by its subtree.</summary>
+    [Parameter]
+    public TopologyHierarchyLayoutPolicy LayoutPolicy { get; set; } = TopologyHierarchyLayoutPolicy.Auto;
+
     /// <summary>Optional ChartForgeX topology icon identifier.</summary>
     [Parameter]
     public string IconId { get; set; } = string.Empty;
@@ -54,6 +58,7 @@ public sealed class NewImageOrganizationMemberCmdlet : PSCmdlet {
             IconId = string.IsNullOrWhiteSpace(IconId) ? null : IconId
         };
         if (MyInvocation.BoundParameters.ContainsKey(nameof(Level))) member.Level = Level;
+        if (MyInvocation.BoundParameters.ContainsKey(nameof(LayoutPolicy))) member.LayoutPolicy = LayoutPolicy;
         if (Metadata != null) {
             foreach (DictionaryEntry entry in Metadata) {
                 if (entry.Key == null) continue;

--- a/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
+++ b/Sources/ImagePlayground.PowerShell/ImagePlayground.PowerShell.csproj
@@ -59,8 +59,8 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalChartForgeXProject)' != 'true' And '$(ChartForgeXProjectPath)' == ''">
-        <PackageReference Include="ChartForgeX" Version="1.3.0" />
-        <PackageReference Include="ChartForgeX.Interactivity.Html" Version="1.3.0" />
+        <PackageReference Include="ChartForgeX" Version="1.4.0" />
+        <PackageReference Include="ChartForgeX.Interactivity.Html" Version="1.4.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalCodeGlyphXProject)' != 'true' And '$(CodeGlyphXProjectPath)' == ''">

--- a/Sources/ImagePlayground.Syntax.TreeSitter/ImagePlayground.Syntax.TreeSitter.csproj
+++ b/Sources/ImagePlayground.Syntax.TreeSitter/ImagePlayground.Syntax.TreeSitter.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\..\ChartForgeX\ChartForgeX\ChartForgeX.csproj" GlobalPropertiesToRemove="Version;VersionPrefix;VersionSuffix;PackageVersion;AssemblyVersion;FileVersion;InformationalVersion" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalChartForgeXProject)' != 'true' And '$(ChartForgeXProjectPath)' == ''">
-    <PackageReference Include="ChartForgeX" Version="1.3.0" />
+    <PackageReference Include="ChartForgeX" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="TreeSitter.DotNet" Version="1.3.0" />

--- a/Tests/New-ImageOrganizationChart.Tests.ps1
+++ b/Tests/New-ImageOrganizationChart.Tests.ps1
@@ -12,21 +12,29 @@ Describe 'New-ImageOrganizationChart' {
         $file = Join-Path -Path $TestDir -ChildPath 'organization.svg'
         Remove-Item -Path $file -ErrorAction SilentlyContinue
 
-        $chart = New-ImageOrganizationChart -TeamId engineering -TeamLabel Engineering -MemberDefinition {
-            New-ImageOrganizationMember -Id director -Name 'Avery Stone' -Role Director -Status Healthy
-            New-ImageOrganizationMember -Id platform -Name 'Morgan Lee' -Role 'Platform Lead' -ParentId director -Status Healthy
-            New-ImageOrganizationMember -Id runtime -Name 'Sam Park' -Role 'Runtime Lead' -ParentId director -Status Warning
+        $chart = New-ImageOrganizationChart -TeamId engineering -TeamLabel Engineering -LayoutPolicy Auto -MemberDefinition {
+            New-ImageOrganizationMember -Id director -Name 'Avery Stone' -Role Director -Status Healthy -LayoutPolicy Standard
+            New-ImageOrganizationMember -Id platform -Name 'Morgan Lee' -Role 'Platform Lead' -ParentId director -Status Healthy -LayoutPolicy Compact
+            New-ImageOrganizationMember -Id runtime -Name 'Sam Park' -Role 'Runtime Lead' -ParentId director -Status Warning -LayoutPolicy Vertical
             New-ImageOrganizationMember -Id engineer -Name 'Alex Kim' -Role Engineer -ParentId platform -Status Healthy
+            New-ImageOrganizationMember -Id analyst -Name 'Chris Gray' -Role Analyst -ParentId runtime -Status Healthy
         } -FilePath $file -Width 900 -Height 520 -PassThru
 
         $chart | Should -BeOfType 'ChartForgeX.Topology.TopologyChart'
-        $chart.Nodes.Count | Should -Be 5
-        $chart.Edges.Count | Should -Be 4
+        $chart.Nodes.Count | Should -Be 6
+        $chart.Edges.Count | Should -Be 5
         $chart.LayoutMode | Should -Be ([ChartForgeX.Topology.TopologyLayoutMode]::Layered)
+        ($chart.Nodes | Where-Object Id -eq director).Metadata['hierarchy.layoutPolicy'] | Should -Be 'Standard'
+        ($chart.Nodes | Where-Object Id -eq platform).Metadata['hierarchy.layoutPolicy'] | Should -Be 'Compact'
+        ($chart.Nodes | Where-Object Id -eq runtime).Metadata['hierarchy.layoutPolicy'] | Should -Be 'Vertical'
+        ($chart.Nodes | Where-Object Id -eq engineer).Metadata['hierarchy.layoutPolicy'] | Should -Be 'Compact'
+        ($chart.Nodes | Where-Object Id -eq analyst).Metadata['hierarchy.layoutPolicy'] | Should -Be 'Vertical'
         Test-Path -Path $file | Should -BeTrue
         $svg = Get-Content -Path $file -Raw
         $svg | Should -Match 'Avery Stone'
         $svg | Should -Match 'hierarchy.relationship'
+        $svg | Should -Match 'layout-hierarchypolicy="Compact"'
+        $svg | Should -Match 'layout-hierarchypolicy="Vertical"'
     }
 
     It 'accepts organization members from the pipeline' {
@@ -43,5 +51,13 @@ Describe 'New-ImageOrganizationChart' {
         $bytes = [System.IO.File]::ReadAllBytes($file)
         $bytes[0] | Should -Be 137
         $bytes[1] | Should -Be 80
+    }
+
+    It 'keeps member policy optional so chart defaults can flow through' {
+        $explicit = New-ImageOrganizationMember -Id explicit -Name Explicit -LayoutPolicy Compact
+        $inherited = New-ImageOrganizationMember -Id inherited -Name Inherited
+
+        $explicit.LayoutPolicy | Should -Be ([ChartForgeX.Topology.TopologyHierarchyLayoutPolicy]::Compact)
+        $inherited.LayoutPolicy | Should -BeNullOrEmpty
     }
 }

--- a/en-US/ImagePlayground-help.xml
+++ b/en-US/ImagePlayground-help.xml
@@ -16079,7 +16079,7 @@ polygonal areas.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Maps PowerShell-authored team members into the shared ChartForgeX hierarchy engine, including compact child buckets and orthogonal parent-child routing.</maml:para>
+      <maml:para>Maps PowerShell-authored team members into the shared ChartForgeX hierarchy engine, including inherited standard, compact, and vertical subtree layouts.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem parameterSetName="Definition">
@@ -16122,6 +16122,24 @@ polygonal areas.</maml:para>
           <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
             <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LayoutPolicy</maml:name>
+          <maml:description>
+            <maml:para>Default sibling layout inherited by organization members that do not specify their own policy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyHierarchyLayoutPolicy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Standard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Compact</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Vertical</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyHierarchyLayoutPolicy</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -16366,6 +16384,24 @@ polygonal areas.</maml:para>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LayoutPolicy</maml:name>
+          <maml:description>
+            <maml:para>Default sibling layout inherited by organization members that do not specify their own policy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyHierarchyLayoutPolicy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Standard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Compact</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Vertical</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyHierarchyLayoutPolicy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>MaxLevel</maml:name>
           <maml:description>
             <maml:para>Highest hierarchy level to include.</maml:para>
@@ -16600,6 +16636,24 @@ polygonal areas.</maml:para>
         <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
           <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LayoutPolicy</maml:name>
+        <maml:description>
+          <maml:para>Default sibling layout inherited by organization members that do not specify their own policy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyHierarchyLayoutPolicy</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Standard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Compact</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Vertical</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyHierarchyLayoutPolicy</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -16884,6 +16938,24 @@ polygonal areas.</maml:para>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LayoutPolicy</maml:name>
+          <maml:description>
+            <maml:para>Sibling layout applied to this member's direct reports and inherited by its subtree.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyHierarchyLayoutPolicy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Standard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Compact</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Vertical</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyHierarchyLayoutPolicy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Level</maml:name>
           <maml:description>
             <maml:para>Optional explicit hierarchy level.</maml:para>
@@ -16985,6 +17057,24 @@ polygonal areas.</maml:para>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LayoutPolicy</maml:name>
+        <maml:description>
+          <maml:para>Sibling layout applied to this member's direct reports and inherited by its subtree.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyHierarchyLayoutPolicy</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Standard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Compact</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Vertical</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyHierarchyLayoutPolicy</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>


### PR DESCRIPTION
## What changed

- Adds `-LayoutPolicy` to `New-ImageOrganizationChart` with `Auto`, `Standard`, `Compact`, and `Vertical` values.
- Lets `New-ImageOrganizationMember` override the layout policy for its own subtree while unspecified members inherit the chart or parent policy.
- Updates the organization example and generated command help.
- Moves the ChartForgeX package references to the public 1.4.0 release that owns the layout behavior.

## Example

```powershell
$members = @(
    New-ImageOrganizationMember -Id 'lead' -Name 'Lead' -LayoutPolicy Compact
    New-ImageOrganizationMember -Id 'engineer-a' -Name 'Engineer A' -ParentId 'lead'
    New-ImageOrganizationMember -Id 'engineer-b' -Name 'Engineer B' -ParentId 'lead'
)

$members | New-ImageOrganizationChart -Title 'Engineering' -LayoutPolicy Auto -FilePath '.\engineering.svg'
```

## Dependency

This PR is based on #225, which introduces the underlying organization authoring surface. ChartForgeX 1.4.0 is already public.