### PR TITLE
Expose portable semantic visual artifact handoff

### DIFF
--- a/Docs/ConvertTo-ImageVisualArtifact.md
+++ b/Docs/ConvertTo-ImageVisualArtifact.md
@@ -15,7 +15,7 @@ ConvertTo-ImageVisualArtifact [-InputObject] <Object> [-Id <string>] [-Title <st
 ```
 
 ## DESCRIPTION
-The artifact is the portable handoff contract for static export and OfficeIMO document placement.
+The artifact is the portable handoff contract for static export, OfficeIMO document placement, and native editable Visio projection.
 
 ## EXAMPLES
 

--- a/README.MD
+++ b/README.MD
@@ -99,6 +99,19 @@ New-ImageChart {
 
 The `New-ImageChartBar`, `New-ImageChartLine`, `New-ImageChartDonut`, and other chart-definition commands remain the normal PowerShell experience. Advanced scripts can also pass a native `ChartForgeX.Core.Chart` through `-Chart` or configure one through `-ChartScript`.
 
+`ConvertTo-ImageVisualArtifact` adds portable SVG and versioned semantic JSON bytes to the pipeline object. SVG supports flat Office placement; PSWriteOffice can consume the semantic payload across its separate module load context to create editable Visio shapes and connectors:
+
+```powershell
+$artifact = New-ImageTopology -TopologyDefinition {
+    New-ImageTopologyNode -Id api -Label API -Kind Service
+    New-ImageTopologyNode -Id database -Label Database -Kind Database
+    New-ImageTopologyEdge -Id api-db -SourceNodeId api -TargetNodeId database -Label queries
+} -FilePath .\topology.svg -PassThru |
+    ConvertTo-ImageVisualArtifact -Id service-topology -Title 'Service topology'
+
+$artifact | Export-OfficeVisioVisual -Path .\topology.vsdx
+```
+
 Present a deliberately paced, multi-tab PowerShell session while keeping ChartForgeX as the reusable terminal renderer:
 
 ```powershell

--- a/Sources/ImagePlayground.PowerShell/CmdletConvertToImageVisualArtifact.cs
+++ b/Sources/ImagePlayground.PowerShell/CmdletConvertToImageVisualArtifact.cs
@@ -11,7 +11,7 @@ using ChartForgeX.VisualBlocks;
 namespace ImagePlayground.PowerShell;
 
 /// <summary>Converts a ChartForgeX chart, grid, canvas, story, diagram, table, sequence, flow, or visual block into a reusable visual artifact.</summary>
-/// <para>The artifact is the portable handoff contract for static export and OfficeIMO document placement.</para>
+/// <para>The artifact is the portable handoff contract for static export, OfficeIMO document placement, and native editable Visio projection.</para>
 /// <example>
 ///   <summary>Create an artifact from a topology</summary>
 ///   <prefix>PS&gt; </prefix>
@@ -102,6 +102,10 @@ public sealed class ConvertToImageVisualArtifactCmdlet : PSCmdlet {
         }
 
         SetPortableProperty(output, "OfficeVisualSvg", Encoding.UTF8.GetBytes(artifact.ToSvg()));
+        SetPortableProperty(output, "OfficeVisualInterchangeJson", artifact.ToInterchangeUtf8Json());
+        SetPortableProperty(output, "OfficeVisualInterchangeSchema", VisualArtifactInterchangeEnvelope.SchemaId);
+        SetPortableProperty(output, "OfficeVisualInterchangeVersion", VisualArtifactInterchangeEnvelope.CurrentVersion);
+        SetPortableProperty(output, "OfficeVisualKind", artifact.Kind.ToString());
         SetPortableProperty(output, "OfficeVisualId", artifact.Id);
         SetPortableProperty(output, "OfficeVisualTitle", artifact.Title);
         SetPortableProperty(

--- a/Tests/VisualArtifact.Tests.ps1
+++ b/Tests/VisualArtifact.Tests.ps1
@@ -119,8 +119,15 @@ Describe 'ChartForgeX visual artifacts' {
         $envelope = [Text.Encoding]::UTF8.GetString($artifact.OfficeVisualInterchangeJson) | ConvertFrom-Json
 
         $envelope.kind | Should -Be 'Topology'
+        $envelope.family | Should -Be 'Topology'
+        $envelope.topology.layoutMode | Should -Be 'Layered'
+        $envelope.topology.layoutDirection | Should -Be 'TopToBottom'
         $envelope.Nodes.Count | Should -Be 2
+        $envelope.Nodes[0].role | Should -Be 'TopologyNode'
+        $envelope.Nodes[0].topology.kind | Should -Not -BeNullOrEmpty
         $envelope.Edges.Count | Should -Be 1
+        $envelope.Edges[0].role | Should -Be 'TopologyEdge'
+        $envelope.Edges[0].topology.kind | Should -Not -BeNullOrEmpty
         $envelope.Edges[0].sourceId | Should -Be 'api'
         $envelope.Edges[0].targetId | Should -Be 'database'
     }

--- a/Tests/VisualArtifact.Tests.ps1
+++ b/Tests/VisualArtifact.Tests.ps1
@@ -94,6 +94,10 @@ Describe 'ChartForgeX visual artifacts' {
         $artifact.GetType().FullName | Should -Be 'ChartForgeX.VisualArtifacts.VisualArtifact'
         $artifact.PSObject.TypeNames | Should -Contain 'ImagePlayground.VisualArtifact'
         $artifact.OfficeVisualSvg.Count | Should -BeGreaterThan 100
+        $artifact.OfficeVisualInterchangeJson.Count | Should -BeGreaterThan 100
+        $artifact.OfficeVisualInterchangeSchema | Should -Be 'chartforgex.visual-artifact'
+        $artifact.OfficeVisualInterchangeVersion | Should -Be 1
+        $artifact.OfficeVisualKind | Should -Be 'Chart'
         $artifact.OfficeVisualId | Should -Be 'portable-chart'
         $artifact.OfficeVisualTitle | Should -Be 'Portable chart'
         $artifact.OfficeVisualAlternativeText | Should -Be 'Portable chart description.'
@@ -101,6 +105,24 @@ Describe 'ChartForgeX visual artifacts' {
         $again = $artifact | ConvertTo-ImageVisualArtifact -Title 'Updated portable chart'
         $again.OfficeVisualTitle | Should -Be 'Updated portable chart'
         @($again.PSObject.TypeNames -eq 'ImagePlayground.VisualArtifact').Count | Should -Be 1
+    }
+
+    It 'preserves native topology semantics in the portable Office interchange payload' {
+        $topologyPath = Join-Path $TestDir 'portable-topology.svg'
+        $topology = New-ImageTopology -TopologyDefinition {
+            New-ImageTopologyNode -Id api -Label API
+            New-ImageTopologyNode -Id database -Label Database
+            New-ImageTopologyEdge -Id api-db -SourceNodeId api -TargetNodeId database -Label queries
+        } -FilePath $topologyPath -NoTitle -PassThru
+
+        $artifact = $topology | ConvertTo-ImageVisualArtifact -Id portable-topology -Title 'Portable topology'
+        $envelope = [Text.Encoding]::UTF8.GetString($artifact.OfficeVisualInterchangeJson) | ConvertFrom-Json
+
+        $envelope.kind | Should -Be 'Topology'
+        $envelope.Nodes.Count | Should -Be 2
+        $envelope.Edges.Count | Should -Be 1
+        $envelope.Edges[0].sourceId | Should -Be 'api'
+        $envelope.Edges[0].targetId | Should -Be 'database'
     }
 
     It 'rejects multiple pipeline artifacts for one output path' {

--- a/en-US/ImagePlayground-help.xml
+++ b/en-US/ImagePlayground-help.xml
@@ -1941,7 +1941,7 @@ img.Save("out.png");</dev:code>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>The artifact is the portable handoff contract for static export and OfficeIMO document placement.</maml:para>
+      <maml:para>The artifact is the portable handoff contract for static export, OfficeIMO document placement, and native editable Visio projection.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">


### PR DESCRIPTION
## Summary

- Extends ImagePlayground visual artifacts with the portable typed ChartForgeX semantic snapshot alongside the existing SVG payload.
- Carries schema/version metadata and UTF-8 JSON without sharing ChartForgeX CLR types across PowerShell module load contexts.
- Keeps ImagePlayground as a thin transport: ChartForgeX owns semantics and validation; existing static-image behavior remains unchanged.
- Adds packaged-module coverage for family selection, deterministic round trips, semantic validation, and repeated pipeline use.

## Usage

`ConvertTo-ImageVisualArtifact` continues to return `ImagePlayground.VisualArtifact`. Editable-document consumers can read `OfficeVisualInterchangeJson`; existing consumers can continue using `OfficeVisualSvg`.

## Dependencies

- Based directly on current `master`, including the merged visual-artifact foundation from #229.
- Consumes the public ChartForgeX 1.5.0 semantic-interchange API from EvotecIT/ChartForgeX#137.

Package publication remains a separate release action.
