### PR TITLE
Publish complete ImagePlayground website documentation

### DIFF
--- a/Docs/Clear-ImageThumbnailCache.md
+++ b/Docs/Clear-ImageThumbnailCache.md
@@ -24,6 +24,7 @@ Clears cached thumbnails.
 Clear-ImageThumbnailCache
 ```
 
+
 ## PARAMETERS
 
 ### CommonParameters

--- a/Docs/New-ImageChartCircle.md
+++ b/Docs/New-ImageChartCircle.md
@@ -21,8 +21,9 @@ Creates circle status chart data item.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageChartCircle
+New-ImageChartCircle -Name 'Availability' -Value 99.9 -Minimum 0 -Maximum 100 -Color '#2DD4BF'
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageChartDonut.md
+++ b/Docs/New-ImageChartDonut.md
@@ -21,8 +21,9 @@ Creates donut chart data item.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageChartDonut
+New-ImageChartDonut -Name 'Completed' -Value 72 -Color Green
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageChartGauge.md
+++ b/Docs/New-ImageChartGauge.md
@@ -21,8 +21,9 @@ Creates gauge chart data item.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageChartGauge
+New-ImageChartGauge -Name 'Capacity' -Value 68 -Minimum 0 -Maximum 100 -Color Orange
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageChartOptions.md
+++ b/Docs/New-ImageChartOptions.md
@@ -21,8 +21,9 @@ Creates renderer options for New-ImageChart.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageChartOptions
+New-ImageChartOptions -ShowLegend -LegendPosition Right -ShowDataLabels -Palette '#8B5CF6','#2DD4BF'
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageChartPictorial.md
+++ b/Docs/New-ImageChartPictorial.md
@@ -21,8 +21,9 @@ Creates pictorial chart row.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageChartPictorial
+New-ImageChartPictorial -Name 'Active users' -Value 42 -Color Blue
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageChartProgress.md
+++ b/Docs/New-ImageChartProgress.md
@@ -21,8 +21,9 @@ Creates progress-bar chart row.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageChartProgress
+New-ImageChartProgress -Name 'Deployment' -Value 78 -Color '#8B5CF6'
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageChartWordCloud.md
+++ b/Docs/New-ImageChartWordCloud.md
@@ -21,8 +21,9 @@ Creates word cloud chart term.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageChartWordCloud
+New-ImageChartWordCloud -Text 'PowerShell' -Weight 12 -Color '#2DD4BF'
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageStoryOutcome.md
+++ b/Docs/New-ImageStoryOutcome.md
@@ -21,8 +21,9 @@ Declares a result that must be visible in the completed visual-story scene.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageStoryOutcome
+New-ImageStoryOutcome -Id 'chart-created' -Label 'The chart is visible' -PanelId 'chart'
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageStoryPanel.md
+++ b/Docs/New-ImageStoryPanel.md
@@ -51,8 +51,9 @@ Creates one resolved source, terminal, media, or text panel for a generic visual
 
 ### EXAMPLE 1
 ```powershell
-New-ImageStoryPanel
+New-ImageStoryPanel -Id 'summary' -Title 'Result' -Text 'Deployment completed.' -Emphasized
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageStoryScene.md
+++ b/Docs/New-ImageStoryScene.md
@@ -21,8 +21,10 @@ Groups resolved panels into one timed visual-story scene.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageStoryScene
+$panel = New-ImageStoryPanel -Id 'summary' -Text 'Deployment completed.' -Emphasized
+New-ImageStoryScene -Id 'result' -Title 'Deployment result' -Panels $panel -DurationSeconds 3
 ```
+
 
 ## PARAMETERS
 

--- a/Docs/New-ImageVisualGridItem.md
+++ b/Docs/New-ImageVisualGridItem.md
@@ -26,8 +26,10 @@ Creates one chart or visual-block placement for a visual grid.
 
 ### EXAMPLE 1
 ```powershell
-New-ImageVisualGridItem
+$card = New-ImageMetricCard -Label 'Requests' -Value 12840 -Trend '+12%'
+New-ImageVisualGridItem -TargetId 'requests' -Block $card -ColumnSpan 2
 ```
+
 
 ## PARAMETERS
 

--- a/Sources/ImagePlayground.PowerShell/CmdletClearImageThumbnailCache.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletClearImageThumbnailCache.cs
@@ -3,6 +3,10 @@ using System.Management.Automation;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Clears cached thumbnails.</summary>
+/// <example>
+///   <summary>Remove every cached thumbnail</summary>
+///   <code>Clear-ImageThumbnailCache</code>
+/// </example>
 [Cmdlet(VerbsCommon.Clear, "ImageThumbnailCache")]
 public sealed class ClearImageThumbnailCacheCmdlet : PSCmdlet {
     /// <inheritdoc />

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartCircle.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartCircle.cs
@@ -5,6 +5,10 @@ using ImagePlayground;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates circle status chart data item.</summary>
+/// <example>
+///   <summary>Create an availability circle</summary>
+///   <code>New-ImageChartCircle -Name 'Availability' -Value 99.9 -Minimum 0 -Maximum 100 -Color '#2DD4BF'</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageChartCircle")]
 public sealed class NewImageChartCircleCmdlet : PSCmdlet {
     /// <summary>Label for the circle.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartDonut.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartDonut.cs
@@ -5,6 +5,10 @@ using ImagePlayground;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates donut chart data item.</summary>
+/// <example>
+///   <summary>Create a completed-work donut slice</summary>
+///   <code>New-ImageChartDonut -Name 'Completed' -Value 72 -Color Green</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageChartDonut")]
 public sealed class NewImageChartDonutCmdlet : PSCmdlet {
     /// <summary>Label for the slice.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartGauge.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartGauge.cs
@@ -5,6 +5,10 @@ using ImagePlayground;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates gauge chart data item.</summary>
+/// <example>
+///   <summary>Create a capacity gauge</summary>
+///   <code>New-ImageChartGauge -Name 'Capacity' -Value 68 -Minimum 0 -Maximum 100 -Color Orange</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageChartGauge")]
 public sealed class NewImageChartGaugeCmdlet : PSCmdlet {
     /// <summary>Label for the gauge.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartOptions.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartOptions.cs
@@ -5,6 +5,10 @@ using ImagePlayground;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates renderer options for New-ImageChart.</summary>
+/// <example>
+///   <summary>Create options for a labeled chart with a right-side legend</summary>
+///   <code>New-ImageChartOptions -ShowLegend -LegendPosition Right -ShowDataLabels -Palette '#8B5CF6','#2DD4BF'</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageChartOptions")]
 [OutputType(typeof(ChartRenderOptions))]
 public sealed class NewImageChartOptionsCmdlet : PSCmdlet {

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartPictorial.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartPictorial.cs
@@ -5,6 +5,10 @@ using ImagePlayground;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates pictorial chart row.</summary>
+/// <example>
+///   <summary>Create a pictorial row for active users</summary>
+///   <code>New-ImageChartPictorial -Name 'Active users' -Value 42 -Color Blue</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageChartPictorial")]
 public sealed class NewImageChartPictorialCmdlet : PSCmdlet {
     /// <summary>Label for the pictorial row.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartProgress.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartProgress.cs
@@ -5,6 +5,10 @@ using ImagePlayground;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates progress-bar chart row.</summary>
+/// <example>
+///   <summary>Create a deployment progress row</summary>
+///   <code>New-ImageChartProgress -Name 'Deployment' -Value 78 -Color '#8B5CF6'</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageChartProgress")]
 public sealed class NewImageChartProgressCmdlet : PSCmdlet {
     /// <summary>Label for the progress row.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageChartWordCloud.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageChartWordCloud.cs
@@ -5,6 +5,10 @@ using ImagePlayground;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates word cloud chart term.</summary>
+/// <example>
+///   <summary>Create a weighted word-cloud term</summary>
+///   <code>New-ImageChartWordCloud -Text 'PowerShell' -Weight 12 -Color '#2DD4BF'</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageChartWordCloud")]
 public sealed class NewImageChartWordCloudCmdlet : PSCmdlet {
     /// <summary>Term text.</summary>

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageStoryOutcome.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageStoryOutcome.cs
@@ -4,6 +4,10 @@ using ImagePlayground.PowerShell.Stories;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Declares a result that must be visible in the completed visual-story scene.</summary>
+/// <example>
+///   <summary>Require the chart panel in the completed scene</summary>
+///   <code>New-ImageStoryOutcome -Id 'chart-created' -Label 'The chart is visible' -PanelId 'chart'</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageStoryOutcome")]
 [OutputType(typeof(ImageStoryOutcomeSpec))]
 public sealed class NewImageStoryOutcomeCmdlet : PSCmdlet {

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageStoryPanel.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageStoryPanel.cs
@@ -8,6 +8,10 @@ using ImagePlayground.PowerShell.Stories;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates one resolved source, terminal, media, or text panel for a generic visual story.</summary>
+/// <example>
+///   <summary>Create an emphasized result panel</summary>
+///   <code>New-ImageStoryPanel -Id 'summary' -Title 'Result' -Text 'Deployment completed.' -Emphasized</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageStoryPanel", DefaultParameterSetName = SourceSet)]
 [OutputType(typeof(ImageStoryPanelSpec))]
 public sealed class NewImageStoryPanelCmdlet : PSCmdlet {

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageStoryScene.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageStoryScene.cs
@@ -5,6 +5,11 @@ using ImagePlayground.PowerShell.Stories;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Groups resolved panels into one timed visual-story scene.</summary>
+/// <example>
+///   <summary>Create a scene from a resolved text panel</summary>
+///   <code>$panel = New-ImageStoryPanel -Id 'summary' -Text 'Deployment completed.' -Emphasized
+/// New-ImageStoryScene -Id 'result' -Title 'Deployment result' -Panels $panel -DurationSeconds 3</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageStoryScene")]
 [OutputType(typeof(ImageStorySceneSpec))]
 public sealed class NewImageStorySceneCmdlet : PSCmdlet {

--- a/Sources/ImagePlayground.PowerShell/CmdletNewImageVisualGridItem.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletNewImageVisualGridItem.cs
@@ -5,6 +5,11 @@ using System.Management.Automation;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Creates one chart or visual-block placement for a visual grid.</summary>
+/// <example>
+///   <summary>Place a metric card across two grid columns</summary>
+///   <code>$card = New-ImageMetricCard -Label 'Requests' -Value 12840 -Trend '+12%'
+/// New-ImageVisualGridItem -TargetId 'requests' -Block $card -ColumnSpan 2</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ImageVisualGridItem", DefaultParameterSetName = BlockSet)]
 [OutputType(typeof(VisualGridItem))]
 public sealed class NewImageVisualGridItemCmdlet : PSCmdlet {

--- a/Website/content/examples/_index.md
+++ b/Website/content/examples/_index.md
@@ -34,4 +34,9 @@ These examples are selected from the ImagePlayground repository because they sho
     <h3>Present a PowerShell script run</h3>
     <p>Turn authored commands or caller-captured output into a polished script-free console animation.</p>
   </a>
+  <a class="ev-example-card" href="./organization-hierarchy/">
+    <span class="ev-example-card__eyebrow">Organization</span>
+    <h3>Render an organization hierarchy</h3>
+    <p>Model reporting relationships and choose branch-level hierarchy layouts.</p>
+  </a>
 </div>

--- a/Website/content/examples/organization-hierarchy.md
+++ b/Website/content/examples/organization-hierarchy.md
@@ -1,0 +1,22 @@
+---
+title: "Render an organization hierarchy"
+description: "Build a compact organization hierarchy from PowerShell with branch-level layout policies."
+layout: docs
+---
+
+Use the organization surface when input data describes reporting relationships rather than a free-form network. A branch can opt into compact or vertical layout while the rest of the hierarchy keeps its normal policy.
+
+```powershell
+using module ImagePlayground
+
+New-ImageOrganizationChart -TeamId engineering -TeamLabel 'Engineering' -LayoutPolicy Auto -MemberDefinition {
+    New-ImageOrganizationMember -Id director -Name 'Avery Stone' -Role 'Director of Engineering' -Status Healthy -LayoutPolicy Standard
+    New-ImageOrganizationMember -Id platform -Name 'Morgan Lee' -Role 'Platform Lead' -ParentId director -Status Healthy -LayoutPolicy Compact
+    New-ImageOrganizationMember -Id product -Name 'Sam Park' -Role 'Product Lead' -ParentId director -Status Healthy -LayoutPolicy Vertical
+    New-ImageOrganizationMember -Id runtime -Name 'Alex Kim' -Role 'Runtime Engineer' -ParentId platform -Status Warning
+    New-ImageOrganizationMember -Id tooling -Name 'Jordan Bell' -Role 'Tooling Engineer' -ParentId platform -Status Healthy
+    New-ImageOrganizationMember -Id ux -Name 'Taylor Reed' -Role 'Product Designer' -ParentId product -Status Healthy
+} -FilePath '.\engineering-organization.svg' -Width 1100 -Height 620
+```
+
+For exact command names and parameter sets in the installed release, use the [ImagePlayground API reference](/projects/imageplayground/api/). The underlying hierarchy and topology model is documented in the [ChartForgeX hub](/projects/chartforgex/).

--- a/Website/content/project-docs/docs/_index.md
+++ b/Website/content/project-docs/docs/_index.md
@@ -16,6 +16,8 @@ ImagePlayground helps PowerShell and .NET workflows generate and process visual 
 
 - [Installation](./install/)
 - [Project overview](./overview/)
+- [Image workflows](./workflows/)
+- [Charts, hierarchy, topology, and visual reporting](./visual-reporting/)
 - [Curated examples](/projects/imageplayground/examples/)
 - [Back to project overview](/projects/imageplayground/)
 

--- a/Website/content/project-docs/docs/install.md
+++ b/Website/content/project-docs/docs/install.md
@@ -18,13 +18,24 @@ Choose the package source that matches your automation.
 Install-Module ImagePlayground -Scope CurrentUser
 ```
 
+Import it and inspect the commands available in your installed version:
+
+```powershell
+Import-Module ImagePlayground
+Get-Command -Module ImagePlayground
+```
+
 ## .NET package
 
 ```bash
 dotnet add package ImagePlayground
 ```
 
+The PowerShell module supports Windows PowerShell 5.1 and PowerShell 7+. Some formats and platform integrations depend on the capabilities available on the current operating system; use the API reference for the exact command contract in the version shown by the project page.
+
 ## Next steps
 
 - Browse the [curated examples](/projects/imageplayground/examples/)
+- Choose an [image or visual reporting workflow](../workflows/)
+- Open the [PowerShell API reference](/projects/imageplayground/api/)
 - Open the [project source](https://github.com/EvotecIT/ImagePlayground)

--- a/Website/content/project-docs/docs/overview.md
+++ b/Website/content/project-docs/docs/overview.md
@@ -10,17 +10,26 @@ meta.project_hub_path: "/projects/imageplayground/"
 meta.project_link_docs: "/projects/imageplayground/docs/"
 ---
 
-Use ImagePlayground when automation needs repeatable image output: QR codes, barcodes, charts, thumbnails, watermarks, or simple processing steps that should run without manual image editing.
+Use ImagePlayground when PowerShell automation needs repeatable visual output without opening an image editor. It combines everyday image processing with codes, metadata workflows, report graphics, topology diagrams, and visual stories.
 
 ## Good fit
 
-- adding QR codes or barcodes to generated reports
-- creating chart images for dashboards or static pages
-- resizing, watermarking, or transforming images in a script
-- sharing image automation patterns between PowerShell and .NET code
+- create and read QR codes and barcodes, including typed QR payloads
+- resize, crop, rotate, watermark, thumbnail, mosaic, merge, and convert images
+- inspect, remove, export, import, or update EXIF and image metadata
+- render ChartForgeX charts, organization hierarchies, topology maps, visual grids, and visual canvases
+- turn authored or captured console activity into static or animated visual stories
+- write PNG, SVG, HTML, GIF, APNG, JPEG, and other supported outputs from repeatable scripts
+
+## Where ImagePlayground ends
+
+ImagePlayground owns the PowerShell experience. Chart construction, deterministic SVG/PNG rendering, topology layout, and reusable visual composition live in [ChartForgeX](/projects/chartforgex/). This keeps the cmdlets approachable while the rendering engine remains reusable from .NET and other hosts.
 
 ## Related project pages
 
 - [Installation](../install/)
+- [Choose a workflow](../workflows/)
+- [Charts, topology, and stories](../visual-reporting/)
+- [PowerShell API](/projects/imageplayground/api/)
 - [Examples](/projects/imageplayground/examples/)
 - [Project overview](/projects/imageplayground/)

--- a/Website/content/project-docs/docs/visual-reporting.md
+++ b/Website/content/project-docs/docs/visual-reporting.md
@@ -1,0 +1,25 @@
+---
+title: "Charts, topology, and visual stories"
+description: "Use ImagePlayground as a PowerShell surface for ChartForgeX report visuals."
+layout: docs
+---
+
+ImagePlayground exposes ChartForgeX through PowerShell-oriented builders and export commands. The reusable rendering model stays in ChartForgeX; ImagePlayground supplies cmdlets, PowerShell parameter sets, packaging, and examples.
+
+## Charts and themes
+
+Build common charts with `New-ImageChart*` commands, apply a reusable theme, and save the same model as PNG, SVG, or HTML. Use a grid when several charts and exact-value blocks need one report surface.
+
+## Organizations and topology
+
+Use `New-ImageTopology*` commands for service maps, infrastructure, ownership, or organization data. Hierarchy layout policies can keep a dense branch compact or vertical without changing unrelated branches. Scenarios and motion cues can explain changes or routes while the static output remains deterministic.
+
+## Visual canvases
+
+Visual canvases combine text, charts, images, shapes, and reusable blocks into fixed-size assets such as report covers, social previews, wallpapers, or email graphics.
+
+## Visual stories
+
+Visual stories turn a sequence of charts, console scenes, and annotations into a single authored narrative. Use SVG or HTML for crisp scalable delivery, PNG for a fixed still, and GIF/APNG when a portable animation is the right output.
+
+See the [curated examples](/projects/imageplayground/examples/) for complete scripts and the [ChartForgeX project hub](/projects/chartforgex/) for the underlying .NET model.

--- a/Website/content/project-docs/docs/workflows.md
+++ b/Website/content/project-docs/docs/workflows.md
@@ -1,0 +1,27 @@
+---
+title: "Choose an ImagePlayground workflow"
+description: "Choose the ImagePlayground command family that matches an image automation job."
+layout: docs
+---
+
+ImagePlayground groups several related jobs behind one PowerShell module. Start with the output you need rather than with a file format.
+
+## Process an existing image
+
+Use `Get-Image` and `Save-Image` for a sequence of edits, or a focused cmdlet when the operation stands alone. Common operations include resizing, cropping, rotation, adjustment, blur, sharpening, text, watermarks, thumbnails, mosaics, merging, and conversion.
+
+## Create or read a code
+
+Use `New-ImageQRCode` and `Get-ImageQRCode` for general QR content. Typed commands cover contact, Wi-Fi, calendar, email, OTP, payment, cryptocurrency, phone, SMS, and location payloads. Barcode commands cover creation and readback workflows.
+
+## Inspect or sanitize metadata
+
+Use the EXIF and metadata commands to inspect provenance, export metadata for review, remove sensitive fields, or apply controlled updates. Treat metadata removal as a deliberate publishing step: always inspect the exported result before distributing an image.
+
+## Build report graphics
+
+Use the chart, grid, topology, hierarchy, visual canvas, and visual story commands when the result is a report asset rather than a photo edit. These surfaces are thin PowerShell adapters over ChartForgeX and can produce static SVG/PNG parity as well as optional HTML or animation where supported.
+
+## Find the exact command
+
+Open the [PowerShell API reference](/projects/imageplayground/api/) to search every exported cmdlet, parameter set, example, and output contract.

--- a/WebsiteArtifacts/project-manifest.json
+++ b/WebsiteArtifacts/project-manifest.json
@@ -1,0 +1,29 @@
+{
+  "slug": "imageplayground",
+  "name": "ImagePlayground",
+  "description": "Automate image processing, codes, metadata, charts, topology, and visual stories from PowerShell.",
+  "mode": "hub-full",
+  "contentMode": "hybrid",
+  "status": "active",
+  "listed": true,
+  "sourceRef": "master",
+  "links": {
+    "source": "https://github.com/EvotecIT/ImagePlayground",
+    "powerShellGallery": "https://www.powershellgallery.com/packages/ImagePlayground",
+    "nuget": "https://www.nuget.org/packages/ImagePlayground",
+    "releases": "https://github.com/EvotecIT/ImagePlayground/releases"
+  },
+  "surfaces": {
+    "docs": true,
+    "apiPowerShell": true,
+    "apiDotNet": false,
+    "examples": true,
+    "downloads": true,
+    "releases": true,
+    "changelog": true
+  },
+  "artifacts": {
+    "docs": "Website/content/project-docs",
+    "examples": "Website/content/examples"
+  }
+}

--- a/en-US/ImagePlayground-help.xml
+++ b/en-US/ImagePlayground-help.xml
@@ -1329,7 +1329,15 @@ img.Save("out.png");</dev:code>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Remove every cached thumbnail</maml:title>
+        <dev:code>Clear-ImageThumbnailCache</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -7313,7 +7321,15 @@ img.Save("out.png");</dev:code>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Create an availability circle</maml:title>
+        <dev:code>New-ImageChartCircle -Name 'Availability' -Value 99.9 -Minimum 0 -Maximum 100 -Color '#2DD4BF'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -7420,7 +7436,15 @@ img.Save("out.png");</dev:code>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Create a completed-work donut slice</maml:title>
+        <dev:code>New-ImageChartDonut -Name 'Completed' -Value 72 -Color Green</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -7690,7 +7714,15 @@ img.Save("out.png");</dev:code>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Create a capacity gauge</maml:title>
+        <dev:code>New-ImageChartGauge -Name 'Capacity' -Value 68 -Minimum 0 -Maximum 100 -Color Orange</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -8922,7 +8954,15 @@ img.Save("out.png");</dev:code>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Create options for a labeled chart with a right-side legend</maml:title>
+        <dev:code>New-ImageChartOptions -ShowLegend -LegendPosition Right -ShowDataLabels -Palette '#8B5CF6','#2DD4BF'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -9029,7 +9069,15 @@ img.Save("out.png");</dev:code>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Create a pictorial row for active users</maml:title>
+        <dev:code>New-ImageChartPictorial -Name 'Active users' -Value 42 -Color Blue</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -9397,7 +9445,15 @@ img.Save("out.png");</dev:code>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Create a deployment progress row</maml:title>
+        <dev:code>New-ImageChartProgress -Name 'Deployment' -Value 78 -Color '#8B5CF6'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -11093,7 +11149,15 @@ img.Save("out.png");</dev:code>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Create a weighted word-cloud term</maml:title>
+        <dev:code>New-ImageChartWordCloud -Text 'PowerShell' -Weight 12 -Color '#2DD4BF'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -25494,7 +25558,15 @@ polygonal areas.</maml:para>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Require the chart panel in the completed scene</maml:title>
+        <dev:code>New-ImageStoryOutcome -Id 'chart-created' -Label 'The chart is visible' -PanelId 'chart'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -26185,7 +26257,15 @@ polygonal areas.</maml:para>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Create an emphasized result panel</maml:title>
+        <dev:code>New-ImageStoryPanel -Id 'summary' -Title 'Result' -Text 'Deployment completed.' -Emphasized</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -26362,7 +26442,16 @@ polygonal areas.</maml:para>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Create a scene from a resolved text panel</maml:title>
+        <dev:code>$panel = New-ImageStoryPanel -Id 'summary' -Text 'Deployment completed.' -Emphasized&#xD;
+            New-ImageStoryScene -Id 'result' -Title 'Deployment result' -Panels $panel -DurationSeconds 3</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
@@ -32252,7 +32341,16 @@ polygonal areas.</maml:para>
         <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
-    <command:examples />
+    <command:examples>
+      <command:example>
+        <maml:title>Place a metric card across two grid columns</maml:title>
+        <dev:code>$card = New-ImageMetricCard -Label 'Requests' -Value 12840 -Trend '+12%'&#xD;
+            New-ImageVisualGridItem -TargetId 'requests' -Block $card -ColumnSpan 2</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
     <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">


### PR DESCRIPTION
## What changed

- add an explicit website manifest for the full ImagePlayground product hub
- expand installation and overview guidance around processing, codes, metadata, charts, topology, canvases, and stories
- add focused workflow and visual-reporting documentation
- add an organization-hierarchy example using the branch-level layout policy from the lower stack layer
- expose docs, PowerShell API, examples, downloads, releases, and changelog as separate surfaces
- add authored PowerShell examples for the 12 newer chart, story, grid, and thumbnail commands so the generated API reference no longer falls back to signatures

## Stack

This is the documentation layer above #226, which itself depends on #225. It intentionally documents the organization layout surface only after that product/API layer.